### PR TITLE
fix: validate VariableIn references and overwrite behaviour

### DIFF
--- a/src/ProgesiGrasshopperAssembly/Components/ProgesiVariableInComponent.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/ProgesiVariableInComponent.cs
@@ -47,6 +47,16 @@ namespace ProgesiGrasshopperAssembly.Components
       p.AddTextParameter("Info", "Info", "Esito/diagnostica.", GH_ParamAccess.item);
     }
 
+    // IDs già accettati per scrittura nella soluzione corrente (tutti i branch del tree).
+    // Serve a respingere branch in conflitto che ripetono lo stesso Id esplicito senza overwrite silenzioso.
+    private readonly HashSet<int> _seenWriteIds = new HashSet<int>();
+
+    protected override void BeforeSolveInstance()
+    {
+      _seenWriteIds.Clear();
+      base.BeforeSolveInstance();
+    }
+
     protected override void SolveInstance(IGH_DataAccess DA)
     {
       bool run = false; string act = "Create"; int id = 0; string name = ""; string val = ""; string unit = ""; string by = "";
@@ -66,8 +76,15 @@ namespace ProgesiGrasshopperAssembly.Components
       bool isUpdate = act.Equals("Update", StringComparison.OrdinalIgnoreCase);
       bool isDelete = act.Equals("Delete", StringComparison.OrdinalIgnoreCase);
 
-      if (!(isCreate || isUpdate || isDelete)) { Emit(DA, val, outId, outHash, "Input non valido: Act", name); return; }
-      if ((isUpdate || isDelete) && id <= 0) { Emit(DA, val, outId, outHash, "Input non valido: Id (>0)", name); return; }
+      if (!(isCreate || isUpdate || isDelete)) { Fail(DA, val, outId, outHash, "Input non valido: Act", name); return; }
+      if ((isUpdate || isDelete) && id <= 0) { Fail(DA, val, outId, outHash, "Input non valido: Id (>0)", name); return; }
+
+      // Tree overwrite safety: lo stesso Id esplicito non può comparire in più branch della stessa soluzione.
+      if ((isCreate || isUpdate) && id > 0 && !_seenWriteIds.Add(id))
+      {
+        Fail(DA, val, outId, outHash, $"Conflitto tree: Id {id} ripetuto in più branch. Nessun overwrite silenzioso.", name);
+        return;
+      }
 
       // Unit come fattore numerico opzionale: Value × Unit se ENTRAMBI numerici
       var inv = CultureInfo.InvariantCulture;
@@ -88,12 +105,15 @@ namespace ProgesiGrasshopperAssembly.Components
         {
           string info; bool ok = MetadataRepositoryCompatExtensions.TryDeleteVariable(repo, id, out info);
           outId = id > 0 ? id : 0; outHash = ""; outInfo = string.IsNullOrWhiteSpace(info) ? (ok ? "OK" : "Operazione non riuscita") : info;
-          Emit(DA, val, outId, outHash, outInfo, name); return;
+          if (!ok) { Fail(DA, val, outId, outHash, outInfo, name); } else { Emit(DA, val, outId, outHash, outInfo, name); }
+          return;
         }
 
         var payload = new VarPayload
         {
           id = id,
+          act = act ?? "Create",
+          allowIdReassign = isCreate && IsTreeOrBatchInput(),
           name = name ?? "",
           value = val ?? "",
           unit = unit ?? "",
@@ -115,14 +135,28 @@ namespace ProgesiGrasshopperAssembly.Components
         var prefix = string.IsNullOrWhiteSpace(upInfo) ? (upOk ? "OK" : "Operazione non riuscita") : upInfo;
         outInfo = string.IsNullOrWhiteSpace(summary) ? prefix : $"{prefix} | {summary}";
 
+        if (!upOk) { Fail(DA, val, outId, outHash, outInfo, name); return; }
         Emit(DA, val, outId, outHash, outInfo, name);
       }
-      catch (Exception ex) { Emit(DA, val, outId, outHash, "Errore: " + ex.Message, name); }
+      catch (Exception ex) { Fail(DA, val, outId, outHash, "Errore: " + ex.Message, name); }
+    }
+
+    // Più path nella stessa soluzione → batch/tree (Test-17: Create con Id esistente → riassegnazione, non overwrite).
+    private bool IsTreeOrBatchInput()
+    {
+      foreach (var param in Params.Input)
+      {
+        if (param?.VolatileData != null && param.VolatileData.PathCount > 1)
+          return true;
+      }
+      return false;
     }
 
     private sealed class VarPayload
     {
       public int id { get; set; }
+      public string act { get; set; }
+      public bool allowIdReassign { get; set; }
       public string name { get; set; }
       public string value { get; set; }
       public string unit { get; set; }
@@ -148,6 +182,13 @@ namespace ProgesiGrasshopperAssembly.Components
       if (pi == null) return;
       var v = pi.GetValue(obj, null);
       target = v == null ? "" : v.ToString();
+    }
+
+    // Esito bloccante: errore rosso sul componente + Info testuale, senza overwrite silenzioso.
+    private void Fail(IGH_DataAccess DA, string val, int id, string hash, string info, string name)
+    {
+      AddRuntimeMessage(GH_RuntimeMessageLevel.Error, string.IsNullOrWhiteSpace(info) ? "Operazione non riuscita" : info);
+      Emit(DA, val, id, hash, info, name);
     }
 
     private void Emit(IGH_DataAccess DA, string val, int id, string hash, string info, string name)

