### PR TITLE
feat: restore ProgesiVariableCluster phase 1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,3 +101,17 @@ The Orchestrator must not simply ask the human to copy/paste long reports. It sh
 
 ## Prompt and run archival policy (summary)
 Classify each controlled run output as one of: ephemeral prompt, controlled run report, reusable prompt/template, evidence record, test run record, human decision, ADR material, GitHub/PR record, manual validation evidence, strategic planning note, or archive candidate. Temporary prompts must not remain active source-of-truth content. Full policy: Notion page "Prompt and Run Archival Policy — Notion Curator Notification Loop".
+
+## ProgesiVariableCluster Phase 1 exception
+
+The general ProgesiVariableCluster recovery freeze remains in force except for the approved Phase 1 file-scoped recovery on branch feat/cluster-recovery-portscope.
+
+Agents may route Phase 1 only if:
+- Cursor Allowed = true
+- the Phase 1 Task Board row is Ready for Cursor
+- the persisted Cursor Task Brief v1.0 is used
+- execution is in 05. Cursor Bridge
+- AxisVar files remain forbidden
+- Phase 2/3 remain blocked
+
+The Orchestrator may prepare/reroute Phase 1 prompts but must not execute implementation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,3 +85,24 @@ If this prompt is running in Claude Code / 00. Controlled Writes, stop immediate
 - 00. Controlled Writes must never execute implementation prompts.
 - 05. Cursor Bridge must be a plain terminal by default.
 - Cursor Agent implementation requires Cursor Allowed = true, an approved task brief, a branch, allowed files, forbidden files, tests, a rollback plan, and human approval.
+
+## ProgesiVariableCluster Phase 1 recovery exception
+
+ProgesiVariableCluster remains a missing capability / suspected regression and must not be treated as generally implemented.
+
+Exception:
+A human-approved, file-scoped Phase 1 recovery is authorised only on branch feat/cluster-recovery-portscope, only under the persisted "Cursor Task Brief v1.0 — ProgesiVariableCluster Recovery Phase 1 (file-scoped port)", and only after Cursor Allowed = true and the approved Task Board row is Ready for Cursor.
+
+This exception does not authorise:
+- AxisVar work
+- wholesale branch merge
+- Phase 2 SQLite recovery
+- Phase 3 EF/DataExchange recovery
+- source cleanup
+- ADR acceptance
+- branch/tag cleanup
+- treating Cluster as fully implemented before build/test/manual validation and human review
+
+AxisVar remains frozen.
+
+Phase 2 and Phase 3 remain blocked until separately approved.

--- a/src/ProgesiCore/ClusterImportParser.cs
+++ b/src/ProgesiCore/ClusterImportParser.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace ProgesiCore
+{
+  /// <summary>
+  /// Parser puro (no Rhino/Excel/GH) per import Cluster da testo.
+  /// Serve per hardening e test.
+  /// </summary>
+  public static class ClusterImportParser
+  {
+    /// <summary>
+    /// Converte una stringa "VariableIds" (potenzialmente sporca) in lista di Id interi.
+    /// Supporta separatori: , ; | ! spazio
+    /// Gestisce NBSP
+    /// Tratta '.' come separatore (perché in una lista di Id non vogliamo decimali).
+    /// </summary>
+    public static int[] ParseVariableIds(string raw)
+    {
+      if (string.IsNullOrWhiteSpace(raw))
+        return Array.Empty<int>();
+
+      // NBSP -> space
+      raw = raw.Replace('\u00A0', ' ').Trim();
+
+      // In una lista di Id, il punto non ha senso come decimale: lo trattiamo come separatore.
+      raw = raw.Replace('.', ',');
+
+      var parts = raw.Split(new[] { ',', ';', '|', ' ', '!' }, StringSplitOptions.RemoveEmptyEntries);
+
+      var ids = new List<int>();
+      foreach (var p in parts)
+      {
+        var t = p.Trim();
+        if (t.Length == 0) continue;
+
+        if (int.TryParse(t, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id) && id > 0)
+          ids.Add(id);
+      }
+
+      return ids.Distinct().OrderBy(x => x).ToArray();
+    }
+
+    /// <summary>
+    /// Helper per il parsing di una riga cluster, dato un getter "cell(key)".
+    /// keys devono essere già normalizzate (es. "ID", "NAME", "DESCRIPTION", "VARIABLEIDS", "HASH").
+    /// </summary>
+    public static bool TryParseClusterRow(
+      Func<string, string> cell,
+      out int id,
+      out string name,
+      out string desc,
+      out int[] varIds,
+      out string hash,
+      out string warn)
+    {
+      id = 0;
+      name = "";
+      desc = "";
+      varIds = Array.Empty<int>();
+      hash = "";
+      warn = "";
+
+      if (cell == null)
+      {
+        warn = "cell getter is null";
+        return false;
+      }
+
+      var rawId = (cell("ID") ?? "").Trim();
+      if (!int.TryParse(rawId, NumberStyles.Integer, CultureInfo.InvariantCulture, out id) || id <= 0)
+      {
+        warn = $"invalid Id='{rawId}'";
+        return false;
+      }
+
+      name = (cell("NAME") ?? "").Trim();
+      if (string.IsNullOrWhiteSpace(name))
+        name = $"Cluster-{id}";
+
+      desc = (cell("DESCRIPTION") ?? "").Trim();
+      hash = (cell("HASH") ?? "").Trim();
+
+      var rawVarIds = (cell("VARIABLEIDS") ?? "").Trim();
+      varIds = ParseVariableIds(rawVarIds);
+
+      if (varIds.Length == 0 && !string.IsNullOrWhiteSpace(rawVarIds))
+        warn = $"empty/invalid VariableIds raw='{rawVarIds}' (Id={id})";
+
+      return true;
+    }
+  }
+}

--- a/src/ProgesiCore/ClusterOutNaming.cs
+++ b/src/ProgesiCore/ClusterOutNaming.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace ProgesiCore
+{
+  /// <summary>
+  /// Helper “puri” per ClusterOut (naming output dinamici + signature).
+  /// Nessuna dipendenza da Rhino/Grasshopper.
+  /// </summary>
+  public static class ClusterOutNaming
+  {
+    public static string BuildSignature(int clusterId, IList<ProgesiVariable> varsInOrder)
+    {
+      var sb = new StringBuilder();
+      sb.Append(clusterId).Append("|");
+
+      // IMPORTANT: varsInOrder deve essere già nell'ordine del cluster
+      for (int i = 0; i < varsInOrder.Count; i++)
+      {
+        var v = varsInOrder[i];
+        sb.Append(v.Id).Append(":");
+        sb.Append(string.IsNullOrWhiteSpace(v.Name) ? "" : v.Name);
+        sb.Append(";");
+      }
+
+      return sb.ToString();
+    }
+
+    public static string SanitizeNick(string s)
+    {
+      if (string.IsNullOrWhiteSpace(s)) return "";
+
+      var x = s.Trim();
+
+      // spazi -> underscore
+      x = Regex.Replace(x, @"\s+", "_");
+
+      // caratteri non ammessi -> underscore
+      x = Regex.Replace(x, @"[^A-Za-z0-9_\-]", "_");
+
+      // evita nickname troppo lunghi
+      if (x.Length > 40) x = x.Substring(0, 40);
+
+      return x;
+    }
+
+    public static string MakeUnique(string nick, ISet<string> used)
+    {
+      if (used == null) throw new ArgumentNullException(nameof(used));
+      if (string.IsNullOrWhiteSpace(nick)) nick = "Var";
+
+      if (!used.Contains(nick))
+      {
+        used.Add(nick);
+        return nick;
+      }
+
+      for (int i = 2; i < 999; i++)
+      {
+        var cand = $"{nick}_{i}";
+        if (!used.Contains(cand))
+        {
+          used.Add(cand);
+          return cand;
+        }
+      }
+
+      var fb = $"Var_{Guid.NewGuid():N}".Substring(0, 40);
+      used.Add(fb);
+      return fb;
+    }
+  }
+}

--- a/src/ProgesiCore/IProgesiVariableClusterRepository.cs
+++ b/src/ProgesiCore/IProgesiVariableClusterRepository.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+namespace ProgesiCore
+{
+  /// <summary>
+  /// Repository astratto per la persistenza di ProgesiVariableCluster.
+  /// Implementazioni: Rhino, SQLite, Excel, EF, ecc.
+  /// </summary>
+  public interface IProgesiVariableClusterRepository
+  {
+    /// <summary>
+    /// Inserisce o aggiorna un cluster.
+    /// Ritorna il cluster con Id assegnato/aggiornato e Hashtag coerente.
+    /// </summary>
+    Task<ProgesiVariableCluster> SaveAsync(
+      ProgesiVariableCluster cluster,
+      CancellationToken ct = default);
+
+    /// <summary>
+    /// Restituisce il cluster con Id specificato, oppure null se non esiste.
+    /// </summary>
+    Task<ProgesiVariableCluster?> GetByIdAsync(
+      int id,
+      CancellationToken ct = default);
+
+    /// <summary>
+    /// Restituisce il cluster con l'hashtag specificato, oppure null se non esiste.
+    /// </summary>
+    Task<ProgesiVariableCluster?> GetByHashtagAsync(
+      string hashtag,
+      CancellationToken ct = default);
+
+    /// <summary>
+    /// Restituisce tutti i cluster presenti nel repository.
+    /// </summary>
+    Task<IReadOnlyList<ProgesiVariableCluster>> GetAllAsync(
+      CancellationToken ct = default);
+
+    /// <summary>
+    /// Elimina il cluster con Id specificato.
+    /// </summary>
+    Task<bool> DeleteAsync(
+      int id,
+      CancellationToken ct = default);
+
+    /// <summary>
+    /// Elimina in blocco i cluster con gli Id specificati.
+    /// Ritorna il numero di record effettivamente eliminati.
+    /// </summary>
+    Task<int> DeleteManyAsync(
+      IEnumerable<int> ids,
+      CancellationToken ct = default);
+  }
+}

--- a/src/ProgesiCore/ProgesiHash.cs
+++ b/src/ProgesiCore/ProgesiHash.cs
@@ -80,6 +80,26 @@ namespace ProgesiCore
       return Sha256Hex(json);
     }
 
