### PR TITLE
docs: reconcile governance after Cluster Phase 1 and ADR acceptance

### DIFF
--- a/.claude/agents/cursor-task-brief-writer.md
+++ b/.claude/agents/cursor-task-brief-writer.md
@@ -7,9 +7,9 @@ description: Use only when Gianluca explicitly asks for the cursor-task-brief-wr
 
 ## Standing constraints
 - AxisVar remains **frozen** and in abeyance.
-- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current test baseline: **64/64 passing at commit `376d81e`**.
+- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role

--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -7,9 +7,9 @@ description: Use only when Gianluca explicitly asks for the documentation-writer
 
 ## Standing constraints
 - AxisVar remains **frozen** and in abeyance.
-- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current test baseline: **64/64 passing at commit `376d81e`**.
+- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role

--- a/.claude/agents/git-governance-agent.md
+++ b/.claude/agents/git-governance-agent.md
@@ -7,9 +7,9 @@ description: Use only when Gianluca explicitly asks for the git-governance-agent
 
 ## Standing constraints
 - AxisVar remains **frozen** and in abeyance.
-- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current test baseline: **64/64 passing at commit `376d81e`**.
+- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role

--- a/.claude/agents/grasshopper-manual-test-designer.md
+++ b/.claude/agents/grasshopper-manual-test-designer.md
@@ -7,9 +7,9 @@ description: Use only when Gianluca explicitly asks for the grasshopper-manual-t
 
 ## Standing constraints
 - AxisVar remains **frozen** and in abeyance.
-- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current test baseline: **64/64 passing at commit `376d81e`**.
+- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role

--- a/.claude/agents/implementation-agent-disabled.md
+++ b/.claude/agents/implementation-agent-disabled.md
@@ -7,9 +7,9 @@ description: Disabled placeholder. Even if named explicitly, this agent must not
 
 ## Standing constraints
 - AxisVar remains **frozen** and in abeyance.
-- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current test baseline: **64/64 passing at commit `376d81e`**.
+- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role

--- a/.claude/agents/notion-project-curator.md
+++ b/.claude/agents/notion-project-curator.md
@@ -7,9 +7,9 @@ description: Use only when Gianluca explicitly asks for the notion-project-curat
 
 ## Standing constraints
 - AxisVar remains **frozen** and in abeyance.
-- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current test baseline: **64/64 passing at commit `376d81e`**.
+- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role

--- a/.claude/agents/progesi-architecture-reviewer.md
+++ b/.claude/agents/progesi-architecture-reviewer.md
@@ -7,9 +7,9 @@ description: Use only when Gianluca explicitly asks for the progesi-architecture
 
 ## Standing constraints
 - AxisVar remains **frozen** and in abeyance.
-- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current test baseline: **64/64 passing at commit `376d81e`**.
+- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role

--- a/.claude/agents/progesi-strategy-planner.md
+++ b/.claude/agents/progesi-strategy-planner.md
@@ -7,9 +7,9 @@ description: Use only when Gianluca explicitly asks for the progesi-strategy-pla
 
 ## Standing constraints
 - AxisVar remains **frozen** and in abeyance.
-- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current test baseline: **64/64 passing at commit `376d81e`**.
+- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role

--- a/.claude/agents/regression-guard.md
+++ b/.claude/agents/regression-guard.md
@@ -7,9 +7,9 @@ description: Use only when Gianluca explicitly asks for the regression-guard age
 
 ## Standing constraints
 - AxisVar remains **frozen** and in abeyance.
-- ProgesiVariableCluster is a **missing capability / suspected regression** — not implemented.
+- ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current test baseline: **64/64 passing at commit `376d81e`**.
+- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role
@@ -18,7 +18,7 @@ Run and interpret build/test checks when explicitly instructed, and compare agai
 ## Allowed actions during current handover
 - No automatic execution.
 - When explicitly instructed: run `dotnet build -c Release` and `dotnet test`.
