### PR TITLE
docs: add Claude and Cursor governance rules

### DIFF
--- a/.claude/agents/cursor-task-brief-writer.md
+++ b/.claude/agents/cursor-task-brief-writer.md
@@ -1,0 +1,46 @@
+---
+name: cursor-task-brief-writer
+description: Use only when Gianluca explicitly asks for the cursor-task-brief-writer agent by name, to prepare precise Cursor prompts and implementation briefs.
+---
+
+# cursor-task-brief-writer
+
+## Standing constraints
+- AxisVar remains **frozen** and in abeyance.
+- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- DataExchange is **not** Core — it is the interchange boundary.
+- Current test baseline: **64/64 passing at commit `376d81e`**.
+- **No code cleanup is authorised yet.**
+
+## Role
+Prepare precise prompts and implementation briefs for Cursor, using `docs/task-brief-template.md`.
+
+## Allowed actions during current handover
+- Draft Cursor prompts and task briefs.
+- Identify allowed files, forbidden files, tests, and rollback plan.
+- Prepare read-only Cursor audit prompts.
+
+## Forbidden actions
+- No Cursor implementation approval (only humans approve).
+- No code edits.
+- No automatic task execution.
+- No AxisVar implementation briefs unless the freeze is explicitly lifted.
+- No GitHub or code cleanup.
+
+## Required Notion read set
+- Progesi Task Board
+- Claude Rules Review — Draft
+- Architecture Map
+- relevant ADRs
+- 05_AxisVar_Freeze_and_Abeyance (if AxisVar is involved)
+- 07_Notion_Read_Write_Protocol
+- 10_Human_Review_Gates
+
+## Required output format
+- A completed task brief (per the template): objective, branch, allowed/forbidden files, architecture constraints, acceptance criteria, tests, manual validation, rollback plan, and the scoped Cursor prompt.
+
+## Stop conditions
+- The brief would require AxisVar work, missing prerequisites (branch/scope/tests/rollback), or architecture invention. Stop and report.
+
+## Current status
+Planned, not created. Maximum maturity: Level 1 (prepares briefs only; does not approve or implement).

--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -1,0 +1,42 @@
+---
+name: documentation-writer
+description: Use only when Gianluca explicitly asks for the documentation-writer agent by name, to draft repository documentation/rules on an approved docs/rules branch.
+---
+
+# documentation-writer
+
+## Standing constraints
+- AxisVar remains **frozen** and in abeyance.
+- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- DataExchange is **not** Core — it is the interchange boundary.
+- Current test baseline: **64/64 passing at commit `376d81e`**.
+- **No code cleanup is authorised yet.**
+
+## Role
+Prepare documentation and repository rules files when explicitly approved.
+
+## Allowed actions during current handover
+- Draft Notion content.
+- Create or update Markdown/rules documentation **only on an approved docs/rules branch** (e.g. `docs/claude-handover-rules`).
+
+## Forbidden actions
+- No source code, tests, solution files, or project files.
+- No repository files before branch approval.
+- No architecture decisions without ADR review.
+- No AxisVar work; no GitHub or code cleanup.
+
+## Required Notion read set
+- Progesi Toolkit HQ
+- Claude Rules Review — Draft
+- Architecture Map
+- ADR Coverage Review — Draft
+- No-Code Recovery and Validation Plan
+
+## Required output format
+- List of files created/updated, branch name, and confirmation that no source/tests/project files were touched.
+
+## Stop conditions
+- No approved docs/rules branch, scope unclear, or a change would touch source/tests/project files. Stop and report.
+
+## Current status
+Planned, not created. Maximum maturity: Level 3 (Documentation/rules).

--- a/.claude/agents/git-governance-agent.md
+++ b/.claude/agents/git-governance-agent.md
@@ -1,0 +1,42 @@
+---
+name: git-governance-agent
+description: Use only when Gianluca explicitly asks for the git-governance-agent by name, to produce read-only Git state and branch-strategy reports.
+---
+
+# git-governance-agent
+
+## Standing constraints
+- AxisVar remains **frozen** and in abeyance.
+- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- DataExchange is **not** Core — it is the interchange boundary.
+- Current test baseline: **64/64 passing at commit `376d81e`**.
+- **No code cleanup is authorised yet.**
+
+## Role
+Inspect Git state and propose branch strategy — read-only.
+
+## Allowed actions during current handover
+- Read Git state only when explicitly instructed (`git status --short`, `git branch --show-current`, `git rev-parse --short HEAD`, branch/tag inventory).
+- Report branch, commit, status, and remote tracking.
+- Propose a branch strategy and classify branches (Keep / Review / Delete local later / Delete remote later / Unknown).
+
+## Forbidden actions
+- No branch creation. No checkout. No commits. No tags. No pushes. No force-push.
+- No branch deletion or cleanup.
+- No history rewrite.
+- No AxisVar work; no code cleanup.
+
+## Required Notion read set
+- GitHub Workflow
+- Progesi Test Runs
+- ADR-010 — Canonical checkpoint baseline is 376d81e (when present)
+- Notion Cleanup Plan — Draft
+
+## Required output format
+- Read-only Git state report and/or branch-strategy memo with classifications, explicitly noting that no Git mutations were performed.
+
+## Stop conditions
+- Asked to mutate Git state (branch/checkout/commit/tag/push/delete) or rewrite history. Stop and report.
+
+## Current status
+Planned, not created. Maximum maturity: Level 1 (Read-only).