+    // ===== Compute per VariableCluster =====
+    public static string Compute(ProgesiVariableCluster c)
+    {
+      if (c == null) throw new ArgumentNullException(nameof(c));
+
+      int[] ids = (c.ProgesiVariableIds ?? Array.Empty<int>())
+        .OrderBy(x => x)
+        .ToArray();
+
+      var payload = new
+      {
+        c.Name,
+        VariableIds = ids,
+        c.Description
+      };
+
+      string json = JsonConvert.SerializeObject(payload, JsonSettings) ?? string.Empty;
+      return Sha256Hex(json);
+    }
+
     // ===== Compute per Metadata =====
     public static string Compute(ProgesiMetadata m)
     {

--- a/src/ProgesiCore/ProgesiVariableCluster.cs
+++ b/src/ProgesiCore/ProgesiVariableCluster.cs
@@ -1,0 +1,175 @@
+﻿using ProgesiCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ProgesiCore
+{
+  // Adatta il namespace / base class ai tuoi progetti
+  public sealed class ProgesiVariableCluster : ValueObject
+  {
+    // Necessario per i repository (Rhino/SQLite/EF)
+    public int Id { get; private set; }
+
+    public string Name { get; private set; }
+
+    /// <summary>
+    /// Id delle ProgesiVariable raggruppate dal cluster.
+    /// Sempre ordinati e senza duplicati.
+    /// </summary>
+    public IReadOnlyList<int> ProgesiVariableIds => _progesiVariableIds;
+
+    private readonly List<int> _progesiVariableIds = new List<int>();
+
+    /// <summary>
+    /// Descrizione opzionale del cluster.
+    /// </summary>
+    public string Description { get; private set; }
+
+    /// <summary>
+    /// Hashtag deterministico del cluster.
+    /// Basato su: Id + Name + lista ordinata degli Id delle ProgesiVariable.
+    /// </summary>
+    public string Hashtag { get; private set; }
+
+    // Costruttore privato per EF / serializer
+    private ProgesiVariableCluster()
+    {
+      Name = string.Empty;
+      Description = string.Empty;
+      Hashtag = string.Empty;
+    }
+
+    private ProgesiVariableCluster(
+        int id,
+        string name,
+        IEnumerable<int> progesiVariableIds,
+        string? description)
+    {
+      if (string.IsNullOrWhiteSpace(name))
+        throw new ArgumentException("Cluster name cannot be null or empty.", nameof(name));
+
+      var ids = (progesiVariableIds ?? Enumerable.Empty<int>())
+          .Where(v => v > 0)
+          .Distinct()
+          .OrderBy(v => v)
+          .ToList();
+
+      if (!ids.Any())
+        throw new ArgumentException("Cluster must contain at least one ProgesiVariable id.", nameof(progesiVariableIds));
+
+      if (id < 0)
+        throw new ArgumentOutOfRangeException(nameof(id), "Id cannot be negative.");
+
+      Id = id;
+      Name = name.Trim();
+      Description = description?.Trim() ?? string.Empty;
+
+      _progesiVariableIds.Clear();
+      _progesiVariableIds.AddRange(ids);
+
+      Hashtag = BuildHashtag(Id, Name, _progesiVariableIds);
+    }
+
+    /// <summary>
+    /// Factory principale per creare un nuovo cluster lato dominio.
+    /// Id tipicamente 0 prima del salvataggio su repository.
+    /// </summary>
+    public static ProgesiVariableCluster CreateNew(
+        string name,
+        IEnumerable<int> progesiVariableIds,
+        string? description = null)
+    {
+      // Id = 0 (non ancora persistito)
+      return new ProgesiVariableCluster(0, name, progesiVariableIds, description);
+    }
+
+    /// <summary>
+    /// Factory pensata per la ricostruzione da repository
+    /// quando l'Id è già noto (ad esempio da DB).
+    /// </summary>
+    public static ProgesiVariableCluster Rehydrate(
+        int id,
+        string name,
+        IEnumerable<int> progesiVariableIds,
+        string? description,
+        string? hashtagFromStore = null)
+    {
+      var cluster = new ProgesiVariableCluster(id, name, progesiVariableIds, description);
+
+      // Se lo storage ha già un hashtag, possiamo fidarci,
+      // altrimenti lo ricalcoliamo.
+      if (!string.IsNullOrWhiteSpace(hashtagFromStore))
+      {
+        cluster.Hashtag = hashtagFromStore!.Trim();
+      }
+
+      return cluster;
+    }
+
+    /// <summary>
+    /// Versione con Id assegnato, ad esempio dopo un inserimento su DB.
+    /// Ritorna una nuova istanza con Id aggiornato e Hashtag ricalcolato.
+    /// </summary>
+    public ProgesiVariableCluster WithId(int newId)
+    {
+      if (newId <= 0)
+        throw new ArgumentOutOfRangeException(nameof(newId), "Cluster id must be positive.");
+
+      return new ProgesiVariableCluster(
+          newId,
+          Name,
+          _progesiVariableIds,
+          Description);
+    }
+
+    /// <summary>
+    /// Determina se due cluster sono logicamente equivalenti,
+    /// indipendentemente dall'Id assegnato dal repository.
+    /// </summary>
+    public bool IsEquivalentTo(ProgesiVariableCluster? other)
+    {
+      if (other is null) return false;
+
+      return string.Equals(Name, other.Name, StringComparison.Ordinal) &&
+             string.Equals(Description, other.Description, StringComparison.Ordinal) &&
+             _progesiVariableIds.SequenceEqual(other._progesiVariableIds);
+    }
+
+    /// <summary>
+    /// Ricalcola l'hashtag del cluster in base allo stato corrente.
+    /// Utile se per qualche motivo hai dovuto cambiare Id o lista di variabili.
+    /// </summary>
+    public ProgesiVariableCluster RecalculateHashtag()
+    {
+      Hashtag = BuildHashtag(Id, Name, _progesiVariableIds);
+      return this;
+    }
+
+    private static string BuildHashtag(int id, string name, IEnumerable<int> orderedIds)
+    {
+      var idsPart = string.Join(",", orderedIds);
+      var seed = $"{id}|{name.Trim()}|{idsPart}";
+
+      // QUI puoi sostituire con la stessa logica usata per Variable/Metadata
+      // ad es. passando seed a un servizio SHA-256 comune.
+      return seed;
+    }
+
+    protected override IEnumerable<object> GetEqualityComponents()
+    {
+      // L'uguaglianza del ValueObject ignora l'Id,
+      // ma considera tutte le altre proprietà significative.
+      yield return Name;
+      yield return Description;
+
+      foreach (var id in _progesiVariableIds)
+        yield return id;
+    }
+
+    public override string ToString()
+    {
+      return $"Cluster(Id={Id}, Name={Name}, Count={_progesiVariableIds.Count})";
+    }
+  }
+}

--- a/src/ProgesiCore/Services/ClusterService.cs
+++ b/src/ProgesiCore/Services/ClusterService.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+namespace ProgesiCore.Services
+{
+  /// <summary>
+  /// Implementazione base di IClusterService.
+  /// Usa solo l'interfaccia IProgesiVariableClusterRepository,
+  /// quindi funziona con InMemory, SQLite, Rhino, EF, ecc.
+  /// </summary>
+  public sealed class ClusterService : IClusterService
+  {
+    private readonly IProgesiVariableClusterRepository _clusterRepository;
+
+    public ClusterService(IProgesiVariableClusterRepository clusterRepository)
+    {
+      _clusterRepository = clusterRepository ?? throw new ArgumentNullException(nameof(clusterRepository));
+    }
+
+    public async Task<ProgesiVariableCluster> CreateOrGetClusterAsync(
+      string name,
+      IEnumerable<int> progesiVariableIds,
+      string? description = null,
+      CancellationToken ct = default)
+    {
+      if (string.IsNullOrWhiteSpace(name))
+        throw new ArgumentException("Cluster name is required.", nameof(name));
+
+      if (progesiVariableIds is null)
+        throw new ArgumentNullException(nameof(progesiVariableIds));
+
+      // normalizza Id: >0, distinct, ordinati
+      var ids = progesiVariableIds
+        .Where(id => id > 0)
+        .Distinct()
+        .OrderBy(id => id)
+        .ToList();
+
+      if (ids.Count == 0)
+        throw new ArgumentException("Cluster must contain at least one variable id.", nameof(progesiVariableIds));
+
+      // Candidate "logico" (Id=0) solo per confronto con i cluster esistenti
+      var candidate = ProgesiVariableCluster.CreateNew(name, ids, description);
+
+      // Recupera tutti i cluster esistenti dallo store
+      var existing = await _clusterRepository.GetAllAsync(ct).ConfigureAwait(false);
+
+      // Dedup logico: stesso Name, Description e lista di Id (ordinata) → cluster equivalente
+      var match = existing.FirstOrDefault(c => c.IsEquivalentTo(candidate));
+      if (match != null)
+      {
+        return match;
+      }
+
+      // Nuovo Id = max(Id) + 1 (o 1 se non ci sono cluster)
+      var nextId = existing.Count == 0 ? 1 : existing.Max(c => c.Id) + 1;
+
+      // Creiamo il cluster reale con Id assegnato;
+      // Rehydrate calcola anche l'Hashtag coerente.
+      var newCluster = ProgesiVariableCluster.Rehydrate(nextId, name, ids, description, null);
+
+      // Salviamo sul repository (che può avere ulteriore dedup via ContentHash, come in SQLite)
+      var saved = await _clusterRepository.SaveAsync(newCluster, ct).ConfigureAwait(false);
+      return saved;
+    }
+
+    public Task<ProgesiVariableCluster?> GetByIdAsync(
+      int id,
+      CancellationToken ct = default)
+      => _clusterRepository.GetByIdAsync(id, ct);
+
+    public Task<ProgesiVariableCluster?> GetByHashtagAsync(
+      string hashtag,
+      CancellationToken ct = default)
+      => _clusterRepository.GetByHashtagAsync(hashtag, ct);
+
+    public Task<IReadOnlyList<ProgesiVariableCluster>> GetAllAsync(
+      CancellationToken ct = default)
+      => _clusterRepository.GetAllAsync(ct);
+
+    public Task<bool> DeleteAsync(
+      int id,
+      CancellationToken ct = default)
+      => _clusterRepository.DeleteAsync(id, ct);
+
+    public Task<int> DeleteManyAsync(
+      IEnumerable<int> ids,
+      CancellationToken ct = default)
+      => _clusterRepository.DeleteManyAsync(ids, ct);
+  }
+}

--- a/src/ProgesiCore/Services/IClusterService.cs
+++ b/src/ProgesiCore/Services/IClusterService.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+namespace ProgesiCore.Services
+{
+  /// <summary>
+  /// Servizio applicativo per lavorare con i ProgesiVariableCluster
+  /// sopra a qualunque implementazione di IProgesiVariableClusterRepository
+  /// (InMemory, SQLite, Rhino, EF, ...).
+  /// </summary>
+  public interface IClusterService
+  {
+    /// <summary>
+    /// Crea un nuovo cluster oppure restituisce quello esistente
+    /// logicamente equivalente (stesso Name, Description e stesso set di Id).
+    /// </summary>
+    Task<ProgesiVariableCluster> CreateOrGetClusterAsync(
+      string name,
+      IEnumerable<int> progesiVariableIds,
+      string? description = null,
+      CancellationToken ct = default);
+
+    Task<ProgesiVariableCluster?> GetByIdAsync(
+      int id,
+      CancellationToken ct = default);
+
+    Task<ProgesiVariableCluster?> GetByHashtagAsync(
+      string hashtag,
+      CancellationToken ct = default);
+
+    Task<IReadOnlyList<ProgesiVariableCluster>> GetAllAsync(
+      CancellationToken ct = default);
+
+    Task<bool> DeleteAsync(
+      int id,
+      CancellationToken ct = default);
+
+    Task<int> DeleteManyAsync(
+      IEnumerable<int> ids,
+      CancellationToken ct = default);
+  }
+}

--- a/src/ProgesiGrasshopperAssembly/Components/ProgesiClusterDefinitionComponent.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/ProgesiClusterDefinitionComponent.cs
@@ -1,0 +1,282 @@
+﻿// ProgesiClusterDefinitionComponent.cs
+#nullable disable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Grasshopper.GUI.Canvas;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Data;
+using Grasshopper.Kernel.Types;
+using ProgesiCore.Services;
+using ProgesiCore;
+using ProgesiGrasshopperAssembly.Infrastructure;
+using ProgesiRepositories.Rhino;
+
+namespace ProgesiGrasshopperAssembly.Components
+{
+  /// <summary>
+  /// Definisce (o recupera) un ProgesiVariableCluster a partire da:
+  /// - Id delle ProgesiVariable in input (tree/lista)
+  /// - Nome del cluster
+  /// - Descrizione opzionale
+  ///
+  /// Se l'input Ids è vuoto, usa TUTTE le ProgesiVariable presenti nel repository Rhino.
+  /// Usa ClusterService + RhinoVariableClusterRepository.
+  /// Nessuna UI custom: componente standard GH con input/output visibili.
+  /// </summary>
+  public sealed class ProgesiClusterDefinitionComponent : GH_Component
+  {
+    public ProgesiClusterDefinitionComponent()
+      : base("Progesi Cluster Definition", "ClusterDef",
+             "Crea o recupera un ProgesiVariableCluster (dedup su Name/Description/Ids).\n" +
+             "Se l'input Ids è vuoto, vengono usate tutte le ProgesiVariable presenti nel documento Rhino.",
+             "Progesi", "Variables")
+    { }
+
+    public override Guid ComponentGuid => new Guid("28C3FBBF-2276-469F-8575-E43CE3E1B216");
+
+    protected override System.Drawing.Bitmap Icon => ProgesiIcons.DataEx;
+
+    protected override void RegisterInputParams(GH_InputParamManager p)
+    {
+      p.AddBooleanParameter("Run", "Run", "Esegui (default FALSE).", GH_ParamAccess.item, false);
+
+      // Act: 0=Create, 1=Update, 2=Delete
+      p.AddIntegerParameter("Act", "Act",
+                            "Azione: 0=Create, 1=Update, 2=Delete. Default 0.",
+                            GH_ParamAccess.item, 0);
+
+      // Identificazione cluster per Update/Delete (Hash ha precedenza su Id)
+      p.AddIntegerParameter("ClusterId", "CId",
+                            "Id del cluster (opzionale; usato per Update/Delete se Hash è vuoto).",
+                            GH_ParamAccess.item, 0);
+      Params.Input[Params.Input.Count - 1].Optional = true;
+
+      p.AddTextParameter("ClusterHash", "CHash",
+                         "Hashtag del cluster (opzionale; ha precedenza su Id per Update/Delete).",
+                         GH_ParamAccess.item, string.Empty);
+      Params.Input[Params.Input.Count - 1].Optional = true;
+
+      // Id delle ProgesiVariable (lista/albero).
+      // Se vuoto, verranno usate tutte le variabili presenti nel documento Rhino.
+      p.AddIntegerParameter("VarIds", "Ids",
+                            "Id delle ProgesiVariable da includere nel cluster (lista/albero). " +
+                            "Se vuoto, vengono usate tutte le variabili presenti nel documento Rhino.",
+                            GH_ParamAccess.tree);
+      Params.Input[Params.Input.Count - 1].Optional = true;
+
+      p.AddTextParameter("Name", "Name", "Nome del cluster.", GH_ParamAccess.item, "ClusterName");
+
+      p.AddTextParameter("Description", "Desc", "Descrizione opzionale del cluster.",
+                         GH_ParamAccess.item, string.Empty);
+      Params.Input[Params.Input.Count - 1].Optional = true;
+    }
+
+    protected override void RegisterOutputParams(GH_OutputParamManager p)
+    {
+      p.AddIntegerParameter("Id", "Id", "Id del cluster.", GH_ParamAccess.item);
+      p.AddTextParameter("Hash", "Hash", "Hashtag del cluster (Id|Name|Ids).", GH_ParamAccess.item);
+      p.AddTextParameter("Info", "Info", "Esito/diagnostica.", GH_ParamAccess.item);
+    }
+    protected override void SolveInstance(IGH_DataAccess DA)
+    {
+      bool run = false;
+      DA.GetData(0, ref run);
+
+      int act = 0;
+      DA.GetData(1, ref act);
+
+      int clusterIdIn = 0;
+      DA.GetData(2, ref clusterIdIn);
+
+      string clusterHashIn = string.Empty;
+      DA.GetData(3, ref clusterHashIn);
+
+      var idsTree = new GH_Structure<GH_Integer>();
+      DA.GetDataTree(4, out idsTree);
+
+      string name = "ClusterName";
+      DA.GetData(5, ref name);
+
+      string desc = string.Empty;
+      DA.GetData(6, ref desc);
+
+      int outId = 0;
+      string outHash = string.Empty;
+      string outInfo;
+
+      if (!run)
+      {
+        DA.SetData(0, outId);
+        DA.SetData(1, outHash);
+        DA.SetData(2, "Idle (imposta Run=true).");
+        return;
+      }
+
+      // Recupera contesto Rhino
+      object ctx;
+      string hub;
+      ServiceHub.TryGetMetadataRepository(out ctx, out hub);
+
+      if (!(ctx is ServiceHub.RhinoContext rh))
+      {
+        outInfo = "Repo non disponibile (serve documento Rhino attivo). " + (hub ?? "");
+        DA.SetData(0, outId);
+        DA.SetData(1, outHash);
+        DA.SetData(2, outInfo);
+        return;
+      }
+
+      var varRepo = new RhinoVariableRepository(rh.Doc);
+      var clusterRepo = new RhinoVariableClusterRepository(rh.Doc);
+
+      // Helper: raccoglie Ids dall'input tree
+      List<int> ReadIdsFromInput()
+      {
+        var ids = new List<int>();
+        foreach (var goo in idsTree.AllData(true))
+        {
+          if (goo is GH_Integer ghi)
+          {
+            int v = ghi.Value;
+            if (v > 0) ids.Add(v);
+          }
+        }
+        return ids.Distinct().OrderBy(x => x).ToList();
+      }
+
+      // Helper: carica tutte le variabili dal repository Rhino e ritorna lista Id
+      List<int> LoadAllVariableIds()
+      {
+        var ids = new List<int>();
+        var allVars = varRepo.GetAllAsync(default).GetAwaiter().GetResult();
+        foreach (var v in allVars)
+        {
+          if (v == null || v.Id <= 0) continue;
+          ids.Add(v.Id);
+        }
+        return ids.Distinct().OrderBy(x => x).ToList();
+      }
+
+      // Helper: risolve cluster esistente (Hash ha precedenza)
+      ProgesiVariableCluster ResolveExistingCluster()
+      {
+        ProgesiVariableCluster cluster = null;
+
+        if (!string.IsNullOrWhiteSpace(clusterHashIn))
+        {
+          cluster = clusterRepo.GetByHashtagAsync(clusterHashIn, default).GetAwaiter().GetResult();
+          return cluster;
+        }
+
+        if (clusterIdIn > 0)
+        {
+          cluster = clusterRepo.GetByIdAsync(clusterIdIn, default).GetAwaiter().GetResult();
+          return cluster;
+        }
+
+        return null;
+      }
+
+      try
+      {
+        // 0=Create, 1=Update, 2=Delete
+        if (act == 2)
+        {
+          // DELETE
+          var existing = ResolveExistingCluster();
+          if (existing == null)
+          {
+            outInfo = "Delete: cluster non trovato (fornire Hash o Id valido).";
+            DA.SetData(0, 0);
+            DA.SetData(1, "");
+            DA.SetData(2, outInfo);
+            return;
+          }
+
+          bool deleted = clusterRepo.DeleteAsync(existing.Id, default).GetAwaiter().GetResult();
+          outInfo = deleted
+            ? $"OK (Deleted Cluster Id={existing.Id})"
+            : $"Delete fallito (Cluster Id={existing.Id})";
+
+          DA.SetData(0, 0);
+          DA.SetData(1, "");
+          DA.SetData(2, outInfo);
+          return;
+        }
+
+        // Per Create/Update calcoliamo la lista Ids (se vuota → tutte)
+        var ids = ReadIdsFromInput();
+        if (ids.Count == 0)
+          ids = LoadAllVariableIds();
+
+        if (ids.Count == 0)
+        {
+          outInfo = "Nessuna variabile disponibile (input Ids vuoto e repository vuoto, oppure variabili inesistenti).";
+          DA.SetData(0, 0);
+          DA.SetData(1, "");
+          DA.SetData(2, outInfo);
+          return;
+        }
+
+        if (act == 1)
+        {
+          // UPDATE
+          var existing = ResolveExistingCluster();
+          if (existing == null)
+          {
+            outInfo = "Update: cluster non trovato (fornire Hash o Id valido).";
+            DA.SetData(0, 0);
+            DA.SetData(1, "");
+            DA.SetData(2, outInfo);
+            return;
+          }
+
+          // Manteniamo lo stesso Id: UPDATE vero (non dedup tramite service!)
+          var updated = ProgesiVariableCluster.Rehydrate(
+            existing.Id,
+            name,
+            ids,
+            desc,
+            null);
+
+          var saved = clusterRepo.SaveAsync(updated, default).GetAwaiter().GetResult();
+
+          outId = saved.Id;
+          outHash = saved.Hashtag ?? string.Empty;
+          outInfo = $"OK (Updated Cluster Id={saved.Id}, Vars={saved.ProgesiVariableIds.Count})";
+
+          DA.SetData(0, outId);
+          DA.SetData(1, outHash);
+          DA.SetData(2, outInfo);
+          return;
+        }
+
+        // CREATE (default)
+        {
+          var service = new ClusterService(clusterRepo);
+          var cluster = service.CreateOrGetClusterAsync(name, ids, desc).GetAwaiter().GetResult();
+
+          outId = cluster.Id;
+          outHash = cluster.Hashtag ?? string.Empty;
+          outInfo = $"OK (Cluster Id={cluster.Id}, Vars={cluster.ProgesiVariableIds.Count})";
+
+          DA.SetData(0, outId);
+          DA.SetData(1, outHash);
+          DA.SetData(2, outInfo);
+          return;
+        }
+      }
+      catch (Exception ex)
+      {
+        outInfo = "Errore: " + ex.Message;
+        DA.SetData(0, 0);
+        DA.SetData(1, "");
+        DA.SetData(2, outInfo);
+        return;
+      }
+    }
+
+
+  }
+}

--- a/src/ProgesiGrasshopperAssembly/Components/ProgesiClusterOutputComponent.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/ProgesiClusterOutputComponent.cs
@@ -1,0 +1,361 @@
+﻿// ProgesiClusterOutputComponent.cs
+#nullable disable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
+using ProgesiGrasshopperAssembly.Infrastructure;
+using ProgesiCore.Services;
+using ProgesiRepositories.Rhino;
+using ProgesiCore;
+
+
+namespace ProgesiGrasshopperAssembly.Components
+{
+  /// <summary>
+  /// Legge un ProgesiVariableCluster da Id o Hash e restituisce:
+  /// - Info (fisso, output #0)
+  /// - Ids (fisso, output #1)
+  /// - Names (fisso, output #2)
+  /// - Values (fisso, output #3, GenericObject list)
+  /// - Output dinamici (#4..): uno per variabile, GenericObject, nickname = ProgesiVariable.Name (sanitizzato)
+  /// </summary>
+  public sealed class ProgesiClusterOutputComponent : GH_Component, IGH_VariableParameterComponent
+  {
+    private bool _pendingDynamicRebuild = false;
+
+    private string _lastSignature = "";
+
+    public ProgesiClusterOutputComponent()
+      : base("Progesi Cluster Output", "ClusterOut",
+             "Legge un ProgesiVariableCluster da Id o Hash e produce:\n" +
+             "- output fissi (Info/Ids/Names/Values)\n" +
+             "- output dinamici: un Value per ogni ProgesiVariable nel cluster",
+             "Progesi", "Variables")
+    { }
+
+    public override Guid ComponentGuid => new Guid("C94FD91C-120C-44B9-9FFC-C280D1D712B7");
+    protected override System.Drawing.Bitmap Icon => ProgesiIcons.DataEx;
+
+    protected override void RegisterInputParams(GH_InputParamManager p)
+    {
+      p.AddBooleanParameter("Run", "Run", "Esegui (default FALSE).", GH_ParamAccess.item, false);
+
+      p.AddIntegerParameter("Id", "Id",
+                            "Id del cluster (opzionale se Hash è valorizzato).",
+                            GH_ParamAccess.item, 0);
+      Params.Input[Params.Input.Count - 1].Optional = true;
+
+      p.AddTextParameter("Hash", "Hash",
+                         "Hashtag del cluster. Se valorizzato, ha precedenza su Id.",
+                         GH_ParamAccess.item, string.Empty);
+      Params.Input[Params.Input.Count - 1].Optional = true;
+    }
+
+    protected override void RegisterOutputParams(GH_OutputParamManager p)
+    {
+      p.AddTextParameter("Info", "Info", "Esito/diagnostica.", GH_ParamAccess.item);
+
+      p.AddIntegerParameter("Ids", "Ids", "Id delle ProgesiVariable nel cluster.", GH_ParamAccess.list);
+      p.AddTextParameter("Names", "Names", "Name delle ProgesiVariable nel cluster.", GH_ParamAccess.list);
+
+      // Values list generic
+      var values = new Param_GenericObject
+      {
+        Name = "Values",
+        NickName = "Values",
+        Description = "Lista dei Value delle ProgesiVariable (GenericObject).",
+        Access = GH_ParamAccess.list
+      };
+      p.AddParameter(values);
+    }
+
+    protected override void SolveInstance(IGH_DataAccess DA)
+    {
+      bool run = false;
+      DA.GetData(0, ref run);
+
+      int id = 0;
+      DA.GetData(1, ref id);
+
+      string hash = string.Empty;
+      DA.GetData(2, ref hash);
+
+      if (!run)
+      {
+        DA.SetData(0, "Idle");
+        DA.SetDataList(1, new int[0]);
+        DA.SetDataList(2, new string[0]);
+        DA.SetDataList(3, new object[0]);
+        // dinamici -> vuoti
+        ClearDynamicOutputs(DA);
+        return;
+      }
+
+      if (string.IsNullOrWhiteSpace(hash) && id <= 0)
+      {
+        DA.SetData(0, "Input non valido: specificare almeno Id o Hash.");
+        DA.SetDataList(1, new int[0]);
+        DA.SetDataList(2, new string[0]);
+        DA.SetDataList(3, new object[0]);
+        ClearDynamicOutputs(DA);
+        return;
+      }
+
+      object ctx;
+      string hub;
+      ServiceHub.TryGetMetadataRepository(out ctx, out hub);
+
+      if (!(ctx is ServiceHub.RhinoContext rh))
+      {
+        DA.SetData(0, "Repo non disponibile (serve documento Rhino attivo). " + (hub ?? ""));
+        DA.SetDataList(1, new int[0]);
+        DA.SetDataList(2, new string[0]);
+        DA.SetDataList(3, new object[0]);
+        ClearDynamicOutputs(DA);
+        return;
+      }
+
+      var ids = new List<int>();
+      var names = new List<string>();
+      var values = new List<object>();
+
+      string info;
+
+      try
+      {
+        var clusterRepo = new RhinoVariableClusterRepository(rh.Doc);
+        var service = new ClusterService(clusterRepo);
+
+        ProgesiVariableCluster cluster = null;
+
+        if (!string.IsNullOrWhiteSpace(hash))
+          cluster = service.GetByHashtagAsync(hash, default).GetAwaiter().GetResult();
+        else
+          cluster = service.GetByIdAsync(id, default).GetAwaiter().GetResult();
+
+        if (cluster == null)
+        {
+          DA.SetData(0, "Cluster non trovato.");
+          DA.SetDataList(1, new int[0]);
+          DA.SetDataList(2, new string[0]);
+          DA.SetDataList(3, new object[0]);
+          ClearDynamicOutputs(DA);
+          return;
+        }
+
+        // Guard: cluster vuoto (file importati male / vecchi dati)
+        if (cluster.ProgesiVariableIds == null || cluster.ProgesiVariableIds.Count == 0)
+        {
+          DA.SetData(0, $"Cluster trovato (Id={cluster.Id}) ma non contiene variabili (VariableIds vuoto).");
+          DA.SetDataList(1, new int[0]);
+          DA.SetDataList(2, new string[0]);
+          DA.SetDataList(3, new object[0]);
+          ClearDynamicOutputs(DA);
+          return;
+        }
+
+        var varRepo = new RhinoVariableRepository(rh.Doc);
+
+        int missing = 0;
+
+        // 1) carico in mappa per evitare duplicati e per ricostruire ordine stabile
+        var byId = new Dictionary<int, ProgesiCore.ProgesiVariable>();
+
+        foreach (int vid in cluster.ProgesiVariableIds)
+        {
+          var v = varRepo.GetByIdAsync(vid, default).GetAwaiter().GetResult();
+          if (v == null)
+          {
+            missing++;
+            continue;
+          }
+
+          // ultimo v vince, ma in pratica vid è univoco
+          byId[vid] = v;
+        }
+
+        // 2) ricostruisco resolved nell'ordine ESATTO del cluster
+        var resolved = new List<ProgesiCore.ProgesiVariable>();
+        foreach (int vid in cluster.ProgesiVariableIds)
+        {
+          if (byId.TryGetValue(vid, out var v))
+            resolved.Add(v);
+        }
+
+
+        // firma per output dinamici (Id + lista Id + lista names)
+        string signature = ClusterOutNaming.BuildSignature(cluster.Id, resolved);
+        bool changed = EnsureDynamicOutputs(signature, resolved);
+
+        // Se ho cambiato il numero di output, esco SUBITO.
+        // ApplyDynamicNicknames verrà eseguito al solve successivo.
+        if (changed)
+          return;
+
+        if (_pendingDynamicRebuild)
+        {
+          ApplyDynamicNicknames(resolved);
+          _pendingDynamicRebuild = false;
+        }
+
+
+        foreach (var v in resolved)
+        {
+          ids.Add(v.Id);
+          string n = string.IsNullOrWhiteSpace(v.Name) ? $"Var-{v.Id}" : v.Name;
+          names.Add(n);
+          values.Add(v.Value);
+        }
+
+        info = $"OK (Cluster Id={cluster.Id}, Vars={cluster.ProgesiVariableIds.Count}, Found={ids.Count}, Missing={missing})";
+
+        DA.SetData(0, info);
+        DA.SetDataList(1, ids);
+        DA.SetDataList(2, names);
+        DA.SetDataList(3, values);
+
+        // Ora è sicuro scrivere nei dinamici
+        for (int i = 0; i < values.Count; i++)
+          DA.SetData(4 + i, values[i]);
+
+         // se ci sono più output dinamici del necessario, svuota i restanti
+        for (int j = 4 + values.Count; j < Params.Output.Count; j++)
+        {
+          DA.SetData(j, null);
+        }
+      }
+      catch (Exception ex)
+      {
+        info = "Errore: " + ex.Message;
+
+        DA.SetData(0, info);
+        DA.SetDataList(1, new int[0]);
+        DA.SetDataList(2, new string[0]);
+        DA.SetDataList(3, new object[0]);
+        ClearDynamicOutputs(DA);
+      }
+    }
+
+    private void ApplyDynamicNicknames(List<ProgesiCore.ProgesiVariable> vars)
+    {
+      int required = vars.Count;
+      int current = Math.Max(0, Params.Output.Count - 4);
+      if (current < required) required = current; // safety
+
+      var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+      for (int i = 0; i < required; i++)
+      {
+        var v = vars[i];
+        string baseName = string.IsNullOrWhiteSpace(v.Name) ? $"Var_{v.Id}" : v.Name;
+        string nick = ClusterOutNaming.SanitizeNick(baseName);
+        if (string.IsNullOrWhiteSpace(nick))
+          nick = $"Var_{v.Id}";
+        nick = ClusterOutNaming.MakeUnique(nick, used);
+
+        var param = Params.Output[4 + i];
+        param.Name = nick;
+        param.NickName = nick;
+        param.Description = $"Value (GenericObject) for {baseName} (Id={v.Id}).";
+        param.Access = GH_ParamAccess.item;
+      }
+
+      Params.OnParametersChanged();
+    }
+
+    // ---------------- IGH_VariableParameterComponent ----------------
+
+    public bool CanInsertParameter(GH_ParameterSide side, int index)
+      => side == GH_ParameterSide.Output && index >= 4;
+
+    public bool CanRemoveParameter(GH_ParameterSide side, int index)
+      => side == GH_ParameterSide.Output && index >= 4;
+
+    public IGH_Param CreateParameter(GH_ParameterSide side, int index)
+    {
+      // solo output dinamici
+      var p = new Param_GenericObject
+      {
+        Name = "Value",
+        NickName = "Value",
+        Description = "Value (GenericObject) of a ProgesiVariable in the cluster.",
+        Access = GH_ParamAccess.item
+      };
+      return p;
+    }
+
+    public bool DestroyParameter(GH_ParameterSide side, int index) => true;
+
+    public void VariableParameterMaintenance()
+    {
+      // chiamato da GH quando parametri cambiano
+      // manteniamo Access item sugli output dinamici
+      for (int i = 4; i < Params.Output.Count; i++)
+      {
+        Params.Output[i].Access = GH_ParamAccess.item;
+      }
+    }
+
+    // ---------------- Helpers ----------------
+    private bool EnsureDynamicOutputs(string signature, List<ProgesiCore.ProgesiVariable> vars)
+    {
+      // Se firma uguale, non tocchiamo nulla
+      if (string.Equals(signature, _lastSignature, StringComparison.Ordinal))
+        return false;
+
+      _lastSignature = signature;
+
+      int required = vars.Count;
+      int current = Math.Max(0, Params.Output.Count - 4);
+
+      bool changedCount = false;
+
+      // Rimuovi in eccesso
+      while (current > required)
+      {
+        Params.UnregisterOutputParameter(Params.Output[Params.Output.Count - 1], true);
+        current--;
+        changedCount = true;
+      }
+
+      // Aggiungi mancanti
+      while (current < required)
+      {
+        var p = new Param_GenericObject
+        {
+          Name = "Value",
+          NickName = "Value",
+          Description = "Value (GenericObject) of a ProgesiVariable in the cluster.",
+          Access = GH_ParamAccess.item
+        };
+        Params.RegisterOutputParam(p);
+        current++;
+        changedCount = true;
+      }
+
+      // Se ho cambiato il numero di parametri: devo uscire dal solve corrente.
+      if (changedCount)
+      {
+        Params.OnParametersChanged();
+        _pendingDynamicRebuild = true; // aggiorna nickname nel solve successivo
+        ExpireSolution(true);
+        return true;
+      }
+
+      // Count uguale: non serve ExpireSolution(true), ma nickname può essere diverso
+      _pendingDynamicRebuild = true;
+      return false;
+    }
+
+    private void ClearDynamicOutputs(IGH_DataAccess DA)
+    {
+      // svuota gli output dinamici correnti (se presenti)
+      for (int i = 4; i < Params.Output.Count; i++)
+      {
+        DA.SetData(i, null);
+      }
+    }
+  }
+}

--- a/src/ProgesiGrasshopperAssembly/Components/ProgesiDataExchangeComponent.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/ProgesiDataExchangeComponent.cs
@@ -260,7 +260,7 @@ namespace ProgesiGrasshopperAssembly.Components
 
       var vars = ReadAllVarsFromTable(table);
       var metas = ReadAllMetasFromTable(table);
-
+      var clusters = ReadAllClustersFromTable(table);
       using (var wb = new XLWorkbook())
       {
         // Variables
@@ -309,10 +309,31 @@ namespace ProgesiGrasshopperAssembly.Components
         }
         wsM.Columns().AdjustToContents();
 
+        // Clusters
+        var wsC = wb.Worksheets.Add("ProgesiClusters");
+        wsC.Cell(1, 1).Value = "Id";
+        wsC.Cell(1, 2).Value = "Hash";
+        wsC.Cell(1, 3).Value = "Name";
+        wsC.Cell(1, 4).Value = "Description";
+        wsC.Cell(1, 5).Value = "VariableIds";
+        int r3 = 2;
+        foreach (var c in clusters)
+        {
+          wsC.Cell(r3, 1).Value = c.Id;
+          wsC.Cell(r3, 2).Value = c.Hash ?? "";
+          wsC.Cell(r3, 3).Value = c.Name ?? "";
+          wsC.Cell(r3, 4).Value = c.Description ?? "";
+          wsC.Cell(r3, 5).Value = (c.VariableIds != null && c.VariableIds.Length > 0)
+            ? string.Join(",", c.VariableIds)
+            : "";
+          r3++;
+        }
+        wsC.Columns().AdjustToContents();
+
         wb.SaveAs(p);
       }
 
