### PR TITLE
docs: clarify superseded cleanup note

### DIFF
--- a/README_CLEANUP.md
+++ b/README_CLEANUP.md
@@ -1,23 +1,41 @@
-# Progesi – Solution Cleanup & Structure
+# Progesi – Solution Cleanup & Structure (Historical / Superseded)
 
-This repository was restructured to simplify development and deployment for Grasshopper.
+> **Status: historical note — superseded.**
+> This file is **not** the current cleanup plan and does **not** authorise any cleanup.
+> It is retained only as a record of an earlier repository restructuring.
 
-## Layout
-- `src/` – active production projects (libraries and Grasshopper assemblies)
-- `tests/` – unit/integration tests
-- `samples/` – example Grasshopper files (`.gh`, `.ghx`)
-- `build/` – build scripts, common MSBuild files
-- `docs/` – documentation, notes
-- `archive_legacy_removed_from_sln/` – old/legacy projects removed from the solution but kept here for reference
+## Current sources of truth
 
-A backup of the original `.sln` was saved next to the current one with the suffix `.backup_before_cleanup.sln`.
+For the current cleanup status, scope and governance, see:
 
-See also `README_DEPLOY.md` for auto-deploy details.
+- Notion: **Documentation-only Cleanup Scope — Draft**
+- Notion: **Repository Code Cleanup Audit — Draft**
+- Notion: **Non-Axis Dead-Code Usage Confirmation — Draft**
+- Repository: `docs/repository-cleanup-protocol.md`
+- Repository: `CLAUDE.md`
 
-## Testing
-A test project `Progesi.Repositories.Sqlite.Tests` was added under `tests/` with a simple **xUnit smoke test**.
+## Current state (reference)
 
-Run tests with:
-```
-dotnet test
-```
+- Protected source checkpoint: **`feat/axis-variable-core` at `376d81e`**.
+- Governance branch: **`docs/claude-handover-rules` at `4b481ff`**.
+- **Source-code cleanup is not authorised by this file.** Any cleanup requires an approved
+  Task Board row, branch, allowed/forbidden files, tests and a rollback plan, per the
+  cleanup protocol above.
+- **AxisVar remains frozen.** ProgesiVariableCluster recovery is **not authorised**.
+
+## Historical context (no longer accurate)
+
+The notes below describe an earlier restructuring and are kept for history only. They do
+**not** reflect the current repository layout and must not be treated as instructions.
+
+- The repository was once described with a layout including `src/`, `tests/`, `samples/`,
+  a `docs/` folder, and additional folders that are **no longer present** in the current
+  tree (for example a top-level build-scripts folder and a separate legacy-archive folder).
+- An earlier `.sln` backup convention and pre-cleanup backup files referenced historically
+  here are **no longer part of the current repository** and should be disregarded.
+- An earlier test-project name referenced here was approximate; the current test projects
+  are defined by the solution and project files (see `Progesi.sln`). Do not rely on the
+  historical name in this note.
+
+For the authoritative current structure, consult the solution/project files and the
+documentation listed under **Current sources of truth** above.


### PR DESCRIPTION
This PR updates README_CLEANUP.md so it is clearly marked as a historical / superseded cleanup note.

Scope:
- Updates README_CLEANUP.md only.
- Clarifies that README_CLEANUP.md is not the current cleanup plan.
- Points to the current Notion and repository cleanup sources of truth.
- States that source cleanup is not authorised by this file.
- States that AxisVar remains frozen.
- States that ProgesiVariableCluster recovery is not authorised.
- Neutralises stale references to old cleanup folders, backup files, build folders and misnamed test project references.

This PR does not modify:
- source code
- tests
- solution files
- project files
- scripts
- deployment files
- package files
- artefacts
- coverage badges
- sample .gh files
- AxisVar files
- ProgesiVariableCluster recovery
- GitHub branches or tags

Validation already performed:
- Controlled Repository Verification/Commit 059 passed.
- dotnet build -c Release passed.
- dotnet test passed: 64 total, 64 passed, 0 failed.
- Documentation-only cleanup pass was reviewed and accepted by Gianluca in Notion.

Important governance facts:
- Base branch: feat/axis-variable-core.
- Head branch: docs/documentation-cleanup-pass-1.
- Prior governance PR #58 has already merged docs/claude-handover-rules into feat/axis-variable-core.
- main remains untouched pending branch-strategy decision.
- No source cleanup or GitHub cleanup is authorised by this PR.

Review notes:
- This PR should show README_CLEANUP.md only.
- Do not merge into main from this PR.
- Do not delete branches after merge unless separately approved.