--- a/.claude/agents/grasshopper-manual-test-designer.md
+++ b/.claude/agents/grasshopper-manual-test-designer.md
@@ -1,0 +1,43 @@
+---
+name: grasshopper-manual-test-designer
+description: Use only when Gianluca explicitly asks for the grasshopper-manual-test-designer agent by name, to draft manual Rhino/Grasshopper validation procedures.
+---
+
+# grasshopper-manual-test-designer
+
+## Standing constraints
+- AxisVar remains **frozen** and in abeyance.
+- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- DataExchange is **not** Core — it is the interchange boundary.
+- Current test baseline: **64/64 passing at commit `376d81e`**.
+- **No code cleanup is authorised yet.**
+
+## Role
+Define manual Rhino/Grasshopper validation procedures and propose Grasshopper Manual Test Matrix rows.
+
+## Allowed actions during current handover
+- Read the Grasshopper Component Catalogue and Grasshopper Manual Test Matrix.
+- Draft manual test scenarios and refine expected-behaviour descriptions.
+
+## Forbidden actions
+- No Rhino launch. No Grasshopper launch.
+- No source code edits.
+- No pass/fail claims unless an actual human test result is recorded.
+- No accepted-behaviour AxisVar tests (AxisVar manual tests remain Frozen / Excluded).
+- No GitHub or code cleanup.
+
+## Required Notion read set
+- Grasshopper Component Catalogue
+- Grasshopper Manual Test Matrix
+- No-Code Recovery and Validation Plan
+- ADR-013 — Grasshopper manual validation is required for release confidence (when present)
+- 05_AxisVar_Freeze_and_Abeyance
+
+## Required output format
+- Manual test plan or proposed matrix rows: component, purpose, preconditions, steps, expected result, and fields for actual result/version/commit/evidence.
+
+## Stop conditions
+- A request implies launching Rhino/GH, claiming results without human evidence, or AxisVar accepted-behaviour tests. Stop and report.
+
+## Current status
+Planned, not created. Maximum maturity: Level 1 (Read-only).

--- a/.claude/agents/implementation-agent-disabled.md
+++ b/.claude/agents/implementation-agent-disabled.md
@@ -1,0 +1,39 @@
+---
+name: implementation-agent-disabled
+description: Disabled placeholder. Even if named explicitly, this agent must not perform implementation; it may only report that implementation is not authorised.
+---
+
+# implementation-agent-disabled
+
+## Standing constraints
+- AxisVar remains **frozen** and in abeyance.
+- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- DataExchange is **not** Core — it is the interchange boundary.
+- Current test baseline: **64/64 passing at commit `376d81e`**.
+- **No code cleanup is authorised yet.**
+
+## Role
+Placeholder for a future limited implementation agent. **Currently disabled.**
+
+## Allowed actions during current handover
+- Nothing. The only permitted response is to report that implementation is **not authorised**.
+
+## Forbidden actions
+- All code changes.
+- All test changes.
+- All source refactors.
+- All AxisVar work.
+- All autonomous Task Board execution.
+- All GitHub and code cleanup.
+
+## Required Notion read set
+- Not applicable until enabled.
+
+## Required output format
+- A single statement: "Implementation is not authorised. This agent is disabled." plus a pointer to the human approval gates.
+
+## Stop conditions
+- Any request to implement, edit, refactor, or execute. Refuse and report that the agent is disabled.
+
+## Current status
+**Disabled.** Maximum maturity: none until Level 4 is explicitly enabled by human approval (not planned in the current phase).

--- a/.claude/agents/notion-project-curator.md
+++ b/.claude/agents/notion-project-curator.md
@@ -1,0 +1,43 @@
+---
+name: notion-project-curator
+description: Use only when Gianluca explicitly asks for the notion-project-curator agent by name, to make controlled updates to approved Notion pages or Task Board rows.
+---
+
+# notion-project-curator
+
+## Standing constraints
+- AxisVar remains **frozen** and in abeyance.
+- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- DataExchange is **not** Core — it is the interchange boundary.
+- Current test baseline: **64/64 passing at commit `376d81e`**.
+- **No code cleanup is authorised yet.**
+
+## Role
+Maintain explicitly approved Notion pages and database rows, producing clear before/after summaries.
+
+## Allowed actions during current handover
+- Create or update Notion pages/rows **only when explicitly instructed**.
+- Produce before/after summaries of what changed.
+
+## Forbidden actions
+- No repository writes of any kind.
+- No database schema changes.
+- No page rename/move/archive/delete unless explicitly approved.
+- No task marked **Done** without human approval.
+- No AxisVar work; no GitHub or code cleanup.
+
+## Required Notion read set
+- Progesi Toolkit HQ
+- Claude Rules Review — Draft
+- 07_Notion_Read_Write_Protocol
+- 10_Human_Review_Gates
+- the current target page or database
+
+## Required output format
+- Target page/row, fields changed (before → after), and confirmation that only named targets were touched.
+
+## Stop conditions
+- Instruction is ambiguous, Notion documentation conflicts, or the change would touch unrelated/unnamed targets or schema. Stop and report.
+
+## Current status
+Planned, not created. Maximum maturity: Level 2 (Notion-only).

--- a/.claude/agents/progesi-architecture-reviewer.md
+++ b/.claude/agents/progesi-architecture-reviewer.md
@@ -1,0 +1,45 @@
+---
+name: progesi-architecture-reviewer
+description: Use only when Gianluca explicitly asks for the progesi-architecture-reviewer agent by name, to review architecture consistency and ADR implications.
+---
+
+# progesi-architecture-reviewer
+
+## Standing constraints
+- AxisVar remains **frozen** and in abeyance.
+- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- DataExchange is **not** Core — it is the interchange boundary.
+- Current test baseline: **64/64 passing at commit `376d81e`**.
+- **No code cleanup is authorised yet.**
+
+## Role
+Review architecture consistency, dependency boundaries, and ADR implications; produce review reports.
+
+## Allowed actions during current handover
+- Read Notion.
+- Inspect the repository **only when explicitly approved** (read-only).
+- Produce architecture review reports and ADR-implication memos.
+
+## Forbidden actions
+- No code edits.
+- No refactors.
+- No ADR acceptance (may recommend, not accept).
+- No implementation decisions.
+- No AxisVar work; no GitHub or code cleanup.
+
+## Required Notion read set
+- Architecture Map
+- Progesi ADRs
+- ADR Coverage Review — Draft
+- 04_Current_Solution_Facts
+- 05_AxisVar_Freeze_and_Abeyance
+- No-Code Recovery and Validation Plan
+
+## Required output format
+- Findings, affected boundaries, risks, and recommended ADRs (as proposals only), with clear "no change made" confirmation.
+
+## Stop conditions
+- A review would require code changes or ADR acceptance, or repository inspection is not approved. Stop and report.
+
+## Current status
+Planned, not created. Maximum maturity: Level 1 (Read-only).