-      string info = $"OK ExportExcel → {p} (Vars:{vars.Length}, Meta:{metas.Length})";
+      string info = $"OK ExportExcel → {p} (Vars:{vars.Length}, Meta:{metas.Length}, Clusters:{clusters.Length})";
       return (p, info);
     }
     private static string NormalizeExportPath(string inPath)
@@ -617,6 +638,7 @@ namespace ProgesiGrasshopperAssembly.Components
       var metas = ReadAllMetasFromTable(table);   // MetaRow[]
       var vars = ReadAllVarsFromTable(table);    // VarRow[]
       var metaIdsPresent = new HashSet<int>(metas.Select(m => m.Id));
+      var clusters = ReadAllClustersFromTable(table);
 
       // 2) Prepara percorso destinazione
       string p = (inPath ?? string.Empty).Trim();
@@ -691,6 +713,20 @@ CREATE TABLE IF NOT EXISTS VariableDepends (
   DepId        INTEGER NOT NULL,
   PRIMARY KEY (VarId, DepId),
   FOREIGN KEY (VarId) REFERENCES Variables(Id) ON DELETE CASCADE
+);
+CREATE TABLE IF NOT EXISTS Clusters (
+  Id          INTEGER PRIMARY KEY,
+  Hash        TEXT NOT NULL,
+  Name        TEXT NOT NULL,
+  Description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS ClusterVariables (
+  ClusterId   INTEGER NOT NULL,
+  VarId       INTEGER NOT NULL,
+  PRIMARY KEY (ClusterId, VarId),
+  FOREIGN KEY (ClusterId) REFERENCES Clusters(Id) ON DELETE CASCADE,
+  FOREIGN KEY (VarId)     REFERENCES Variables(Id) ON DELETE CASCADE
 );";
           cmd.ExecuteNonQuery();
 
@@ -777,6 +813,55 @@ CREATE TABLE IF NOT EXISTS VariableDepends (
             }
           }
 