-- Compare results against the `376d81e` baseline (64/64).
+- Compare results against the current operating baseline (**88/88 at `6286aec`**); `376d81e` (64/64) remains the historical checkpoint per ADR-010.
 
 ## Forbidden actions
 - No fixes. No source edits. No test edits.
@@ -33,7 +33,7 @@ Run and interpret build/test checks when explicitly instructed, and compare agai
 - the current task row
 
 ## Required output format
-- Command(s) run, pass/fail counts, comparison to baseline (64/64), and any deltas — with no remediation performed.
+- Command(s) run, pass/fail counts, comparison to the current operating baseline (88/88 at `6286aec`), and any deltas — with no remediation performed.
 
 ## Stop conditions
 - Asked to fix failures, edit code/tests, or run without explicit instruction. Stop and report.

--- a/.cursor/rules/progesi-architecture.mdc
+++ b/.cursor/rules/progesi-architecture.mdc
@@ -9,9 +9,9 @@ These rules are authoritative for Cursor in this repository. If a request confli
 
 ## Standing facts (always true)
 - AxisVar is **frozen** — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
-- ProgesiVariableCluster is a **missing capability / suspected regression** — it is not in the current repository and is **not implemented**.
+- ProgesiVariableCluster: **Phase 1 recovered and closed** for the submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) are not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current test baseline is **64/64 passing at commit `376d81e`**.
+- Current operating baseline is **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); the historical protected source-code checkpoint remains **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Core independence

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,9 @@ Agents are assistants, **not autonomous project owners**. Nothing here enables a
 
 ## Standing constraints (apply to all agents)
 - AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
-- ProgesiVariableCluster is a **missing capability / suspected regression** — not present in the current repository and not implemented.
+- ProgesiVariableCluster: **Phase 1 recovered and closed** for the submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) are not recovered** and remain blocked. Not full release validation. See the Phase 1 exception below and the dated reconciliation section at the end of this file.
 - DataExchange is **not** a Core domain object — it is the interchange boundary.
-- Current test baseline: **64/64 passing at commit `376d81e`**.
+- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); the historical protected source-code checkpoint remains **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Principles
@@ -115,3 +115,21 @@ Agents may route Phase 1 only if:
 - Phase 2/3 remain blocked
 
 The Orchestrator may prepare/reroute Phase 1 prompts but must not execute implementation.
+
+## Current operating baseline and status — reconciliation (2026-07-15)
+
+This section reconciles the standing constraints above with the current post-Cluster-Phase-1 / post-ADR-acceptance state. Where earlier text names `376d81e` / 64/64 as the *current* baseline, treat that wording as **historical**. This section does **not** weaken any standing constraint, the AxisVar freeze, the implementation prompt guard, the Phase 1 exception, or any agent maturity/limit. It grants no new authorisation and enables no autonomy.
+
+1. **Baselines.** Current operating baseline: **88/88 tests passing at `6286aec`** (after PR #63 / Cluster Phase 1). Historical protected source-code checkpoint: **64/64 at `376d81e`** on `feat/axis-variable-core`.
+
+2. **ProgesiVariableCluster.** Phase 1 is **recovered and closed** for the submitted/manual-validation scenarios (GH-CLUSTER-001..004 recorded Passed). **Phase 2 (SQLite) and Phase 3 (EF / DataExchange) are not recovered and remain blocked** until separately approved. Not a full release-validation sign-off. The Phase 1 exception above remains in force; the Orchestrator still must not execute implementation.
+
+3. **ADR acceptance posture.** The three consolidation ADRs are **Accepted as interim / direction-setting** only (no implementation authority): DataExchange (interim A+E interchange boundary; target Option D); EF/SQLite (EF long-term target; SQLite interim canonical; EF retirement deferred); ProgesiDomainServices / ADR-009 (Option C direction accepted, consolidation planned not implemented). Agents may reference these directions but must still route any implementation through an approved brief, branch, tests, and human approval in 05. Cursor Bridge.
+
+4. **AxisVar.** Remains **frozen and in abeyance**. No agent may touch AxisVar.
+
+5. **Agents and Notion Curator.** All agents remain **controlled and human-gated** at their documented maturity levels; no autonomous Task Board execution; `implementation-agent-disabled` stays disabled; the Notion Curator operates only within its approved controlled-write scope.
+
+6. **`main` and any beta/release line.** Future-only — no merge to `main` and no release tagging is authorised here.
+
+7. **No new authorisation.** This section records state only; it authorises no implementation, cleanup, ADR-driven code change, branch/tag cleanup, or scope broadening.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,9 +5,9 @@ If anything here conflicts with Notion, **stop and report** before acting.
 
 ## Standing constraints (apply to all work)
 - AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
-- ProgesiVariableCluster is a **missing capability / suspected regression** — it is not present in the current repository and must not be treated as implemented.
+- ProgesiVariableCluster: **Phase 1 recovered and closed** for the submitted/manual-validation scenarios (Core model/service, InMemory repository, narrow Rhino support repository, ClusterDef/ClusterOut components, `ProgesiClusters` Excel export, and Cluster tests). **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) are not recovered** and remain blocked. This is not full release validation. See the Phase 1 recovery exception below and the dated reconciliation section at the end of this file.
 - DataExchange is **not** a Core domain object — it is the interchange boundary.