--- a/src/ProgesiGrasshopperAssembly/Infrastructure/MetadataRepositoryCompatExtensions.cs
+++ b/src/ProgesiGrasshopperAssembly/Infrastructure/MetadataRepositoryCompatExtensions.cs
@@ -402,6 +402,8 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
         var table = doc.Strings;
 
         var id = ReadInt(payload, "id");
+        var explicitId = id;                            // Id fornito esplicitamente dall'utente (>0)
+        var act = ReadString(payload, "act");           // Create | Update (Delete è gestito altrove)
         var name = ReadString(payload, "name");
         var value = ReadString(payload, "value");
         var unit = ReadString(payload, "unit");
@@ -440,6 +442,64 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
         else if (string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)) typedValue = true;
         else if (string.Equals(value, "false", StringComparison.OrdinalIgnoreCase)) typedValue = false;
 
+        var varRepo = new RhinoVariableRepository(doc);
+        var metaRepo = new RhinoMetadataRepository(doc);
+
+        // === Reference validation & overwrite safety (prima di qualsiasi mutazione dello store) ===
+
+        // 1) Dipendenze: ogni Id referenziato deve esistere (forward reference NON consentita).
+        var missingDeps = new List<int>();
+        foreach (var dep in depends ?? Array.Empty<int>())
+        {
+          var dv = varRepo.GetByIdAsync(dep).GetAwaiter().GetResult();
+          if (dv == null) missingDeps.Add(dep);
+        }
+        if (missingDeps.Count > 0)
+        {
+          info = "Dipendenze inesistenti (forward reference non consentita): Id " + string.Join(", ", missingDeps) + ".";
+          return false;
+        }
+
+        // 2) Metadata: se fornito un MId, deve risolvere a un record esistente.
+        if (!string.IsNullOrWhiteSpace(midStr))
+        {
+          if (!metaId.HasValue)
+          {
+            info = "Metadata non risolvibile: '" + midStr.Trim() + "'.";
+            return false;
+          }
+          var mm = metaRepo.GetAsync(metaId.Value).GetAwaiter().GetResult();
+          if (mm == null)
+          {
+            info = "Metadata inesistente: Id " + metaId.Value + ".";
+            return false;
+          }
+        }
+
+        // 3) Overwrite safety per Id esplicito: Create singolo rifiuta un Id esistente;
+        //    Create batch/tree riassegna senza mutare il record esistente; Update richiede un Id esistente.
+        bool actIsUpdate = string.Equals(act, "Update", StringComparison.OrdinalIgnoreCase);
+        int idReassignedFrom = 0;
+        if (explicitId > 0)
+        {
+          var existing = varRepo.GetByIdAsync(explicitId).GetAwaiter().GetResult();
+          if (!actIsUpdate && existing != null)
+          {
+            if (!ReadBool(payload, "allowIdReassign"))
+            {
+              info = "Create rifiutato: Id " + explicitId + " già esistente. Usa Action=Update per modificare.";
+              return false;
+            }
+            idReassignedFrom = explicitId;
+            id = 0;
+          }
+          if (actIsUpdate && existing == null)
+          {
+            info = "Update rifiutato: Id " + explicitId + " inesistente.";
+            return false;
+          }
+        }
+
         // dedupe sul content-hash DI DOMINIO
         var depN = (depends ?? Array.Empty<int>()).Distinct().OrderBy(x => x).ToArray();
         var tmp = new ProgesiVariable(0, name ?? string.Empty, typedValue, depN, metaId, isAss);