+          // 3.5) Clusters + reset join
+          cmd.Parameters.Clear();
+
+          // reset per export deterministico
+          cmd.CommandText = "DELETE FROM ClusterVariables;";
+          cmd.ExecuteNonQuery();
+
+          cmd.CommandText = "DELETE FROM Clusters;";
+          cmd.ExecuteNonQuery();
+
+          // insert clusters
+          cmd.CommandText = "INSERT OR REPLACE INTO Clusters (Id,Hash,Name,Description) VALUES (@id,@hash,@name,@desc)";
+          var cId = new SQLiteParameter("@id");
+          var cHash = new SQLiteParameter("@hash");
+          var cName = new SQLiteParameter("@name");
+          var cDesc = new SQLiteParameter("@desc");
+          cmd.Parameters.AddRange(new[] { cId, cHash, cName, cDesc });
+
+          foreach (var c in clusters)
+          {
+            cId.Value = c.Id;
+            cHash.Value = c.Hash ?? string.Empty;
+            cName.Value = c.Name ?? string.Empty;
+            cDesc.Value = c.Description ?? string.Empty;
+            cmd.ExecuteNonQuery();
+          }
+
+          // 3.6) ClusterVariables (join)
+          cmd.Parameters.Clear();
+          cmd.CommandText = "INSERT OR REPLACE INTO ClusterVariables (ClusterId,VarId) VALUES (@cid,@vid)";
+          var jCid = new SQLiteParameter("@cid");
+          var jVid = new SQLiteParameter("@vid");
+          cmd.Parameters.AddRange(new[] { jCid, jVid });
+
+          // usiamo solo VarId esistenti (coerente con depends)
+          foreach (var c in clusters)
+          {
+            if (c.VariableIds == null || c.VariableIds.Length == 0) continue;
+
+            foreach (var vid in c.VariableIds)
+            {
+              if (!varIds.Contains(vid)) continue; // varIds è HashSet<int> già creato sopra
+
+              jCid.Value = c.Id;
+              jVid.Value = vid;
+              cmd.ExecuteNonQuery();
+            }
+          }
+
           tx.Commit();
         }
       }