-- Current test baseline: **64/64 passing at commit `376d81e`** (protected checkpoint on `feat/axis-variable-core`).
+- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1). The historical protected source-code checkpoint remains **64/64 at `376d81e`** on `feat/axis-variable-core`.
 - **No code cleanup is authorised yet.**
 
 ## 1. Current mode
@@ -68,7 +68,7 @@ Read-only inspection and documentation are allowed. The freeze lifts only after 
 
 ## 7. Build/test commands
 - Run build/test **only when explicitly instructed**.
-- Canonical baseline: `dotnet build -c Release` then `dotnet test` → **64 tests passing** at commit `376d81e`.
+- Canonical commands: `dotnet build -c Release` then `dotnet test`. Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1). Historical protected source-code checkpoint: **64/64 at `376d81e`**.
 - Never run Rhino or Grasshopper from here.
 
 ## 8. Reporting requirements
@@ -106,3 +106,25 @@ This exception does not authorise:
 AxisVar remains frozen.
 
 Phase 2 and Phase 3 remain blocked until separately approved.
+
+## Current operating baseline and status — reconciliation (2026-07-15)
+
+This section reconciles the standing constraints and mode notes above with the current post-Cluster-Phase-1 / post-ADR-acceptance state. Where earlier text names `376d81e` / 64/64 as the *current* baseline, or describes the mode as "no-code handover", treat that wording as **historical**; the current operating state is recorded here. This section does **not** weaken any standing constraint, the AxisVar freeze, the implementation prompt guard (§9), or the ProgesiVariableCluster Phase 1 recovery exception above. It grants no new authorisation.
+
+1. **Baselines.** Current operating baseline: **88/88 tests passing at `6286aec`** (state after the PR #63 / Cluster Phase 1 merge). Historical protected source-code checkpoint: **64/64 at `376d81e`** on `feat/axis-variable-core` — retained as the pre-Cluster reference, not the current count. §1 "Current mode" predates ADR acceptance and Cluster Phase 1 and is superseded by this section for current-state purposes.
+
+2. **ProgesiVariableCluster.** Phase 1 is **recovered and closed** for the submitted and manually validated scenarios (Core model/service, InMemory repository, narrow Rhino support repository, ClusterDef/ClusterOut Grasshopper components, `ProgesiClusters` Excel export, Cluster tests; GH-CLUSTER-001..004 recorded Passed). **Phase 2 (SQLite persistence) and Phase 3 (EF / DataExchange) are not recovered and remain blocked** until separately approved. This is not a full release-validation sign-off. The Phase 1 recovery exception above remains in force exactly as written.
+
+3. **ADR acceptance posture.** The three consolidation ADRs are now **Accepted as interim / direction-setting** — acceptance sets direction only and authorises no implementation:
+   - **DataExchange ADR** — interim: keep DataExchange as the interchange boundary (Options A + E); long-term target is Option D.
+   - **EF / SQLite ADR** — EF is the **long-term target**; the SQLite repository remains the **interim canonical** persistence; EF retirement is deferred and there is no near-term SQLite retirement.
+   - **ProgesiDomainServices ADR (ADR-009)** — Option C direction accepted; consolidation is planned, not yet implemented.
+   Any implementation flowing from these ADRs still requires an approved Task Board row, a branch, a task brief, tests, and human approval, and must run in 05. Cursor Bridge — never in 00. Controlled Writes.
+
+4. **AxisVar.** Remains **frozen and in abeyance** exactly as in §5. Nothing here lifts that freeze.
+
+5. **Agents and Notion Curator.** All agents remain **controlled and human-gated** at their documented maturity levels (see `AGENTS.md`); no autonomous Task Board execution; implementation agents remain disabled; the Notion Curator operates only within its approved controlled-write scope.
+
+6. **`main` and any beta/release line.** Untouched by this work and **future-only** — no merge to `main` and no release tagging is authorised by this reconciliation.
+
+7. **No new authorisation.** This section records state; it authorises no code cleanup, no ADR-driven implementation, no branch/tag cleanup, and no scope broadening.

--- a/docs/claude-governance.md
+++ b/docs/claude-governance.md
@@ -4,9 +4,9 @@ Detailed governance for Claude Code on the Progesi Toolkit, derived from the Not
 
 ## Standing constraints (apply to all work)
 - AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
-- ProgesiVariableCluster is a **missing capability / suspected regression** — not present in the current repository and not implemented.
+- ProgesiVariableCluster: **Phase 1 recovered and closed** for the submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) are not recovered** and remain blocked. Not full release validation. See the Phase 1 recovery exception in `CLAUDE.md`.
 - DataExchange is **not** a Core domain object — it is the interchange boundary.