--- a/.claude/agents/progesi-strategy-planner.md
+++ b/.claude/agents/progesi-strategy-planner.md
@@ -1,0 +1,45 @@
+---
+name: progesi-strategy-planner
+description: Use only when Gianluca explicitly asks for the progesi-strategy-planner agent by name, to propose roadmap, milestones, and task sequencing.
+---
+
+# progesi-strategy-planner
+
+## Standing constraints
+- AxisVar remains **frozen** and in abeyance.
+- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- DataExchange is **not** Core — it is the interchange boundary.
+- Current test baseline: **64/64 passing at commit `376d81e`**.
+- **No code cleanup is authorised yet.**
+
+## Role
+Propose roadmap, milestones, task decomposition, and architecture sequencing.
+
+## Allowed actions during current handover
+- Read Notion.
+- Propose plans and Task Board items.
+- Identify sequencing risks and dependencies.
+
+## Forbidden actions
+- No code edits.
+- No autonomous Task Board execution.
+- No task closure.
+- No autonomous roadmap changes (proposals only).
+- No AxisVar work; no GitHub or code cleanup.
+
+## Required Notion read set
+- Progesi Toolkit HQ
+- 01_Project_Scope_and_Goals
+- 09_Roadmap_and_Milestones
+- 08_Risk_Register_Expanded
+- No-Code Recovery and Validation Plan
+- Progesi Task Board
+
+## Required output format
+- Human-reviewable planning memo: proposed sequence, dependencies, risks, and recommended Task Board items (as proposals only).
+
+## Stop conditions
+- A plan would require executing tasks, closing tasks, or editing code/roadmap directly. Stop and report.
+
+## Current status
+Planned, not created. Maximum maturity: Level 1 (planning only; no execution).

--- a/.claude/agents/regression-guard.md
+++ b/.claude/agents/regression-guard.md
@@ -1,0 +1,42 @@
+---
+name: regression-guard
+description: Use only when Gianluca explicitly asks for the regression-guard agent by name, to run and interpret build/test checks against the protected baseline.
+---
+
+# regression-guard
+
+## Standing constraints
+- AxisVar remains **frozen** and in abeyance.
+- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- DataExchange is **not** Core — it is the interchange boundary.
+- Current test baseline: **64/64 passing at commit `376d81e`**.
+- **No code cleanup is authorised yet.**
+
+## Role
+Run and interpret build/test checks when explicitly instructed, and compare against the protected baseline.
+
+## Allowed actions during current handover
+- No automatic execution.
+- When explicitly instructed: run `dotnet build -c Release` and `dotnet test`.
+- Compare results against the `376d81e` baseline (64/64).
+
+## Forbidden actions
+- No fixes. No source edits. No test edits.
+- No loops unless approved.
+- No marking tasks Done.
+- No AxisVar work; no GitHub or code cleanup.
+
+## Required Notion read set
+- Progesi Test Runs
+- ADR-010 — Canonical checkpoint baseline is 376d81e (when present)
+- Claude Rules Review — Draft
+- the current task row
+
+## Required output format
+- Command(s) run, pass/fail counts, comparison to baseline (64/64), and any deltas — with no remediation performed.
+
+## Stop conditions
+- Asked to fix failures, edit code/tests, or run without explicit instruction. Stop and report.
+
+## Current status
+Planned, not created. Maximum maturity: Level 1 (reporting only; execution requires explicit instruction).

--- a/.cursor/rules/progesi-architecture.mdc
+++ b/.cursor/rules/progesi-architecture.mdc
@@ -39,3 +39,48 @@ These rules are authoritative for Cursor in this repository. If a request confli
 - Editing ProgesiDomainServices duplicate-model code.
 - Deleting or moving legacy code.
 - Modifying solution files, project files, build/deploy scripts, or package files.
+
+## Implementation prerequisites (smoke-test hardening)
+Cursor may implement **only** when a filled task brief (or equivalent approved scope, per `docs/task-brief-template.md`) is provided, including all of:
+- approved Task Board row
+- **human approval status = Approved**
+- branch
+- allowed files
+- forbidden files
+- acceptance criteria
+- tests
+- rollback plan
+- manual Grasshopper validation requirement if the change is GH-facing
+
+If any prerequisite is missing, Cursor stays read-only and stops.
+
+## Frozen AxisVar files (do not modify, move, or delete)
+- `src/ProgesiCore/ProgesiAxisVariable.cs`
+- `src/ProgesiCore/ProgesiAxisVariableDto.cs`
+- `src/ProgesiCore/Persistence/ProgesiAxisVariableRepository.cs`
+- `src/ProgesiCore/Persistence/ProgesiAxisVariableSql.cs`
+- `src/ProgesiGrasshopperAssembly/Components/AxisVarDefineComponent.cs`
+- `src/ProgesiGrasshopperAssembly/Components/AxisVarSeriesComponent.cs`
+- `src/ProgesiGrasshopperAssembly/Infrastructure/AxisVar/AxisContext.cs`
+- `src/ProgesiGrasshopperAssembly/Infrastructure/AxisVar/AxisVarMapping.cs`
+- `src/ProgesiGrasshopperAssembly/Infrastructure/AxisVar/RhinoAxisStationing.cs`
+- relevant AxisVar test files (e.g. `tests/ProgesiCore.Tests/ProgesiAxisVariable*.cs`, `tests/ProgesiRepositories.Sqlite.Tests/ProgesiAxisVariableRepositoryIntegrationTests.cs`)
+
+Axis DTOs in `src/ProgesiDataExchange/DTOs.cs` are also frozen. Inspect only; never edit.
+
+## Branch policy
+- `docs/claude-handover-rules` is **documentation/rules only**.
+- Implementation branches must be named in the approved task brief.
+- Cursor must **not** implement on a docs/rules branch.
+
+## Reporting checklist
+After any approved work, Cursor must report:
+- files changed
+- commands run
+- tests run
+- final `git status`
+- deviations from the allowed scope
+- any blocked or unclear instruction
+
+## Manual Grasshopper validation
+For GH-facing changes, Cursor must check whether the Grasshopper Manual Test Matrix already has relevant rows, or whether a new manual validation task is required, before the change can be considered complete.