@@ -784,9 +869,8 @@ CREATE TABLE IF NOT EXISTS VariableDepends (
       // 4) Riepilogo
       var info = string.Format(                                  // <-- fix Count/Length e firma di Format
           CultureInfo.InvariantCulture,
-          "OK ExportSqlite → {0} (Meta:{1}, Vars:{2})",
-          p, metas.Length, vars.Length);
-
+          "OK ExportSqlite → {0} (Meta:{1}, Vars:{2}, Clusters:{3})",
+          p, metas.Length, vars.Length, clusters.Length);
       return (p, info);
     }
 
@@ -833,6 +917,7 @@ CREATE TABLE IF NOT EXISTS VariableDepends (
 
       int metaRows = 0, metaOk = 0, metaWarn = 0, metaErr = 0;
       int varRows = 0, varOk = 0, varWarn = 0, varErr = 0;
+      int clusterRows = 0, clusterOk = 0, clusterWarn = 0, clusterErr = 0;
 
       using (var cn = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source={db};Mode=ReadOnly"))
       {
@@ -915,6 +1000,7 @@ CREATE TABLE IF NOT EXISTS VariableDepends (
           }
         }
 
+        bool hasClusters = HasTable("Clusters") && HasTable("ClusterVariables");
         // ===== VARIABLES =====
         using (var cmd = cn.CreateCommand())
         {
@@ -978,6 +1064,74 @@ CREATE TABLE IF NOT EXISTS VariableDepends (
             }
           }
         }
+        if (hasClusters && !dryRun)
+        {
+          // Scriviamo direttamente nella StringTable Rhino come fa DataEx per Excel
+          var doc = RhinoDoc.ActiveDoc ?? throw new InvalidOperationException("RhinoDoc.ActiveDoc is null.");
+          var table = doc.Strings ?? throw new InvalidOperationException("RhinoDoc.Strings is null.");
+
+          using (var cmdC = cn.CreateCommand())
+          {
+            cmdC.CommandText = "SELECT Id, Name, Description, Hash FROM Clusters ORDER BY Id";
+            using (var rdC = cmdC.ExecuteReader())
+            {
+              while (rdC.Read())
+              {
+                clusterRows++;
+
+                int cid = rdC.IsDBNull(0) ? 0 : rdC.GetInt32(0);
+                string cnm = rdC.IsDBNull(1) ? "" : rdC.GetString(1);
+                string cds = rdC.IsDBNull(2) ? "" : rdC.GetString(2);
+                string ch = rdC.IsDBNull(3) ? "" : rdC.GetString(3);
+
+                // varIds join
+                var varIdsList = new List<int>();
+                using (var cmdJ = cn.CreateCommand())
+                {
+                  cmdJ.CommandText = "SELECT VarId FROM ClusterVariables WHERE ClusterId=@id ORDER BY VarId";
+                  cmdJ.Parameters.AddWithValue("@id", cid);
+                  using (var rdJ = cmdJ.ExecuteReader())
+                  {
+                    while (rdJ.Read())
+                    {
+                      int vid = rdJ.IsDBNull(0) ? 0 : rdJ.GetInt32(0);
+                      if (vid > 0) varIdsList.Add(vid);
+                    }
+                  }
+                }
+
+                var varIdsArr = varIdsList.Distinct().OrderBy(x => x).ToArray();
+
+                // ricalcolo hash coerente dal dominio (salviamo comunque ch in dto per traccia)
+                var cluster = ProgesiVariableCluster.Rehydrate(cid, cnm ?? "", varIdsArr, cds, string.IsNullOrWhiteSpace(ch) ? null : ch);
+
+                var dto = new ClusterDto
+                {
+                  Id = cid,
+                  Name = cnm ?? "",
+                  Description = cds ?? "",
+                  VariableIds = varIdsArr,
+                  Hashtag = cluster.Hashtag
+                };
+
+                string json = JsonConvert.SerializeObject(dto);
+
+                table.SetString("Progesi.Cluster", "cluster:" + cid.ToString(CultureInfo.InvariantCulture), json);
+
+                // bump __next__
+                int next = ReadCounter(table, "Progesi.Cluster");
+                if (cid + 1 > next)
+                  table.SetString("Progesi.Cluster", "__next__", (cid + 1).ToString(CultureInfo.InvariantCulture));
+
+                clusterOk++;
+              }
+            }
+          }
+
+          LOG("INFO", $"[Clusters] Imported {clusterOk}/{clusterRows} from SQLite.");
+          counts.Append(new GH_String($"Clusters rows={clusterRows} ok={clusterOk} warn={clusterWarn} err={clusterErr}"), new GH_Path(2));
+        }
+
       }
 
       // counts + log