@@ -450,10 +510,8 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
 
         if (id <= 0) id = NextId(table, "Progesi.Var", "__next__");
 
-        var repo = new RhinoVariableRepository(doc);
-
         // dis-indicizza vecchio content-hash se update
-        var current = repo.GetByIdAsync(id).GetAwaiter().GetResult();
+        var current = varRepo.GetByIdAsync(id).GetAwaiter().GetResult();
         if (current != null)
         {
           var oldContent = ProgesiHash.Compute(current);
@@ -465,7 +523,7 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
                                               metadataId: metaId,
                                               isAssumption: isAss);
 
-        repo.SaveAsync(variableNew).GetAwaiter().GetResult();
+        varRepo.SaveAsync(variableNew).GetAwaiter().GetResult();
 
         var newContent = ProgesiHash.Compute(variableNew);
         IndexHash(table, "Progesi.VarHash", newContent, id);
@@ -481,6 +539,9 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
         var assN = isAss ? "1" : "0";
         var nameN = ToNorm(name);
         var summary = $"ID:{id} | NAME:{nameN} | VALC:{valc} | BY:{(string.IsNullOrEmpty(byN) ? "-" : byN)} | MID:{(metaId.HasValue ? metaId.Value.ToString() : "-")} | DEP:[{depStr}] | ASS:{assN}";
+
+        if (idReassignedFrom > 0)
+          info = "Id " + idReassignedFrom + " già in uso; assegnato Id " + id + ".";
 
         persisted = new
         {


### PR DESCRIPTION
This PR fixes ProgesiVariableIn reference validation and overwrite-safety behaviour.

Scope:
- Updates ProgesiVariableIn component behaviour.
- Updates VariableIn repository-compatibility upsert behaviour.
- Rejects explicit dependency references when the referenced variables do not exist.
- Rejects explicit metadata ID/hash references when the referenced metadata records do not exist.
- Preserves null / empty dependency and metadata inputs as valid.
- Rejects single Create with an existing explicit ID.
- Allows Update with an existing ID only when Action = Update.
- Avoids tree-input overwrite by reassigning/skipping in-use IDs according to the reviewed policy.
- Preserves VarIn → VarOut roundtrip behaviour.

Files changed:
- src/ProgesiGrasshopperAssembly/Components/ProgesiVariableInComponent.cs
- src/ProgesiGrasshopperAssembly/Infrastructure/MetadataRepositoryCompatExtensions.cs

This PR does not modify:
- AxisVar files
- ProgesiVariableCluster
- DataExchange
- EF / SQLite tooling
- ProgesiDomainServices
- solution files
- project files
- scripts
- deployment files
- artefacts
- unrelated Grasshopper components

Validation already performed:
- dotnet build -c Release passed.
- dotnet test -c Release passed: 64 total, 64 passed, 0 failed.
- Candidate was deployed to Grasshopper Libraries.
- Manual Grasshopper validation by Gianluca confirmed:
  - tree input no longer overwrites existing variables
  - invalid specified dependency IDs now produce red blocking error
  - invalid specified metadata IDs/hashcodes now produce red blocking error
  - null / empty dependency and metadata inputs remain valid
  - GH-VAR-002 VarIn → VarOut roundtrip still works

Important notes:
- The earlier implementation-route deviation was recorded in Notion.
- Cursor later reviewed and revised the candidate.
- No automated tests were added because the behaviour is Rhino/Grasshopper-bound.
- Manual Grasshopper validation evidence is recorded in Notion.
- GH-VAR-001 should not be marked Passed until the merged version is recorded in the Manual Test Matrix.

Review notes:
- This PR should be reviewed before merge.
- Do not merge into main.
- Do not delete the branch after merge unless separately approved.
- Do not broaden this PR into source cleanup.