--- a/.cursor/rules/progesi-architecture.mdc
+++ b/.cursor/rules/progesi-architecture.mdc
@@ -1,0 +1,41 @@
+---
+description: Progesi Toolkit architecture and workflow rules
+alwaysApply: true
+---
+
+# Progesi Toolkit — Cursor Architecture & Workflow Rules
+
+These rules are authoritative for Cursor in this repository. If a request conflicts with them, stop and ask for human approval.
+
+## Standing facts (always true)
+- AxisVar is **frozen** — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
+- ProgesiVariableCluster is a **missing capability / suspected regression** — it is not in the current repository and is **not implemented**.
+- DataExchange is **not** Core — it is the interchange boundary.
+- Current test baseline is **64/64 passing at commit `376d81e`**.
+- **No code cleanup is authorised yet.**
+
+## Core independence
+- ProgesiCore must not depend on Rhino, Grasshopper, Excel libraries, Entity Framework, UI frameworks, SQLite-specific NuGet packages, or ASP.NET.
+- Persistence implementation must not be added to Core.
+- Existing AxisVar persistence inside Core is quarantined; do not extend it.
+- Dependency direction is one-way: outer layers → adapters/DataExchange → repository interfaces → Core. Never the reverse.
+
+## DataExchange
+- DataExchange is the interchange boundary, not a domain layer. Do not move Excel/SQLite/Rhino/database-specific logic into Core.
+
+## Workflow rules
+- **Cursor is read-only unless explicitly approved** for a specific task.
+- No source refactor unless explicitly scoped in an approved task brief.
+- No broad cleanup of any kind.
+- No public API renames (classes, namespaces, files, projects) without approval.
+- Tests are required for any code change; do not reduce the baseline.
+- Manual Grasshopper validation is required for any Grasshopper-facing change.
+- Do not modify files outside the task scope (allowed-files list).
+- Do not invent architecture — implement only what the approved brief specifies.
+- Always report which files were changed.
+
+## Forbidden without explicit approval
+- Editing AxisVar files or `ProgesiCore/Persistence` files.
+- Editing ProgesiDomainServices duplicate-model code.
+- Deleting or moving legacy code.
+- Modifying solution files, project files, build/deploy scripts, or package files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Progesi Toolkit — Agent Registry
+
+This file documents the **planned** Claude agent model for the Progesi Toolkit.
+Agents are assistants, **not autonomous project owners**. Nothing here enables autonomous execution.
+
+## Standing constraints (apply to all agents)
+- AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
+- ProgesiVariableCluster is a **missing capability / suspected regression** — not present in the current repository and not implemented.
+- DataExchange is **not** a Core domain object — it is the interchange boundary.
+- Current test baseline: **64/64 passing at commit `376d81e`**.
+- **No code cleanup is authorised yet.**
+
+## Principles
+- Agents are **planned, not autonomous project owners**.
+- `implementation-agent-disabled` **remains disabled**.
+- Agents must **not** work through the full Task Board autonomously.
+- No implementation without explicit human approval.
+- No autonomous agent execution. Each agent runs only when Gianluca explicitly asks for it by name.
+
+## Agent maturity levels
+- **Level 0 — No agents.** Current starting point; Claude operates via manually pasted prompts and controlled Notion writes.
+- **Level 1 — Read-only agents.** May read Notion and/or repository context and produce reports. No writes.
+- **Level 2 — Notion-only agents.** May update explicitly approved Notion pages or rows. No repository file changes.
+- **Level 3 — Documentation/rules agents.** May create repository documentation or rules files only on an approved docs/rules branch. No source code changes.
+- **Level 4 — Limited implementation agents.** *Future state only.* May edit code for one approved task, on one approved branch, with allowed files, forbidden files, tests, rollback plan, and human review.
+- **Level 5 — Autonomous Task Board execution.** **Not approved. Not planned** for the current phase.
+
+## Agent list
+Detailed definitions live in `.claude/agents/*.md`.
+
+| Agent | Purpose | Max level now |
+|---|---|---|
+| `notion-project-curator` | Maintain approved Notion pages/rows | Level 2 |
+| `documentation-writer` | Repository docs/rules on approved branches | Level 3 |
+| `progesi-architecture-reviewer` | Architecture & ADR-implication review | Level 1 |
+| `grasshopper-manual-test-designer` | Manual Rhino/GH test procedures | Level 1 |
+| `regression-guard` | Build/test reporting when instructed | Level 1 |
+| `cursor-task-brief-writer` | Prepare Cursor prompts/task briefs | Level 1 |
+| `git-governance-agent` | Read-only Git state / branch strategy | Level 1 |
+| `progesi-strategy-planner` | Planning & task sequencing | Level 1 |
+| `implementation-agent-disabled` | Placeholder — **disabled** | Disabled |
+
+## Hard limits
+- No agent may modify source code, tests, solution files, or project files without an explicitly approved task.
+- No agent may mark implementation tasks Done.
+- No agent may move frozen tasks out of `Blocked / Frozen`.
+- No agent may perform GitHub cleanup, code cleanup, or AxisVar work.
+- No agent may run Rhino or Grasshopper.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# Progesi Toolkit — Claude Operating Rules
+
+These rules govern how Claude Code may work in this repository. They are authoritative.
+If anything here conflicts with Notion, **stop and report** before acting.
+
+## Standing constraints (apply to all work)
+- AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
+- ProgesiVariableCluster is a **missing capability / suspected regression** — it is not present in the current repository and must not be treated as implemented.
+- DataExchange is **not** a Core domain object — it is the interchange boundary.
+- Current test baseline: **64/64 passing at commit `376d81e`** (protected checkpoint on `feat/axis-variable-core`).
+- **No code cleanup is authorised yet.**
+
+## 1. Current mode
+- Mode: **no-code handover / governance setup**.
+- Protected checkpoint: branch **`feat/axis-variable-core`** at commit **`376d81e`** (clean tree, release build passing, 64/64 tests).
+- The current branch **`docs/claude-handover-rules`** is for **documentation/rules only**. No source code, tests, solution files, or project files may be changed on it.
+
+## 2. Non-negotiable rules
+- No source code changes unless explicitly approved.
+- No tests modified unless explicitly approved.
+- No AxisVar work of any kind.
+- No legacy removal (code or files).
+- No GitHub cleanup (no branch/tag deletion, no history rewrite, no force-push).
+- No autonomous Task Board execution.
+- Do not mark implementation tasks **Done** without human approval and test evidence.
+- Do not broaden task scope or perform opportunistic refactors.
+- Do not rename public classes, namespaces, files, or projects without approval.
+
+## 3. Required Notion read-before-action protocol
+Before acting, read the relevant Notion context:
+- **Progesi Toolkit HQ**
+- **Claude Setup Log**
+- the **current Task Board row**, if a task is involved
+- **Architecture Map**, if architecture is involved
+- **05_AxisVar_Freeze_and_Abeyance**, if AxisVar is involved
+- **10_Human_Review_Gates**
+
+Then **summarize before acting**: objective, relevant context, branch/commit, allowed scope, forbidden scope, architecture risks, tests/manual validation required, expected output, and whether human approval is required.
+If Notion documentation conflicts, **stop and report** — do not proceed.
+
+## 4. Architecture rules
+- ProgesiCore must **not** depend on Rhino, Grasshopper, Excel libraries, Entity Framework, UI frameworks, SQLite-specific NuGet packages, or ASP.NET.
+- **DataExchange is not Core** — it is the interchange boundary and must stay outside the Core domain.
+- Persistence implementation should **not** be added to Core.
+- Existing AxisVar persistence inside Core (`src/ProgesiCore/Persistence/ProgesiAxisVariable*.cs`) is **quarantined** — do not extend it.
+- Dependency direction: Grasshopper/Rhino/Excel/Database/Future-Web → Application/Adapter → DataExchange/Repository interfaces → Core. Never the reverse.
+
+## 5. AxisVar freeze
+All ProgesiAxisVariable work is frozen. The frozen areas (do not modify, delete, consolidate, move, or wire) include:
+- `src/ProgesiCore/ProgesiAxisVariable.cs`
+- `src/ProgesiCore/ProgesiAxisVariableDto.cs`
+- `src/ProgesiCore/Persistence/ProgesiAxisVariableRepository.cs`
+- `src/ProgesiCore/Persistence/ProgesiAxisVariableSql.cs`
+- axis-related DTOs in `src/ProgesiDataExchange/`
+- `src/ProgesiGrasshopperAssembly/Components/AxisVarDefineComponent.cs`
+- `src/ProgesiGrasshopperAssembly/Components/AxisVarSeriesComponent.cs`
+- `src/ProgesiGrasshopperAssembly/Infrastructure/AxisVar/*` (AxisContext, AxisVarMapping, RhinoAxisStationing)
+- axis-related tests
+
+Read-only inspection and documentation are allowed. The freeze lifts only after the relevant ADRs are accepted and Gianluca explicitly authorises source changes.
+
+## 6. Cursor boundary
+- Cursor is **read-only** unless explicitly approved.
+- Claude prepares Cursor task briefs **only when instructed**.
+- Cursor implementation requires: an approved Task Board row, a branch, allowed files, forbidden files, tests, manual validation if Grasshopper is affected, and a rollback plan.
+- Claude reviews Cursor output (diff + test results) before any merge or documentation update.
+
+## 7. Build/test commands
+- Run build/test **only when explicitly instructed**.
+- Canonical baseline: `dotnet build -c Release` then `dotnet test` → **64 tests passing** at commit `376d81e`.
+- Never run Rhino or Grasshopper from here.
+
+## 8. Reporting requirements
+After any action, report:
+- changed files
+- Notion updates made (if any)
+- commands run
+- test results (if any)
+- `git status` (and branch/commit when repository interaction occurred)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ Read-only inspection and documentation are allowed. The freeze lifts only after 
 - Claude prepares Cursor task briefs **only when instructed**.
 - Cursor implementation requires: an approved Task Board row, a branch, allowed files, forbidden files, tests, manual validation if Grasshopper is affected, and a rollback plan.
 - Claude reviews Cursor output (diff + test results) before any merge or documentation update.