@@ -988,9 +1142,11 @@ CREATE TABLE IF NOT EXISTS VariableDepends (
       try { File.WriteAllLines(logPath, logLines, Encoding.UTF8); } catch { logPath = ""; }
 
       string prefix = dryRun ? "PREVIEW " : "OK ";
-      string info = $"{prefix}ImportSqlite ← {db} | Meta {metaOk}/{metaRows} (warn:{metaWarn}, err:{metaErr}) | " +
-                    $"Vars {varOk}/{varRows} (warn:{varWarn}, err:{varErr}) | Log: {(string.IsNullOrWhiteSpace(logPath) ? "-" : logPath)}";
-
+      string info = $"{prefix}ImportSqlite ← {db} | " +
+              $"Meta {metaOk}/{metaRows} (warn:{metaWarn}, err:{metaErr}) | " +
+              $"Vars {varOk}/{varRows} (warn:{varWarn}, err:{varErr}) | " +
+              $"Clusters {clusterOk}/{clusterRows} (warn:{clusterWarn}, err:{clusterErr}) | " +
+              $"Log: {(string.IsNullOrWhiteSpace(logPath) ? "-" : logPath)}";
       return (db, logPath, warnTree, errTree, counts, errRC, info);
     }
 
@@ -1049,6 +1205,18 @@ CREATE TABLE IF NOT EXISTS VariableDepends (
           }
         }
       }
+    }
+    private static string ResolveSqlitePath(string inputPath)
+    {
+      // Se è una directory, metti dentro un default filename
+      if (Directory.Exists(inputPath))
+        return Path.Combine(inputPath, "progesi.db");
+
+      // Se non ha estensione, aggiungi .db
+      if (string.IsNullOrWhiteSpace(Path.GetExtension(inputPath)))
+        return inputPath + ".db";
+
+      return inputPath;
     }
 
     private static string NormalizeKey(string s)
