### PR TITLE
docs: add implementation prompt guard and curator handoff rules

### DIFF
--- a/.claude/agents/cursor-task-brief-writer.md
+++ b/.claude/agents/cursor-task-brief-writer.md
@@ -44,3 +44,19 @@ Prepare precise prompts and implementation briefs for Cursor, using `docs/task-b
 
 ## Current status
 Planned, not created. Maximum maturity: Level 1 (prepares briefs only; does not approve or implement).
+
+## Implementation prompt guard
+If this prompt is running in Claude Code / 00. Controlled Writes, stop immediately. Implementation may run only in 05. Cursor Bridge after Cursor Allowed = true.
+
+- 00. Controlled Writes must never execute implementation prompts.
+- 05. Cursor Bridge must be a plain terminal by default.
+- Cursor Agent implementation requires Cursor Allowed = true, an approved task brief, a branch, allowed files, forbidden files, tests, a rollback plan, and human approval.
+
+## Agent completion rule
+This agent must end with exactly one of:
+1. No Notion update required — explain why.
+2. Notion Curator packet prepared — route to 00. Controlled Writes.
+3. Human input required — specify the exact Human Input row/question.
+4. Unsafe to proceed — explain the stop condition.
+
+It must not silently finish after changing repository, GitHub, build/test/deploy, or validation state.

--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -40,3 +40,12 @@ Prepare documentation and repository rules files when explicitly approved.
 
 ## Current status
 Planned, not created. Maximum maturity: Level 3 (Documentation/rules).
+
+## Agent completion rule
+This agent must end with exactly one of:
+1. No Notion update required — explain why.
+2. Notion Curator packet prepared — route to 00. Controlled Writes.
+3. Human input required — specify the exact Human Input row/question.
+4. Unsafe to proceed — explain the stop condition.
+
+It must not silently finish after changing repository, GitHub, build/test/deploy, or validation state.

--- a/.claude/agents/git-governance-agent.md
+++ b/.claude/agents/git-governance-agent.md
@@ -40,3 +40,12 @@ Inspect Git state and propose branch strategy — read-only.
 
 ## Current status
 Planned, not created. Maximum maturity: Level 1 (Read-only).
+
+## Agent completion rule
+This agent must end with exactly one of:
+1. No Notion update required — explain why.
+2. Notion Curator packet prepared — route to 00. Controlled Writes.
+3. Human input required — specify the exact Human Input row/question.
+4. Unsafe to proceed — explain the stop condition.
+
+It must not silently finish after changing repository, GitHub, build/test/deploy, or validation state.

--- a/.claude/agents/grasshopper-manual-test-designer.md
+++ b/.claude/agents/grasshopper-manual-test-designer.md
@@ -41,3 +41,12 @@ Define manual Rhino/Grasshopper validation procedures and propose Grasshopper Ma
 
 ## Current status
 Planned, not created. Maximum maturity: Level 1 (Read-only).
+
+## Agent completion rule
+This agent must end with exactly one of:
+1. No Notion update required — explain why.
+2. Notion Curator packet prepared — route to 00. Controlled Writes.
+3. Human input required — specify the exact Human Input row/question.
+4. Unsafe to proceed — explain the stop condition.
+
+It must not silently finish after changing repository, GitHub, build/test/deploy, or validation state.

--- a/.claude/agents/implementation-agent-disabled.md
+++ b/.claude/agents/implementation-agent-disabled.md
@@ -37,3 +37,8 @@ Placeholder for a future limited implementation agent. **Currently disabled.**
 
 ## Current status
 **Disabled.** Maximum maturity: none until Level 4 is explicitly enabled by human approval (not planned in the current phase).
+
+## Implementation prompt guard (still disabled)
+- This agent remains disabled.
+- It must not be activated by this documentation change (`docs/implementation-prompt-guard`).
+- Implementation authority belongs only to explicitly approved Cursor Bridge tasks (Cursor Allowed = true, approved brief, branch, allowed/forbidden files, tests, rollback plan, human approval) or to a separately approved future implementation agent. This documentation change creates no implementation authority.

--- a/.claude/agents/notion-project-curator.md
+++ b/.claude/agents/notion-project-curator.md
@@ -41,3 +41,18 @@ Maintain explicitly approved Notion pages and database rows, producing clear bef
 
 ## Current status
 Planned, not created. Maximum maturity: Level 2 (Notion-only).
+
+## Agent completion rule
+This agent must end with exactly one of:
+1. No Notion update required — explain why.
+2. Notion Curator packet prepared — route to 00. Controlled Writes.
+3. Human input required — specify the exact Human Input row/question.
+4. Unsafe to proceed — explain the stop condition.
+
+It must not silently finish after changing Notion state without recording what changed.
+
+## Notion Curator notification packet
+At the end of a task that changes state, produce a compact packet containing: task name; agent / tab used; date; what changed; repository branch / commit (if applicable); files changed (if applicable); PR number (if applicable); build/test result (if applicable); manual validation result (if applicable); human decision needed (if any); Notion pages that may need update; Task Board rows that may need update; evidence pages to create/update; rows that should remain open; rows that may be Done; follow-up tasks; stop / escalation notes.
+
+## Prompt and run archival policy (summary)
+Classify each controlled run output as one of: ephemeral prompt, controlled run report, reusable prompt/template, evidence record, test run record, human decision, ADR material, GitHub/PR record, manual validation evidence, strategic planning note, or archive candidate. Temporary prompts must not remain active source-of-truth content. Full policy: Notion page "Prompt and Run Archival Policy — Notion Curator Notification Loop".

--- a/.claude/agents/progesi-architecture-reviewer.md
+++ b/.claude/agents/progesi-architecture-reviewer.md
@@ -43,3 +43,12 @@ Review architecture consistency, dependency boundaries, and ADR implications; pr
 
 ## Current status
 Planned, not created. Maximum maturity: Level 1 (Read-only).
+
+## Agent completion rule
+This agent must end with exactly one of:
+1. No Notion update required — explain why.
+2. Notion Curator packet prepared — route to 00. Controlled Writes.
+3. Human input required — specify the exact Human Input row/question.
+4. Unsafe to proceed — explain the stop condition.
+
+It must not silently finish after changing repository, GitHub, build/test/deploy, or validation state.

--- a/.claude/agents/progesi-strategy-planner.md
+++ b/.claude/agents/progesi-strategy-planner.md
@@ -43,3 +43,12 @@ Propose roadmap, milestones, task decomposition, and architecture sequencing.
 
 ## Current status
 Planned, not created. Maximum maturity: Level 1 (planning only; no execution).
+
+## Agent completion rule
+This agent must end with exactly one of:
+1. No Notion update required — explain why.
+2. Notion Curator packet prepared — route to 00. Controlled Writes.
+3. Human input required — specify the exact Human Input row/question.
+4. Unsafe to proceed — explain the stop condition.
+
+It must not silently finish after changing repository, GitHub, build/test/deploy, or validation state.

--- a/.claude/agents/progesi-workstream-orchestrator.md
+++ b/.claude/agents/progesi-workstream-orchestrator.md
@@ -118,3 +118,30 @@ Stop if:
 - Cursor implementation is requested without task brief and human approval
 - GitHub deletion is requested
 - ADR acceptance is requested without human review
+
+## Implementation prompt guard
+If this prompt is running in Claude Code / 00. Controlled Writes, stop immediately. Implementation may run only in 05. Cursor Bridge after Cursor Allowed = true.
+
+- 00. Controlled Writes must never execute implementation prompts.
+- 05. Cursor Bridge must be a plain terminal by default.
+- Cursor Agent implementation requires Cursor Allowed = true, an approved task brief, a branch, allowed files, forbidden files, tests, a rollback plan, and human approval.
+
+## Agent completion rule
+This agent must end with exactly one of:
+1. No Notion update required — explain why.
+2. Notion Curator packet prepared — route to 00. Controlled Writes.
+3. Human input required — specify the exact Human Input row/question.
+4. Unsafe to proceed — explain the stop condition.
+
+It must not silently finish after changing repository, GitHub, build/test/deploy, or validation state.
+
+## Notion Curator notification packet
+At the end of a task that changes state, produce a compact packet containing: task name; agent / tab used; date; what changed; repository branch / commit (if applicable); files changed (if applicable); PR number (if applicable); build/test result (if applicable); manual validation result (if applicable); human decision needed (if any); Notion pages that may need update; Task Board rows that may need update; evidence pages to create/update; rows that should remain open; rows that may be Done; follow-up tasks; stop / escalation notes.
+
+## Orchestrator routing rule
+The Orchestrator must not simply ask the human to copy/paste long reports. It should:
+- identify the next responsible agent
+- prepare the smallest controlled prompt
+- include the current Notion links / task IDs
+- include the expected Notion Curator packet
+- stop only when human approval, manual observation, or an architectural decision is required

--- a/.claude/agents/regression-guard.md
+++ b/.claude/agents/regression-guard.md
@@ -40,3 +40,12 @@ Run and interpret build/test checks when explicitly instructed, and compare agai
 
 ## Current status
 Planned, not created. Maximum maturity: Level 1 (reporting only; execution requires explicit instruction).
+
+## Agent completion rule
+This agent must end with exactly one of:
+1. No Notion update required — explain why.
+2. Notion Curator packet prepared — route to 00. Controlled Writes.
+3. Human input required — specify the exact Human Input row/question.
+4. Unsafe to proceed — explain the stop condition.
+
+It must not silently finish after changing repository, GitHub, build/test/deploy, or validation state.

--- a/.cursor/rules/progesi-architecture.mdc
+++ b/.cursor/rules/progesi-architecture.mdc
@@ -84,3 +84,16 @@ After any approved work, Cursor must report:
 
 ## Manual Grasshopper validation
 For GH-facing changes, Cursor must check whether the Grasshopper Manual Test Matrix already has relevant rows, or whether a new manual validation task is required, before the change can be considered complete.
+
+## Implementation prompt guard
+If this prompt is running in Claude Code / 00. Controlled Writes, stop immediately. Implementation may run only in 05. Cursor Bridge after Cursor Allowed = true.
+
+- 00. Controlled Writes must never execute implementation prompts.
+- 05. Cursor Bridge must be a plain terminal by default.
+- Cursor Agent implementation requires Cursor Allowed = true, an approved task brief, a branch, allowed files, forbidden files, tests, a rollback plan, and human approval.
+
+## Notion Curator reporting (Cursor)
+- Cursor must include a Notion Curator packet in its final report.
+- Cursor must not update Notion directly unless separately authorised.
+- Cursor must not mark tasks Done.
+- Cursor implementation reports must be routed back to 00. Controlled Writes for Notion recording.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,50 @@ Detailed definitions live in `.claude/agents/*.md`.
 - No agent may move frozen tasks out of `Blocked / Frozen`.
 - No agent may perform GitHub cleanup, code cleanup, or AxisVar work.
 - No agent may run Rhino or Grasshopper.
+
+## Implementation prompt guard
+If this prompt is running in Claude Code / 00. Controlled Writes, stop immediately. Implementation may run only in 05. Cursor Bridge after Cursor Allowed = true.
+
+- 00. Controlled Writes must never execute implementation prompts.
+- 05. Cursor Bridge must be a plain terminal by default.
+- Cursor Agent implementation requires Cursor Allowed = true, an approved task brief, a branch, allowed files, forbidden files, tests, a rollback plan, and human approval.
+
+## Agent completion rule
+Every specialist agent must end with exactly one of:
+1. No Notion update required — explain why.
+2. Notion Curator packet prepared — route to 00. Controlled Writes.
+3. Human input required — specify the exact Human Input row/question.
+4. Unsafe to proceed — explain the stop condition.
+
+An agent must not silently finish after changing repository, GitHub, build/test/deploy, or validation state.
+
+## Notion Curator notification packet
+At the end of a task that changes state, produce a compact packet containing:
+- Task name
+- Agent / tab used
+- Date
+- What changed
+- Repository branch / commit, if applicable
+- Files changed, if applicable
+- PR number, if applicable
+- Build/test result, if applicable
+- Manual validation result, if applicable
+- Human decision needed, if any
+- Notion pages that may need update
+- Task Board rows that may need update
+- Evidence pages to create/update
+- Rows that should remain open
+- Rows that may be Done
+- Follow-up tasks
+- Stop / escalation notes
+
+## Orchestrator routing rule
+The Orchestrator must not simply ask the human to copy/paste long reports. It should:
+- identify the next responsible agent
+- prepare the smallest controlled prompt
+- include the current Notion links / task IDs
+- include the expected Notion Curator packet
+- stop only when human approval, manual observation, or an architectural decision is required
+
+## Prompt and run archival policy (summary)
+Classify each controlled run output as one of: ephemeral prompt, controlled run report, reusable prompt/template, evidence record, test run record, human decision, ADR material, GitHub/PR record, manual validation evidence, strategic planning note, or archive candidate. Temporary prompts must not remain active source-of-truth content. Full policy: Notion page "Prompt and Run Archival Policy — Notion Curator Notification Loop".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,3 +78,10 @@ After any action, report:
 - commands run
 - test results (if any)
 - `git status` (and branch/commit when repository interaction occurred)
+
+## 9. Implementation prompt guard
+If this prompt is running in Claude Code / 00. Controlled Writes, stop immediately. Implementation may run only in 05. Cursor Bridge after Cursor Allowed = true.
+
+- 00. Controlled Writes must never execute implementation prompts.
+- 05. Cursor Bridge must be a plain terminal by default.
+- Cursor Agent implementation requires Cursor Allowed = true, an approved task brief, a branch, allowed files, forbidden files, tests, a rollback plan, and human approval.

--- a/docs/claude-governance.md
+++ b/docs/claude-governance.md
@@ -69,3 +69,18 @@ No autonomous Claude agents are enabled. Agents are defined in `.claude/agents/*
 
 ## Escalation / stop rules
 Stop and report when: the allowed action is unclear, Notion documentation conflicts, an unexpected file would change, scope would broaden, or an action would touch frozen/quarantined areas. When in doubt, do less and ask.
+
+## Agent completion rule
+Every specialist agent must end with exactly one of:
+1. No Notion update required — explain why.
+2. Notion Curator packet prepared — route to 00. Controlled Writes.
+3. Human input required — specify the exact Human Input row/question.
+4. Unsafe to proceed — explain the stop condition.
+
+An agent must not silently finish after changing repository, GitHub, build/test/deploy, or validation state.
+
+## Notion Curator notification packet
+At the end of a task that changes state, produce a compact packet containing: task name; agent / tab used; date; what changed; repository branch / commit (if applicable); files changed (if applicable); PR number (if applicable); build/test result (if applicable); manual validation result (if applicable); human decision needed (if any); Notion pages that may need update; Task Board rows that may need update; evidence pages to create/update; rows that should remain open; rows that may be Done; follow-up tasks; stop / escalation notes.
+
+## Prompt and run archival policy (summary)
+Classify each controlled run output as one of: ephemeral prompt, controlled run report, reusable prompt/template, evidence record, test run record, human decision, ADR material, GitHub/PR record, manual validation evidence, strategic planning note, or archive candidate. Temporary prompts must not remain active source-of-truth content. Full policy: Notion page "Prompt and Run Archival Policy — Notion Curator Notification Loop".

--- a/docs/cursor-interface-protocol.md
+++ b/docs/cursor-interface-protocol.md
@@ -50,3 +50,16 @@ If any prerequisite is missing, implementation does not proceed.
 
 ## Claude's review responsibility
 After Cursor implements, Claude reviews the diff and test results against the brief and the architecture rules before any merge or Notion update. Anything outside the approved scope is rejected and reported.
+
+## Implementation prompt guard
+If this prompt is running in Claude Code / 00. Controlled Writes, stop immediately. Implementation may run only in 05. Cursor Bridge after Cursor Allowed = true.
+
+- 00. Controlled Writes must never execute implementation prompts.
+- 05. Cursor Bridge must be a plain terminal by default.
+- Cursor Agent implementation requires Cursor Allowed = true, an approved task brief, a branch, allowed files, forbidden files, tests, a rollback plan, and human approval.
+
+## Notion Curator reporting (Cursor)
+- Cursor must include a Notion Curator packet in its final report.
+- Cursor must not update Notion directly unless separately authorised.
+- Cursor must not mark tasks Done.
+- Cursor implementation reports must be routed back to 00. Controlled Writes for Notion recording.

--- a/docs/task-brief-template.md
+++ b/docs/task-brief-template.md
@@ -87,3 +87,10 @@ After the task, report:
 - [ ] Final `git status`
 - [ ] Deviations from the allowed scope (if any)
 - [ ] Any blocked or unclear instruction
+
+## Controlled-run governance
+- [ ] Implementation prompt guard acknowledged: "If this prompt is running in Claude Code / 00. Controlled Writes, stop immediately. Implementation may run only in 05. Cursor Bridge after Cursor Allowed = true."
+- [ ] Notion Curator packet required after completion (route to 00. Controlled Writes)
+- Prompt/run artefact classification: <ephemeral prompt | controlled run report | reusable prompt/template | evidence record | test run record | human decision | ADR material | GitHub/PR record | manual validation evidence | strategic planning note | archive candidate>
+- Tab where this task must run: <00. Controlled Writes | 05. Cursor Bridge | 07. Build Test Deploy | 08. Grasshopper Validation | planning tab>
+- May this task be run by: <Claude | Cursor | neither> (Cursor only with Cursor Allowed = true and an approved brief)

--- a/docs/workstream-terminal-layout.md
+++ b/docs/workstream-terminal-layout.md
@@ -105,3 +105,33 @@ claiming pass/fail without human Rhino/Grasshopper evidence.
 - Repository writes must be serialized.
 - Cursor implementation must be one approved task at a time.
 - Human input gates override agent momentum.
+
+## Implementation prompt guard
+If this prompt is running in Claude Code / 00. Controlled Writes, stop immediately. Implementation may run only in 05. Cursor Bridge after Cursor Allowed = true.
+
+- 00. Controlled Writes must never execute implementation prompts.
+- 05. Cursor Bridge must be a plain terminal by default.
+- Cursor Agent implementation requires Cursor Allowed = true, an approved task brief, a branch, allowed files, forbidden files, tests, a rollback plan, and human approval.
+
+## Agent completion rule
+Every specialist agent must end with exactly one of:
+1. No Notion update required — explain why.
+2. Notion Curator packet prepared — route to 00. Controlled Writes.
+3. Human input required — specify the exact Human Input row/question.
+4. Unsafe to proceed — explain the stop condition.
+
+An agent must not silently finish after changing repository, GitHub, build/test/deploy, or validation state.
+
+## Notion Curator notification packet
+At the end of a task that changes state, produce a compact packet containing: task name; agent / tab used; date; what changed; repository branch / commit (if applicable); files changed (if applicable); PR number (if applicable); build/test result (if applicable); manual validation result (if applicable); human decision needed (if any); Notion pages that may need update; Task Board rows that may need update; evidence pages to create/update; rows that should remain open; rows that may be Done; follow-up tasks; stop / escalation notes.
+
+## Orchestrator routing rule
+The Orchestrator must not simply ask the human to copy/paste long reports. It should:
+- identify the next responsible agent
+- prepare the smallest controlled prompt
+- include the current Notion links / task IDs
+- include the expected Notion Curator packet
+- stop only when human approval, manual observation, or an architectural decision is required
+
+## Prompt and run archival policy (summary)
+Classify each controlled run output as one of: ephemeral prompt, controlled run report, reusable prompt/template, evidence record, test run record, human decision, ADR material, GitHub/PR record, manual validation evidence, strategic planning note, or archive candidate. Temporary prompts must not remain active source-of-truth content. Full policy: Notion page "Prompt and Run Archival Policy — Notion Curator Notification Loop".


### PR DESCRIPTION
This PR adds governance hardening after the Warp / Claude / Cursor reliability work and the VariableIn route-deviation recovery.

Scope:
- Adds the implementation prompt guard to repository governance documentation.
- Adds the agent completion rule.
- Adds the Notion Curator notification packet.
- Adds the Orchestrator routing rule.
- Adds prompt/run archival policy summary.
- Adds task-brief fields for:
  - implementation prompt guard acknowledgement
  - Notion Curator packet requirement
  - prompt/run artefact classification
  - required tab
  - whether task may run by Claude, Cursor, or neither
- Strengthens Cursor-facing final reporting and handoff expectations.

Changed files:
- CLAUDE.md
- AGENTS.md
- docs/claude-governance.md
- docs/cursor-interface-protocol.md
- docs/workstream-terminal-layout.md
- docs/task-brief-template.md
- .cursor/rules/progesi-architecture.mdc
- .claude/agents/*.md

This PR does not modify:
- source code
- tests
- solution files
- project files
- scripts
- deployment files
- package files
- artefacts
- AxisVar files
- ProgesiVariableCluster
- DataExchange
- EF / SQLite tooling
- ProgesiDomainServices

Validation already performed:
- dotnet build -c Release passed.
- dotnet test -c Release passed: 64 total, 64 passed, 0 failed.
- The branch was pushed as origin/docs/implementation-prompt-guard at commit 9b100ac.

Important rules added:
- Implementation prompts must not run in 00. Controlled Writes / Claude Code.
- Implementation may run only in 05. Cursor Bridge after Cursor Allowed = true.
- Every specialist agent must end with:
  1. No Notion update required — explain why.
  2. Notion Curator packet prepared — route to 00. Controlled Writes.
  3. Human input required — specify exact Human Input row/question.
  4. Unsafe to proceed — explain stop condition.

Review notes:
- This is a documentation/governance-only PR.
- Do not merge into main.
- Do not delete the branch after merge unless separately approved.
- This PR does not enable autonomous agents or source-code implementation.