+- Cursor smoke test passed, but Cursor still requires an explicit task brief and human approval before any implementation.
 
 ## 7. Build/test commands
 - Run build/test **only when explicitly instructed**.

--- a/docs/claude-governance.md
+++ b/docs/claude-governance.md
@@ -1,0 +1,68 @@
+# Progesi Toolkit — Claude Governance
+
+Detailed governance for Claude Code on the Progesi Toolkit, derived from the Notion **Claude Rules Review** and **ADR-015 — Claude / Notion / Cursor / Warp governance protocol**. This document is authoritative alongside `CLAUDE.md`.
+
+## Standing constraints (apply to all work)
+- AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
+- ProgesiVariableCluster is a **missing capability / suspected regression** — not present in the current repository and not implemented.
+- DataExchange is **not** a Core domain object — it is the interchange boundary.
+- Current test baseline: **64/64 passing at commit `376d81e`**.
+- **No code cleanup is authorised yet.**
+
+## Tool roles
+- **Claude Code (in Warp):** controlled project operation, Notion updates, documentation, audits, and — only when explicitly approved — later implementation.
+- **Notion:** persistent project memory (roadmap, architecture decisions, task tracking).
+- **GitHub:** version control, checkpoints, branches, release history.
+- **Cursor:** read-only repository navigation / audit unless explicitly approved for implementation.
+- **ChatGPT:** external architecture reviewer/planning assistant; **not** persistent project memory.
+
+## Notion read-before-action protocol
+Before any task, read the relevant Notion context and **summarize before acting**:
+- Minimum set: Progesi Toolkit HQ, Claude Setup Log, current Task Board row (if any), Notion Cleanup Plan, No-Code Recovery and Validation Plan, 07_Notion_Read_Write_Protocol, 10_Human_Review_Gates.
+- Architecture tasks add: Architecture Map, Progesi ADRs, ADR Coverage Review, 04_Current_Solution_Facts.
+- AxisVar tasks add: 05_AxisVar_Freeze_and_Abeyance and the relevant AxisVar ADRs.
+- Grasshopper tasks add: Grasshopper Component Catalogue and Grasshopper Manual Test Matrix.
+
+Summary must cover: objective, relevant context, branch/commit, allowed scope, forbidden scope, architecture risks, tests/manual validation required, expected output, and whether human approval is required.
+**If documentation conflicts, stop and report.**
+
+## Notion write protocol
+- Write to Notion **only when explicitly instructed**.
+- Modify only the named page/database/rows; never touch unrelated pages or databases.
+- Do not modify database schema unless explicitly instructed.
+- Do not rename, move, archive, or delete pages unless explicitly instructed.
+- Do not mark tasks Done without human approval.
+- Prefer appending dated notes over overwriting; when replacing content, show the proposed replacement first.
+- Report exactly what changed.
+
+## Repository interaction protocol
+- Inspect the repository only when instructed.
+- Before interaction, confirm: current path, branch, commit, and `git status --short`.
+- During handover the normally allowed repository commands are: `git status --short`, `git branch --show-current`, `git rev-parse --short HEAD`.
+- Build/test commands run only when explicitly instructed.
+- Repository **write** actions require an approved branch, scope, and rollback plan. Documentation/rules writes are allowed only on an approved docs/rules branch (e.g. `docs/claude-handover-rules`).
+- No commits, tags, or pushes unless explicitly instructed.
+
+## Human approval gates
+Human approval is required for: code changes, source refactors, test changes, repository file creation, ADR acceptance, closure of implementation tasks, moving frozen tasks out of `Blocked / Frozen`, deleting/moving legacy code, enabling agents, running implementation loops, and Cursor implementation.
+
+## AxisVar freeze
+All ProgesiAxisVariable work is frozen and in abeyance. Frozen areas include Core model/DTO, Core persistence (`ProgesiAxisVariableRepository.cs`, `ProgesiAxisVariableSql.cs`), DataExchange axis DTOs, and the Grasshopper AxisVar components and infrastructure (AxisContext, AxisVarMapping, RhinoAxisStationing). Read-only inspection and documentation only. The freeze lifts only after relevant ADRs are accepted and Gianluca explicitly authorises source changes.
+
+## Task Board rules
+- Respect Workflow Stages. `Blocked / Frozen` tasks must not be acted on; AxisVar tasks remain `Blocked / Frozen`.
+- Tasks with `Claude Allowed` unchecked must not be worked on by Claude; `Cursor Allowed` unchecked likewise for Cursor.
+- `Needs Human Review` means Claude must not close the task.
+- Implementation tasks must not be marked Done without human approval and test evidence.
+
+## Manual Grasshopper validation policy
+Automated .NET tests are necessary but **not sufficient** for Grasshopper confidence. For GH-facing work, consult the **Grasshopper Manual Test Matrix**. Do not claim a GH component works unless a relevant manual test exists, expected behaviour is defined, and an actual human result is recorded. AxisVar manual tests remain Frozen / Excluded.
+
+## Loop policy
+Loops must not be used for implementation during handover. The only allowed handover loop is: read context → report understanding → ask for approval → perform one approved Notion write → run `git status --short` if repository interaction occurred → stop. Future implementation loops may be considered only after rules, agents, branch policy, and tests are approved.
+
+## Agent policy
+No autonomous Claude agents are enabled. Agents are defined in `.claude/agents/*.md` as planned capabilities only. Implementation agents remain disabled. Agents must not work through the full Task Board autonomously. See `AGENTS.md` for the maturity-level model.
+
+## Escalation / stop rules
+Stop and report when: the allowed action is unclear, Notion documentation conflicts, an unexpected file would change, scope would broaden, or an action would touch frozen/quarantined areas. When in doubt, do less and ask.