@@ -1113,7 +1281,16 @@ CREATE TABLE IF NOT EXISTS VariableDepends (
     private static string ReadCell(IXLWorksheet ws, int row, Dictionary<string, int> map, string key)
     {
       if (!map.TryGetValue(key, out int col)) return "";
-      return ws.Cell(row, col).GetString() ?? "";
+      var cell = ws.Cell(row, col);
+
+      var s = cell.GetString();
+      if (!string.IsNullOrWhiteSpace(s)) return s;
+
+      s = cell.GetFormattedString();
+      if (!string.IsNullOrWhiteSpace(s)) return s;
+
+      try { return cell.Value.ToString(); }
+      catch { return ""; }
     }
 
     private static bool IsBlank(string s) => string.IsNullOrWhiteSpace(s);
@@ -1204,12 +1381,71 @@ CREATE TABLE IF NOT EXISTS VariableDepends (
       public string[] Refs;
       public string LM;
     }
+#nullable enable
+    private sealed class ClusterDto
+    {
+      public int Id { get; set; }
+      public string? Name { get; set; }
+      public string? Description { get; set; }
+      public int[]? VariableIds { get; set; }
+      public string? Hashtag { get; set; }
+    }
+
+    private sealed class ClusterRow
+    {
+      public int Id;
+      public string Hash = "";
+      public string Name = "";
+      public string Description = "";
+      public int[] VariableIds = Array.Empty<int>();
+    }
+#nullable disable
+
+    private static ClusterRow[] ReadAllClustersFromTable(StringTable table)
+    {
+      var list = new List<ClusterRow>();
+
+      foreach (var id in EnumerateIds(table, "Progesi.Cluster", "cluster:"))
+      {
+        string json = table.GetValue("Progesi.Cluster", "cluster:" + id.ToString(CultureInfo.InvariantCulture));
+        if (string.IsNullOrWhiteSpace(json)) continue;
+
+        ClusterDto dto;
+        try { dto = JsonConvert.DeserializeObject<ClusterDto>(json); }
+        catch { continue; }
+
+        if (dto == null) continue;
+
+        var varIds = dto.VariableIds ?? Array.Empty<int>();
+
+        string name = dto.Name ?? "";
+        string desc = dto.Description ?? "";
+
+        var cluster = ProgesiVariableCluster.Rehydrate(
+          id,
+          name,
+          varIds,
+          desc,
+          dto.Hashtag);
+
+        list.Add(new ClusterRow
+        {
+          Id = id,
+          Hash = cluster.Hashtag ?? "",
+          Name = name,
+          Description = desc,
+          VariableIds = varIds
+        });
+      }
+
+      list.Sort((a, b) => a.Id.CompareTo(b.Id));
+      return list.ToArray();
+    }
 
     private static VarRow[] ReadAllVarsFromTable(StringTable table)
     {
-      int next = ReadCounter(table, "Progesi.Var");
       var list = new List<VarRow>();
-      for (int id = 1; id < next; id++)
+      foreach (var id in EnumerateIds(table, "Progesi.Var", "var:"))
       {
         string json = table.GetValue("Progesi.Var", "var:" + id.ToString(CultureInfo.InvariantCulture));
         if (string.IsNullOrWhiteSpace(json)) continue;
@@ -1242,9 +1478,8 @@ CREATE TABLE IF NOT EXISTS VariableDepends (
 
     private static MetaRow[] ReadAllMetasFromTable(StringTable table)
     {
-      int next = ReadCounter(table, "Progesi.Meta");
       var list = new List<MetaRow>();
-      for (int id = 1; id < next; id++)
+      foreach (var id in EnumerateIds(table, "Progesi.Meta", "meta:"))
       {
         string json = table.GetValue("Progesi.Meta", "meta:" + id.ToString(CultureInfo.InvariantCulture));
         if (string.IsNullOrWhiteSpace(json)) continue;
@@ -1271,6 +1506,25 @@ CREATE TABLE IF NOT EXISTS VariableDepends (
 
 
       return list.ToArray();
+    }
+
+    private static int[] EnumerateIds(StringTable table, string section, string prefix)
+    {
+      var names = table.GetEntryNames(section) ?? Array.Empty<string>();
+      var ids = new List<int>();
+
+      foreach (var n in names)
+      {
+        if (string.IsNullOrWhiteSpace(n)) continue;
+        if (!n.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) continue;
+
+        var tail = n.Substring(prefix.Length).Trim();
+        if (int.TryParse(tail, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id) && id > 0)
+          ids.Add(id);
+      }
+
+      ids.Sort();
+      return ids.Distinct().ToArray();
     }
 
     private static object ParseValue(string value, string valueType)

--- a/src/ProgesiRepositories.InMemory/InMemoryVariableClusterRepository.cs
+++ b/src/ProgesiRepositories.InMemory/InMemoryVariableClusterRepository.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ProgesiCore;
+
+namespace ProgesiRepositories.InMemory
+{
+  /// <summary>
+  /// Repository in-memory per ProgesiVariableCluster.
+  /// Implementa IProgesiVariableClusterRepository usando un semplice dizionario.
+  /// Utile per test e per scenari dove non vogliamo toccare DB/Rhino.
+  /// </summary>
+  public sealed class InMemoryVariableClusterRepository : IProgesiVariableClusterRepository
+  {
+    private readonly ConcurrentDictionary<int, ProgesiVariableCluster> _store =
+      new ConcurrentDictionary<int, ProgesiVariableCluster>();
+
+    /// <summary>
+    /// Salva (o aggiorna) un cluster in memoria.
+    /// </summary>
+    public Task<ProgesiVariableCluster> SaveAsync(
+      ProgesiVariableCluster cluster,
+      CancellationToken ct = default)
+    {
+      if (cluster is null) throw new ArgumentNullException(nameof(cluster));
+
+      _store[cluster.Id] = cluster;
+      return Task.FromResult(cluster);
+    }
+
+    /// <summary>
+    /// Restituisce il cluster con l'Id specificato, oppure null se non esiste.
+    /// </summary>
+    public Task<ProgesiVariableCluster?> GetByIdAsync(
+      int id,
+      CancellationToken ct = default)
+    {
+      _store.TryGetValue(id, out var cluster);
+      return Task.FromResult<ProgesiVariableCluster?>(cluster);
+    }
+
+    /// <summary>
+    /// Restituisce il cluster che ha l'hashtag indicato, oppure null se non trovato.
+    /// </summary>
+    public Task<ProgesiVariableCluster?> GetByHashtagAsync(
+      string hashtag,
+      CancellationToken ct = default)
+    {
+      if (string.IsNullOrWhiteSpace(hashtag))
+        return Task.FromResult<ProgesiVariableCluster?>(null);
+
+      var match = _store.Values
+        .FirstOrDefault(c => string.Equals(c.Hashtag, hashtag, StringComparison.Ordinal));
+
+      return Task.FromResult<ProgesiVariableCluster?>(match);
+    }
+
+    /// <summary>
+    /// Restituisce tutti i cluster presenti nello store in-memory.
+    /// </summary>
+    public Task<IReadOnlyList<ProgesiVariableCluster>> GetAllAsync(
+      CancellationToken ct = default)
+    {
+      IReadOnlyList<ProgesiVariableCluster> list = _store.Values.ToList();
+      return Task.FromResult(list);
+    }
+
+    /// <summary>
+    /// Elimina il cluster con Id specificato.
+    /// </summary>
+    public Task<bool> DeleteAsync(
+      int id,
+      CancellationToken ct = default)
+    {
+      var removed = _store.TryRemove(id, out _);
+      return Task.FromResult(removed);
+    }
+
+    /// <summary>
+    /// Elimina in blocco i cluster con gli Id specificati.
+    /// Ritorna il numero effettivo di elementi rimossi.
+    /// </summary>
+    public Task<int> DeleteManyAsync(
+      IEnumerable<int> ids,
+      CancellationToken ct = default)
+    {
+      if (ids is null) throw new ArgumentNullException(nameof(ids));
+
+      int count = 0;
+      foreach (var id in ids)
+      {
+        if (_store.TryRemove(id, out _))
+          count++;
+      }
+
+      return Task.FromResult(count);
+    }
+  }
+}

--- a/src/ProgesiRepositories.Rhino/RhinoVariableClusterRepository.cs
+++ b/src/ProgesiRepositories.Rhino/RhinoVariableClusterRepository.cs
@@ -1,0 +1,187 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using ProgesiCore;
+using Rhino;
+using Rhino.DocObjects.Tables;
+
+namespace ProgesiRepositories.Rhino
+{
+  /// <summary>
+  /// Repository Rhino per ProgesiVariableCluster.
+  /// Salva i cluster nel RhinoDoc.Strings (StringTable) come JSON,
+  /// sezione dedicata "Progesi.Cluster".
+  /// </summary>
+  public sealed class RhinoVariableClusterRepository : IProgesiVariableClusterRepository
+  {
+    private const string Section = "Progesi.Cluster";
+
+    private readonly StringTable _table;
+
+    public RhinoVariableClusterRepository(RhinoDoc doc)
+    {
+      if (doc is null) throw new ArgumentNullException(nameof(doc));
+      _table = doc.Strings ?? throw new InvalidOperationException("RhinoDoc.Strings is null.");
+    }
+
+    // ======================= CRUD =======================
+
+    public Task<ProgesiVariableCluster> SaveAsync(
+      ProgesiVariableCluster cluster,
+      CancellationToken ct = default)
+    {
+      if (cluster is null) throw new ArgumentNullException(nameof(cluster));
+
+      var dto = new Dto
+      {
+        Id = cluster.Id,
+        Name = cluster.Name,
+        Description = cluster.Description,
+        VariableIds = cluster.ProgesiVariableIds?.ToArray() ?? Array.Empty<int>(),
+        Hashtag = cluster.Hashtag
+      };
+
+      string json = JsonConvert.SerializeObject(dto);
+      _table.SetString(Section, KeyOf(cluster.Id), json);
+
+      return Task.FromResult(cluster);
+    }
+
+    public Task<ProgesiVariableCluster?> GetByIdAsync(
+      int id,
+      CancellationToken ct = default)
+    {
+      if (id <= 0)
+        return Task.FromResult<ProgesiVariableCluster?>(null);
+
+      string key = KeyOf(id);
+      string? json = _table.GetValue(Section, key);
+
+      if (string.IsNullOrWhiteSpace(json))
+        return Task.FromResult<ProgesiVariableCluster?>(null);
+
+      var dto = JsonConvert.DeserializeObject<Dto>(json);
+      if (dto == null || dto.Id <= 0)
+        return Task.FromResult<ProgesiVariableCluster?>(null);
+
+      int[] ids = dto.VariableIds ?? Array.Empty<int>();
+
+      var cluster = ProgesiVariableCluster.Rehydrate(
+        dto.Id,
+        dto.Name ?? string.Empty,
+        ids,
+        dto.Description,
+        dto.Hashtag);
+
+      return Task.FromResult<ProgesiVariableCluster?>(cluster);
+    }
+
+    public async Task<ProgesiVariableCluster?> GetByHashtagAsync(
+      string hashtag,
+      CancellationToken ct = default)
+    {
+      if (string.IsNullOrWhiteSpace(hashtag))
+        return null;
+
+      var all = await GetAllAsync(ct).ConfigureAwait(false);
+      var match = all.FirstOrDefault(c =>
+        string.Equals(c.Hashtag, hashtag, StringComparison.Ordinal));
+
+      return match;
+    }
+
+    public Task<IReadOnlyList<ProgesiVariableCluster>> GetAllAsync(
+      CancellationToken ct = default)
+    {
+      var result = new List<ProgesiVariableCluster>();
+
+      // Otteniamo tutti gli "entry names" della sezione dedicata ai cluster.
+      string[] names = _table.GetEntryNames(Section) ?? Array.Empty<string>();
+
+      foreach (var entry in names)
+      {
+        string? json = _table.GetValue(Section, entry);
+        if (string.IsNullOrWhiteSpace(json))
+          continue;
+
+        Dto? dto;
+        try
+        {
+          dto = JsonConvert.DeserializeObject<Dto>(json);
+        }
+        catch
+        {
+          // JSON corrotto o non riconosciuto: ignora questa entry.
+          continue;
+        }
+
+        if (dto == null || dto.Id <= 0)
+          continue;
+
+        int[] ids = dto.VariableIds ?? Array.Empty<int>();
+
+        var cluster = ProgesiVariableCluster.Rehydrate(
+          dto.Id,
+          dto.Name ?? string.Empty,
+          ids,
+          dto.Description,
+          dto.Hashtag);
+
+        result.Add(cluster);
+      }
+
+      // Ordiniamo per Id giusto per avere un output stabile.
+      result.Sort((a, b) => a.Id.CompareTo(b.Id));
+
+      return Task.FromResult<IReadOnlyList<ProgesiVariableCluster>>(result);
+    }
+
+    public Task<bool> DeleteAsync(
+      int id,
+      CancellationToken ct = default)
+    {
+      if (id <= 0)
+        return Task.FromResult(false);
+
+      string key = KeyOf(id);
+      _table.Delete(Section, key);
+
+      // Non abbiamo un ritorno booleano da Rhino, quindi assumiamo true.
+      return Task.FromResult(true);
+    }
+
+    public Task<int> DeleteManyAsync(
+      IEnumerable<int> ids,
+      CancellationToken ct = default)
+    {
+      if (ids is null) throw new ArgumentNullException(nameof(ids));
+
+      int count = 0;
+      foreach (var id in ids)
+      {
+        if (id <= 0) continue;
+        string key = KeyOf(id);
+        _table.Delete(Section, key);
+        count++;
+      }
+
+      return Task.FromResult(count);
+    }
+
+    private static string KeyOf(int id) => $"cluster:{id}";
+
+    // DTO per la serializzazione su StringTable (JSON)
+    private sealed class Dto
+    {
+      public int Id { get; set; }
+      public string? Name { get; set; }
+      public string? Description { get; set; }
+      public int[]? VariableIds { get; set; }
+      public string? Hashtag { get; set; }
+    }
+  }
+}

--- a/tests/ProgesiCore.Tests/ClusterImportParserTests.cs
+++ b/tests/ProgesiCore.Tests/ClusterImportParserTests.cs
@@ -1,0 +1,56 @@
+﻿using ProgesiCore;
+using Xunit;
+
+namespace ProgesiCore.Tests
+{
+  public class ClusterImportParserTests
+  {
+    [Theory]
+    [InlineData("3,4", new[] { 3, 4 })]
+    [InlineData("3.4", new[] { 3, 4 })]          // Excel decimal -> separatore
+    [InlineData("3,4.5", new[] { 3, 4, 5 })]     // misto
+    [InlineData("1!5", new[] { 1, 5 })]
+    [InlineData("1|5", new[] { 1, 5 })]
+    [InlineData(" 1  5 ", new[] { 1, 5 })]
+    [InlineData("3,\u00A04", new[] { 3, 4 })]    // NBSP
+    public void ParseVariableIds_Works(string raw, int[] expected)
+    {
+      var ids = ClusterImportParser.ParseVariableIds(raw);
+      Assert.Equal(expected, ids);
+    }
+
+    [Fact]
+    public void TryParseClusterRow_Parses_Row()
+    {
+      string Cell(string key)
+      {
+        switch (key)
+        {
+          case "ID": return "5";
+          case "NAME": return "Alfio";
+          case "DESCRIPTION": return "Ciccio";
+          case "HASH": return "5|Alfio|3,4";
+          case "VARIABLEIDS": return "3.4";
+          default: return "";
+        }
+      }
+
+      var ok = ClusterImportParser.TryParseClusterRow(
+        Cell,
+        out var id,
+        out var name,
+        out var desc,
+        out var varIds,
+        out var hash,
+        out var warn);
+
+      Assert.True(ok);
+      Assert.Equal(5, id);
+      Assert.Equal("Alfio", name);
+      Assert.Equal("Ciccio", desc);
+      Assert.Equal("5|Alfio|3,4", hash);
+      Assert.Equal(new[] { 3, 4 }, varIds);
+      Assert.True(string.IsNullOrEmpty(warn));
+    }
+  }
+}

--- a/tests/ProgesiCore.Tests/ClusterOutNamingTests.cs
+++ b/tests/ProgesiCore.Tests/ClusterOutNamingTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using ProgesiCore;
+using Xunit;
+
+namespace ProgesiCore.Tests
+{
+  public class ClusterOutNamingTests
+  {
+    [Theory]
+    [InlineData("Var 1", "Var_1")]
+    [InlineData("A/B", "A_B")]
+    [InlineData("A|B", "A_B")]
+    [InlineData("  spaced   name ", "spaced_name")]
+    public void SanitizeNick_Works(string input, string expected)
+    {
+      Assert.Equal(expected, ClusterOutNaming.SanitizeNick(input));
+    }
+
+    [Fact]
+    public void MakeUnique_AppendsSuffix()
+    {
+      var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+      var a = ClusterOutNaming.MakeUnique("Load", used);
+      var b = ClusterOutNaming.MakeUnique("Load", used);
+      var c = ClusterOutNaming.MakeUnique("Load", used);
+
+      Assert.Equal("Load", a);
+      Assert.Equal("Load_2", b);
+      Assert.Equal("Load_3", c);
+    }
+
+    [Fact]
+    public void BuildSignature_IsStableForSameInput()
+    {
+      var vars = new List<ProgesiVariable>
+      {
+        new ProgesiVariable(1, "Var-1", 10, Array.Empty<int>(), null, false),
+        new ProgesiVariable(2, "Var-2", 20, Array.Empty<int>(), null, false)
+      };
+
+      var s1 = ClusterOutNaming.BuildSignature(7, vars);
+      var s2 = ClusterOutNaming.BuildSignature(7, vars);
+
+      Assert.Equal(s1, s2);
+    }
+
+    [Fact]
+    public void BuildSignature_ChangesWhenNameChanges()
+    {
+      var varsA = new List<ProgesiVariable>
+      {
+        new ProgesiVariable(1, "A", 10, Array.Empty<int>(), null, false)
+      };
+
+      var varsB = new List<ProgesiVariable>
+      {
+        new ProgesiVariable(1, "B", 10, Array.Empty<int>(), null, false)
+      };
+
+      var s1 = ClusterOutNaming.BuildSignature(1, varsA);
+      var s2 = ClusterOutNaming.BuildSignature(1, varsB);
+
+      Assert.NotEqual(s1, s2);
+    }
+  }
+}

--- a/tests/ProgesiCore.Tests/ClusterServiceTests.cs
+++ b/tests/ProgesiCore.Tests/ClusterServiceTests.cs
@@ -1,0 +1,85 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using ProgesiCore.Services;
+using ProgesiRepositories.InMemory;
+using Xunit;
+
+namespace Progesi.Core.Tests.Services
+{
+  public class ClusterServiceTests
+  {
+    [Fact]
+    public async Task CreateOrGetCluster_Creates_New_Cluster_When_Repository_Is_Empty()
+    {
+      // arrange
+      var clusterRepo = new InMemoryVariableClusterRepository();
+      var service = new ClusterService(clusterRepo);
+
+      // act
+      var cluster = await service.CreateOrGetClusterAsync("C1", new[] { 1, 2, 3 }, "desc");
+
+      // assert
+      Assert.NotNull(cluster);
+      Assert.Equal("C1", cluster.Name);
+      Assert.True(cluster.Id > 0);
+      Assert.True(cluster.ProgesiVariableIds.SequenceEqual(new[] { 1, 2, 3 }));
+
+      var all = await service.GetAllAsync();
+      Assert.Single(all);
+    }
+
+    [Fact]
+    public async Task CreateOrGetCluster_Reuses_Existing_For_Equivalent_Cluster()
+    {
+      // arrange
+      var clusterRepo = new InMemoryVariableClusterRepository();
+      var service = new ClusterService(clusterRepo);
+
+      // primo cluster
+      var first = await service.CreateOrGetClusterAsync("C1", new[] { 1, 2, 3 }, "desc");
+
+      // stesso cluster logico: stessi Id ma in ordine diverso
+      var second = await service.CreateOrGetClusterAsync("C1", new[] { 3, 1, 2 }, "desc");
+
+      // assert
+      Assert.Equal(first.Id, second.Id);
+
+      var all = await service.GetAllAsync();
+      Assert.Single(all); // dedup riuscito: uno solo nello store
+    }
+
+    [Fact]
+    public async Task CreateOrGetCluster_Creates_New_When_VariableIds_Differ()
+    {
+      // arrange
+      var clusterRepo = new InMemoryVariableClusterRepository();
+      var service = new ClusterService(clusterRepo);
+
+      var a = await service.CreateOrGetClusterAsync("C1", new[] { 1, 2 }, "desc");
+      var b = await service.CreateOrGetClusterAsync("C1", new[] { 1, 2, 3 }, "desc");
+
+      // assert
+      Assert.NotEqual(a.Id, b.Id);
+
+      var all = await service.GetAllAsync();
+      Assert.Equal(2, all.Count);
+    }
+
+    [Fact]
+    public async Task CreateOrGetCluster_Creates_New_When_Description_Differs()
+    {
+      // arrange
+      var clusterRepo = new InMemoryVariableClusterRepository();
+      var service = new ClusterService(clusterRepo);
+
+      var a = await service.CreateOrGetClusterAsync("C1", new[] { 1, 2, 3 }, "desc-1");
+      var b = await service.CreateOrGetClusterAsync("C1", new[] { 1, 2, 3 }, "desc-2");
+
+      // assert
+      Assert.NotEqual(a.Id, b.Id);
+
+      var all = await service.GetAllAsync();
+      Assert.Equal(2, all.Count);
+    }
+  }
+}

--- a/tests/ProgesiCore.Tests/ProgesiCore.Tests.csproj
+++ b/tests/ProgesiCore.Tests/ProgesiCore.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\ProgesiCore\ProgesiCore.csproj" />
+    <ProjectReference Include="..\..\src\ProgesiRepositories.InMemory\ProgesiRepositories.InMemory.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ProgesiCore.Tests/ProgesiVariableClusterTests.cs
+++ b/tests/ProgesiCore.Tests/ProgesiVariableClusterTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Linq;
+using ProgesiCore;
+using Xunit;
+
+namespace Progesi.Core.Tests.Variables
+{
+  public class ProgesiVariableClusterTests
+  {
+    [Fact]
+    public void CreateNew_Should_NormalizeIds()
+    {
+      // arrange
+      var ids = new[] { 3, 1, 2, 3 };
+
+      // act
+      var cluster = ProgesiVariableCluster.CreateNew("MyCluster", ids, "test");
+
+      // assert
+      cluster.ProgesiVariableIds.SequenceEqual(new[] { 1, 2, 3 }).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CreateNew_Should_Throw_If_Name_Is_Empty()
+    {
+      var ids = new[] { 1 };
+
+      Assert.Throws<ArgumentException>(() =>
+          ProgesiVariableCluster.CreateNew(string.Empty, ids));
+    }
+
+    [Fact]
+    public void CreateNew_Should_Throw_If_No_VariableIds()
+    {
+      Assert.Throws<ArgumentException>(() =>
+          ProgesiVariableCluster.CreateNew("MyCluster", Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void IsEquivalentTo_Should_Be_True_For_Same_Data_Different_Ids()
+    {
+      var ids = new[] { 1, 2, 3 };
+
+      var cluster1 = ProgesiVariableCluster.Rehydrate(1, "C1", ids, "desc");
+      var cluster2 = ProgesiVariableCluster.Rehydrate(99, "C1", ids, "desc");
+
+      cluster1.IsEquivalentTo(cluster2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void BuildHashtag_Should_Be_Deterministic()
+    {
+      var ids = new[] { 3, 1, 2 };
+
+      var c1 = ProgesiVariableCluster.Rehydrate(10, "C", ids, "d");
+      var c2 = ProgesiVariableCluster.Rehydrate(10, "C", new[] { 1, 2, 3 }, "d");
+
+      c1.Hashtag.ShouldBe(c2.Hashtag);
+    }
+  }
+
+  // Piccola estensione per evitare dipendenza da Shouldly
+  internal static class AssertExtensions
+  {
+    public static void ShouldBeTrue(this bool value)
+    {
+      Assert.True(value);
+    }
+
+    public static void ShouldBe(this string actual, string expected)
+    {
+      Assert.Equal(expected, actual);
+    }
+  }
+}


### PR DESCRIPTION
This PR restores ProgesiVariableCluster Phase 1 as a file-scoped port onto the current active line.

Scope:
- Restores Cluster core/domain model.
- Restores Cluster parser/naming/service logic.
- Restores in-memory Cluster repository.
- Adds narrow Rhino Cluster repository support required by the recovered GH components.
- Restores ClusterDef and ClusterOut Grasshopper components.
- Adds Cluster Phase 1 tests.
- Adds ProgesiClusters Excel export worksheet.
- Adds a Phase 1 governance exception documenting that this recovery is scoped and does not make Cluster generally complete.

Validation already performed:
- dotnet build -c Release passed.
- dotnet test -c Release passed: 88 total, 88 passed, 0 failed.
- Cluster filtered tests passed: 24 total, 24 passed, 0 failed.
- Manual Grasshopper validation by Gianluca:
  - ClusterDef / ClusterOut behaviour appeared satisfactory.
  - Excel export now includes ProgesiClusters sheet.
  - ProgesiVariables and ProgesiMetadata sheets remain present.
  - AxisVar was not involved.

This PR does not include:
- AxisVar work
- ProgesiAxisVariable work
- SQLite Cluster repository recovery
- EF / Progesi.Data.EF recovery
- Phase 2 or Phase 3 Cluster recovery
- wholesale merge from feat/dataex-sqlite-clusters
- DataExchange architecture refactor
- source cleanup
- solution/project-file broad changes
- deployment script changes
- artefacts

Important limitations:
- This is Phase 1 only.
- It does not claim full Cluster product/release validation.
- It does not recover SQLite Cluster repository or EF integration.
- It does not unfreeze AxisVar.
- Manual Test Matrix / final validation rows should be updated only after review/merge/post-merge verification.

Review notes:
- Review carefully for DataExchangeComponent changes.
- Review ProgesiHash change to confirm existing Var/Meta hash logic remains unchanged.
- Do not merge into main.
- Do not delete the branch after merge unless separately approved.