-- Current test baseline: **64/64 passing at commit `376d81e`**.
+- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); the historical protected source-code checkpoint remains **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Tool roles

--- a/docs/cursor-interface-protocol.md
+++ b/docs/cursor-interface-protocol.md
@@ -4,9 +4,9 @@ This document defines the boundary between Claude and Cursor. It complements `do
 
 ## Standing constraints (apply to all work)
 - AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
-- ProgesiVariableCluster is a **missing capability / suspected regression** — not present in the current repository and not implemented.
+- ProgesiVariableCluster: **Phase 1 recovered and closed** for the submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) are not recovered** and remain blocked. Not full release validation. See the Phase 1 recovery exception in `CLAUDE.md`.
 - DataExchange is **not** a Core domain object — it is the interchange boundary.
-- Current test baseline: **64/64 passing at commit `376d81e`**.
+- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); the historical protected source-code checkpoint remains **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## No direct control requirement

--- a/docs/repository-cleanup-protocol.md
+++ b/docs/repository-cleanup-protocol.md
@@ -4,9 +4,9 @@ Safe, staged process for any future repository cleanup (source or GitHub). Nothi
 
 ## Standing constraints (apply to all work)
 - AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
-- ProgesiVariableCluster is a **missing capability / suspected regression** — not present in the current repository and not implemented.
+- ProgesiVariableCluster: **Phase 1 recovered and closed** for the submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) are not recovered** and remain blocked. Not full release validation. See the Phase 1 recovery exception in `CLAUDE.md`.
 - DataExchange is **not** a Core domain object — it is the interchange boundary.
-- Current test baseline: **64/64 passing at commit `376d81e`**.
+- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); the historical protected source-code checkpoint remains **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Core principles
@@ -20,7 +20,7 @@ Safe, staged process for any future repository cleanup (source or GitHub). Nothi
 ## Source cleanup requirements
 Any source cleanup requires:
 - an approved branch and explicit scope (allowed/forbidden files),
-- tests to run (baseline 64/64 must be preserved unless a change is explicitly approved),
+- tests to run (current operating baseline 88/88 at `6286aec` must be preserved unless a change is explicitly approved),
 - manual Grasshopper validation if any GH-facing code is affected,
 - a rollback plan,
 - human approval.

--- a/docs/strategic-planning-prompt.md
+++ b/docs/strategic-planning-prompt.md
@@ -26,7 +26,7 @@ Current standing rules:
 - Core must remain independent of Rhino, Grasshopper, Excel, EF, UI, SQLite-specific packages and ASP.NET.
 - DataExchange is not Core.
 - AxisVar is frozen.
-- ProgesiVariableCluster is missing / suspected regression.
+- ProgesiVariableCluster Phase 1 is recovered and closed for submitted/manual-validation scenarios; Phase 2 (SQLite) and Phase 3 (EF/DataExchange) remain blocked.
 - Cursor is read-only unless explicitly approved.
 - Source cleanup requires ADRs, human approval, branch, tests and rollback plan.
 - Manual Grasshopper validation is required before GH-facing release confidence.

--- a/docs/task-brief-template.md
+++ b/docs/task-brief-template.md
@@ -5,9 +5,9 @@ Copy this template per task. A brief is only actionable after **Human approval s
 
 ## Standing constraints (apply to every brief)
 - AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
-- ProgesiVariableCluster is a **missing capability / suspected regression** — not present in the current repository and not implemented.
+- ProgesiVariableCluster: **Phase 1 recovered and closed** for the submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) are not recovered** and remain blocked. Not full release validation. See the Phase 1 recovery exception in `CLAUDE.md`.
 - DataExchange is **not** a Core domain object — it is the interchange boundary.
-- Current test baseline: **64/64 passing at commit `376d81e`**.
+- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); the historical protected source-code checkpoint remains **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ---
@@ -43,7 +43,7 @@ Copy this template per task. A brief is only actionable after **Human approval s
 <bullet list of objectively checkable outcomes>
 
 ## Tests to run
-<exact commands, e.g. `dotnet build -c Release`, `dotnet test`; expected: baseline 64/64 unless the task adds tests>
+<exact commands, e.g. `dotnet build -c Release`, `dotnet test`; expected: current operating baseline **88/88 at `6286aec`** unless the task adds tests (historical checkpoint: 64/64 at `376d81e`)>
 
 ## Manual validation required
 <Grasshopper Manual Test Matrix rows / procedures, if GH is affected; otherwise "None">


### PR DESCRIPTION
This PR reconciles repository governance documentation with the current post-Cluster Phase 1 and post-consolidation-ADR operating state.

Scope:
- Updates governance docs to distinguish:
  - 376d81e / 64-test state as historical protected source-code checkpoint where relevant
  - 6286aec / 88-test state as current operating baseline after PR #63
- Records that ProgesiVariableCluster Phase 1 is closed for submitted/manual validation scenarios.
- Records that Cluster Phase 2 SQLite repository and Phase 3 EF/DataExchange are not recovered.
- Records that DataExchange, EF/SQLite and ProgesiDomainServices ADRs are accepted as interim / direction-setting ADRs only.
- Preserves AxisVar freeze.
- Preserves implementation prompt guard and Cursor approval rules.
- Preserves the rule that agents are controlled roles, not autonomous workers.
- Clarifies that no implementation, cleanup, GitHub cleanup, Cluster Phase 2/3, AxisVar work, or main merge is authorised by the accepted ADR posture.

Validation already performed:
- dotnet build -c Release passed.
- dotnet test -c Release passed: 88 total, 88 passed, 0 failed.

This PR does not modify:
- source code
- tests
- solution files
- project files
- scripts
- deployment files
- package files
- artefacts
- AxisVar files
- ProgesiVariableCluster implementation files

Review notes:
- This is documentation/governance only.
- Do not merge into main.
- Do not delete the branch after merge unless separately approved.
- This PR does not enable autonomous agents or implementation authority.