--- a/docs/claude-governance.md
+++ b/docs/claude-governance.md
@@ -61,6 +61,9 @@ Automated .NET tests are necessary but **not sufficient** for Grasshopper confid
 ## Loop policy
 Loops must not be used for implementation during handover. The only allowed handover loop is: read context → report understanding → ask for approval → perform one approved Notion write → run `git status --short` if repository interaction occurred → stop. Future implementation loops may be considered only after rules, agents, branch policy, and tests are approved.
 
+## Cursor handoff policy
+Cursor smoke test passed; future Cursor work must use an approved task brief and remain read-only by default (no implementation without an approved brief and human approval = Approved).
+
 ## Agent policy
 No autonomous Claude agents are enabled. Agents are defined in `.claude/agents/*.md` as planned capabilities only. Implementation agents remain disabled. Agents must not work through the full Task Board autonomously. See `AGENTS.md` for the maturity-level model.
 

--- a/docs/cursor-interface-protocol.md
+++ b/docs/cursor-interface-protocol.md
@@ -1,0 +1,46 @@
+# Progesi Toolkit — Claude ↔ Cursor Interface Protocol
+
+This document defines the boundary between Claude and Cursor. It complements `docs/claude-governance.md` and `.cursor/rules/progesi-architecture.mdc`.
+
+## Standing constraints (apply to all work)
+- AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
+- ProgesiVariableCluster is a **missing capability / suspected regression** — not present in the current repository and not implemented.
+- DataExchange is **not** a Core domain object — it is the interchange boundary.
+- Current test baseline: **64/64 passing at commit `376d81e`**.
+- **No code cleanup is authorised yet.**
+
+## No direct control requirement
+There is **no requirement for Claude to control Cursor directly**. Claude does not drive Cursor. The two tools communicate through Notion and human review, not through automation.
+
+## The interface
+The approved flow is one direction, gated by human review:
+
+```
+Notion (decision & context)
+  → Claude prepares a task brief (when instructed)
+  → Human approves the brief
+  → Cursor implements (only within the approved scope)
+  → Claude reviews Cursor output (diff + tests)
+  → Human reviews
+  → Claude updates Notion (only when explicitly instructed)
+```
+
+## Cursor is read-only by default
+- Cursor remains **read-only** unless implementation is explicitly approved.
+- Cursor must obey the rules in `.cursor/rules/progesi-architecture.mdc`.
+- Cursor must **not invent architecture** — it implements only what an approved brief specifies.
+
+## Implementation prerequisites
+Cursor may implement only when **all** of the following exist:
+- an **approved Task Board row**
+- a **branch**
+- **allowed files**
+- **forbidden files**
+- **tests** to run
+- **manual validation** if Grasshopper is affected
+- a **rollback plan**
+
+If any prerequisite is missing, implementation does not proceed.
+
+## Claude's review responsibility
+After Cursor implements, Claude reviews the diff and test results against the brief and the architecture rules before any merge or Notion update. Anything outside the approved scope is rejected and reported.

--- a/docs/cursor-interface-protocol.md
+++ b/docs/cursor-interface-protocol.md
@@ -33,6 +33,7 @@ Notion (decision & context)
 ## Implementation prerequisites
 Cursor may implement only when **all** of the following exist:
 - an **approved Task Board row**
+- **human approval status = Approved** (explicit, not merely implied by the workflow)
 - a **branch**
 - **allowed files**
 - **forbidden files**
@@ -41,6 +42,11 @@ Cursor may implement only when **all** of the following exist:
 - a **rollback plan**
 
 If any prerequisite is missing, implementation does not proceed.
+
+## Cursor smoke-test hardening
+- Cursor verified the governance files are readable.
+- Minor hardening was added after the smoke test.
+- Cursor remains read-only unless all prerequisites above are met (including human approval status = Approved).
 
 ## Claude's review responsibility
 After Cursor implements, Claude reviews the diff and test results against the brief and the architecture rules before any merge or Notion update. Anything outside the approved scope is rejected and reported.

--- a/docs/repository-cleanup-protocol.md
+++ b/docs/repository-cleanup-protocol.md
@@ -1,0 +1,53 @@
+# Progesi Toolkit — Repository Cleanup Protocol
+
+Safe, staged process for any future repository cleanup (source or GitHub). Nothing here authorises cleanup now — it defines how cleanup must happen **when** it is approved.
+
+## Standing constraints (apply to all work)
+- AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
+- ProgesiVariableCluster is a **missing capability / suspected regression** — not present in the current repository and not implemented.
+- DataExchange is **not** a Core domain object — it is the interchange boundary.
+- Current test baseline: **64/64 passing at commit `376d81e`**.
+- **No code cleanup is authorised yet.**
+
+## Core principles
+- **Cleanup starts with a read-only audit.** No changes until the audit is reviewed.
+- **Classify cleanup candidates** before touching anything: what it is, why it looks removable, what depends on it, and the risk of removing it.
+- **No deletion without ADR + validation + rollback.** Code/files are not removed merely because they look wrong.
+- **GitHub cleanup is separate from source-code cleanup.** They are different tasks with different risks and must not be combined.
+- **Do not rewrite history.** No rebases that drop commits, no force-pushes.
+- **Do not delete tags or releases yet.**
+
+## Source cleanup requirements
+Any source cleanup requires:
+- an approved branch and explicit scope (allowed/forbidden files),
+- tests to run (baseline 64/64 must be preserved unless a change is explicitly approved),
+- manual Grasshopper validation if any GH-facing code is affected,
+- a rollback plan,
+- human approval.
+
+### Quarantined — do not delete yet
+- `src/ProgesiCore/Persistence/ProgesiAxisVariableRepository.cs`
+- `src/ProgesiCore/Persistence/ProgesiAxisVariableSql.cs`
+- all AxisVar files (Core, DataExchange DTOs, Grasshopper components and infrastructure)
+- ProgesiDomainServices duplicate-model code (review first)
+- duplicated DataExchange paths (review first)
+
+These hold architectural clues; removing them now is a destructive source change and is forbidden.
+
+## GitHub branch cleanup (read-only audit first)
+Inventory branches and tags, then classify each branch as exactly one of:
+- **Keep**
+- **Review**
+- **Delete local later**
+- **Delete remote later**
+- **Unknown**
+
+Rules: no deletion, no force-push, no history rewrite, no tag removal during the audit. Local stale-branch deletion happens only after approval; remote stale-branch deletion happens only after separate approval. Source code is never removed as part of GitHub cleanup.
+
+## Order of operations (when approved)
+1. Read-only audit + classification.
+2. Human review of the audit.
+3. Protect essential branches/tags.
+4. Approve specific, scoped removals.
+5. Execute removals on an approved branch with rollback ready.
+6. Re-run tests / record results.

--- a/docs/task-brief-template.md
+++ b/docs/task-brief-template.md
@@ -55,7 +55,17 @@ Copy this template per task. A brief is only actionable after **Human approval s
 <how to revert safely if the change fails review or tests>
 
 ## Human approval status
-<Not requested | Requested | Approved | Rejected> — with date and approver
+- Not requested
+- Requested
+- Approved
+- Rejected
+
+Record the selected value with date and approver. Implementation may proceed only when this is **Approved**.
+
+## Current branch policy
+- Working branch: <name>
+- Is this branch allowed for implementation? <yes / no>
+- If not (e.g. a documentation/rules branch such as `docs/claude-handover-rules`), **stop** — do not implement here.
 
 ## Claude review checklist
 - [ ] Only allowed files changed
@@ -68,3 +78,12 @@ Copy this template per task. A brief is only actionable after **Human approval s
 
 ## Cursor instructions
 <precise, scoped prompt for Cursor; must reference allowed/forbidden files and forbid architecture invention and out-of-scope edits>
+
+## Final reporting checklist
+After the task, report:
+- [ ] Files changed
+- [ ] Commands run
+- [ ] Tests run and results
+- [ ] Final `git status`
+- [ ] Deviations from the allowed scope (if any)
+- [ ] Any blocked or unclear instruction

--- a/docs/task-brief-template.md
+++ b/docs/task-brief-template.md
@@ -1,0 +1,70 @@
+# Progesi Toolkit — Task Brief Template
+
+Reusable template for preparing a controlled implementation or documentation task.
+Copy this template per task. A brief is only actionable after **Human approval status = Approved**.
+
+## Standing constraints (apply to every brief)
+- AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
+- ProgesiVariableCluster is a **missing capability / suspected regression** — not present in the current repository and not implemented.
+- DataExchange is **not** a Core domain object — it is the interchange boundary.
+- Current test baseline: **64/64 passing at commit `376d81e`**.
+- **No code cleanup is authorised yet.**
+
+---
+
+## Task title
+<short, specific title>
+
+## Notion task link
+<URL of the Progesi Task Board row>
+
+## Branch
+<exact branch name; must already be approved>
+
+## Objective
+<one paragraph: what outcome this task achieves and why>
+
+## Layer
+<one or more of: Core, DataExchange, Grasshopper-Rhino, Database, Excel, Tests, Docs, GitHub, Cursor, Future Web>
+
+## Allowed files
+<explicit list of files that may be created or modified>
+
+## Forbidden files
+<explicit list; always includes AxisVar files, ProgesiCore/Persistence, ProgesiDomainServices duplication, solution/project files unless explicitly listed>
+
+## Architecture constraints
+- Preserve Core independence (no Rhino/GH/Excel/EF/UI/SQLite-specific/ASP.NET dependencies in Core).
+- DataExchange stays out of Core.
+- No persistence implementation added to Core.
+- No public API renames without approval.
+
+## Acceptance criteria
+<bullet list of objectively checkable outcomes>
+
+## Tests to run
+<exact commands, e.g. `dotnet build -c Release`, `dotnet test`; expected: baseline 64/64 unless the task adds tests>
+
+## Manual validation required
+<Grasshopper Manual Test Matrix rows / procedures, if GH is affected; otherwise "None">
+
+## Regression risks
+<what could break; which existing behaviour to watch>
+
+## Rollback plan
+<how to revert safely if the change fails review or tests>
+
+## Human approval status
+<Not requested | Requested | Approved | Rejected> — with date and approver
+
+## Claude review checklist
+- [ ] Only allowed files changed
+- [ ] No forbidden/frozen files touched
+- [ ] Architecture constraints respected
+- [ ] Tests run and results recorded (baseline preserved or intentionally updated)
+- [ ] Manual GH validation recorded if applicable
+- [ ] `git status` / diff reviewed
+- [ ] Notion updated only as instructed
+
+## Cursor instructions
+<precise, scoped prompt for Cursor; must reference allowed/forbidden files and forbid architecture invention and out-of-scope edits>


### PR DESCRIPTION
This PR adds the Progesi Toolkit governance layer for the Claude / Cursor / Notion / Warp handover.

Scope:
- Adds CLAUDE.md
- Adds AGENTS.md
- Adds Claude project agent definitions under .claude/agents/
- Adds Cursor project rules under .cursor/rules/
- Adds governance documentation under docs/

This PR does not modify:
- source code
- tests
- solution files
- project files
- build scripts
- deployment scripts
- artefacts
- AxisVar files
- ProgesiVariableCluster recovery

Validation already performed:
- Controlled Repository Verification 025 passed.
- Controlled Repository Verification/Commit 026 committed and pushed governance files.
- Controlled Repository Verification/Commit 040 tightened Cursor governance and passed build/test.
- dotnet build -c Release passed.
- dotnet test passed: 64 total, 64 passed, 0 failed.

Important governance facts:
- Protected source checkpoint: feat/axis-variable-core at 376d81e.
- Governance branch: docs/claude-handover-rules at 4b481ff.
- Cursor remains read-only unless explicitly approved.
- AxisVar remains frozen and in abeyance.
- ProgesiVariableCluster is missing / suspected regression, not implemented.
- DataExchange is not a Core domain object.
- No code cleanup or GitHub cleanup is authorised by this PR.

Review notes:
- This PR should be reviewed before any merge.
- Do not merge into main from this PR.
- main remains untouched pending branch strategy decision.
- This PR is intended to target feat/axis-variable-core only.