### PR TITLE
test: add DataExchange and Tier 1-2 test scaffolding

### DIFF
--- a/Progesi.CI.slnf
+++ b/Progesi.CI.slnf
@@ -4,7 +4,8 @@
     "projects": [
       "src\\ProgesiCore\\ProgesiCore.csproj",
       "src\\ProgesiRepositories.InMemory\\ProgesiRepositories.InMemory.csproj",
-      "tests\\ProgesiCore.Tests\\ProgesiCore.Tests.csproj"
+      "tests\\ProgesiCore.Tests\\ProgesiCore.Tests.csproj",
+      "tests\\ProgesiDataExchange.Tests\\ProgesiDataExchange.Tests.csproj"
     ]
   }
 }

--- a/Progesi.sln
+++ b/Progesi.sln
@@ -33,6 +33,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Progesi.EF.Tool", "src\Progesi.EF.Tool\Progesi.EF.Tool.csproj", "{91AB0E1A-4CD4-4241-89B6-AE08AC1CBD9B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProgesiDataExchange.Tests", "tests\ProgesiDataExchange.Tests\ProgesiDataExchange.Tests.csproj", "{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -199,6 +203,18 @@ Global
 		{91AB0E1A-4CD4-4241-89B6-AE08AC1CBD9B}.Release|x64.Build.0 = Release|Any CPU
 		{91AB0E1A-4CD4-4241-89B6-AE08AC1CBD9B}.Release|x86.ActiveCfg = Release|Any CPU
 		{91AB0E1A-4CD4-4241-89B6-AE08AC1CBD9B}.Release|x86.Build.0 = Release|Any CPU
+		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1}.Debug|x64.Build.0 = Debug|Any CPU
+		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1}.Debug|x86.Build.0 = Debug|Any CPU
+		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1}.Release|x64.ActiveCfg = Release|Any CPU
+		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1}.Release|x64.Build.0 = Release|Any CPU
+		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1}.Release|x86.ActiveCfg = Release|Any CPU
+		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -206,6 +222,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{B79C1976-E4EC-4AAD-B77D-8CE2F5F7A673} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
 		{91AB0E1A-4CD4-4241-89B6-AE08AC1CBD9B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C753CED5-7508-4B2A-A107-C1E530FD786B}

--- a/tests/ProgesiCore.Tests/InMemoryVariableClusterRepositoryTests.cs
+++ b/tests/ProgesiCore.Tests/InMemoryVariableClusterRepositoryTests.cs
@@ -1,0 +1,75 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ProgesiCore;
+using ProgesiRepositories.InMemory;
+using Xunit;
+
+namespace ProgesiCore.Tests
+{
+  public class InMemoryVariableClusterRepositoryTests
+  {
+    [Fact]
+    public async Task SaveAsync_Then_GetByIdAsync_RoundTrips_Cluster()
+    {
+      var repo = new InMemoryVariableClusterRepository();
+      var cluster = ProgesiVariableCluster.Rehydrate(7, "RepoC", new[] { 1, 2 }, "desc");
+
+      await repo.SaveAsync(cluster);
+      var loaded = await repo.GetByIdAsync(7);
+
+      loaded.Should().NotBeNull();
+      loaded!.Name.Should().Be("RepoC");
+      loaded.ProgesiVariableIds.Should().Equal(1, 2);
+    }
+
+    [Fact]
+    public async Task GetByHashtagAsync_Finds_Saved_Cluster()
+    {
+      var repo = new InMemoryVariableClusterRepository();
+      var cluster = ProgesiVariableCluster.Rehydrate(3, "HashC", new[] { 9 }, null);
+      await repo.SaveAsync(cluster);
+
+      var loaded = await repo.GetByHashtagAsync(cluster.Hashtag);
+
+      loaded.Should().NotBeNull();
+      loaded!.Id.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_Returns_All_Saved_Clusters()
+    {
+      var repo = new InMemoryVariableClusterRepository();
+      await repo.SaveAsync(ProgesiVariableCluster.Rehydrate(1, "A", new[] { 1 }, null));
+      await repo.SaveAsync(ProgesiVariableCluster.Rehydrate(2, "B", new[] { 2 }, null));
+
+      var all = await repo.GetAllAsync();
+
+      all.Should().HaveCount(2);
+      all.Select(c => c.Id).Should().BeEquivalentTo(new[] { 1, 2 });
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Removes_Cluster()
+    {
+      var repo = new InMemoryVariableClusterRepository();
+      await repo.SaveAsync(ProgesiVariableCluster.Rehydrate(4, "Del", new[] { 1 }, null));
+
+      (await repo.DeleteAsync(4)).Should().BeTrue();
+      (await repo.GetByIdAsync(4)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteManyAsync_Removes_Only_Existing_Ids()
+    {
+      var repo = new InMemoryVariableClusterRepository();
+      await repo.SaveAsync(ProgesiVariableCluster.Rehydrate(1, "A", new[] { 1 }, null));
+      await repo.SaveAsync(ProgesiVariableCluster.Rehydrate(2, "B", new[] { 2 }, null));
+
+      var removed = await repo.DeleteManyAsync(new[] { 1, 99, 2 });
+
+      removed.Should().Be(2);
+      (await repo.GetAllAsync()).Should().BeEmpty();
+    }
+  }
+}

--- a/tests/ProgesiCore.Tests/ProgesiHashClusterTests.cs
+++ b/tests/ProgesiCore.Tests/ProgesiHashClusterTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using ProgesiCore;
+using Xunit;
+
+namespace ProgesiCore.Tests
+{
+  public class ProgesiHashClusterTests
+  {
+    [Fact]
+    public void Compute_Cluster_Throws_On_Null()
+    {
+      System.Action act = () => ProgesiHash.Compute((ProgesiVariableCluster)null!);
+      act.Should().Throw<System.ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Compute_Cluster_OrderIndependent_For_VariableIds()
+    {
+      var a = ProgesiVariableCluster.Rehydrate(1, "C1", new[] { 3, 1, 2 }, "desc");
+      var b = ProgesiVariableCluster.Rehydrate(1, "C1", new[] { 1, 2, 3 }, "desc");
+
+      ProgesiHash.Compute(a).Should().Be(ProgesiHash.Compute(b));
+    }
+
+    [Fact]
+    public void Compute_Cluster_Sensitive_To_Name_And_Description()
+    {
+      var baseline = ProgesiVariableCluster.Rehydrate(1, "C1", new[] { 1, 2 }, "desc");
+      var renamed = ProgesiVariableCluster.Rehydrate(1, "C2", new[] { 1, 2 }, "desc");
+      var redesc = ProgesiVariableCluster.Rehydrate(1, "C1", new[] { 1, 2 }, "other");
+
+      ProgesiHash.Compute(baseline).Should().NotBe(ProgesiHash.Compute(renamed));
+      ProgesiHash.Compute(baseline).Should().NotBe(ProgesiHash.Compute(redesc));
+    }
+
+    [Fact]
+    public void Compute_Cluster_Is_Deterministic()
+    {
+      var cluster = ProgesiVariableCluster.CreateNew("Stable", new[] { 5, 4 }, "note");
+      var first = ProgesiHash.Compute(cluster);
+      var second = ProgesiHash.Compute(cluster);
+
+      first.Should().Be(second);
+      first.Should().NotBeNullOrWhiteSpace();
+    }
+  }
+}

--- a/tests/ProgesiDataExchange.Tests/ExcelSerializerMetadataSheetTests.cs
+++ b/tests/ProgesiDataExchange.Tests/ExcelSerializerMetadataSheetTests.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Linq;
+using ClosedXML.Excel;
+using FluentAssertions;
+using Progesi.DataExchange;
+using Xunit;
+
+namespace Progesi.DataExchange.Tests
+{
+  public class ExcelSerializerMetadataSheetTests
+  {
+    private static readonly string[] ExpectedHeaders =
+    {
+      "Id", "Hash", "Info", "By", "Ref", "LastModifiedUtc"
+    };
+
+    [Fact]
+    public void Write_MetadataSheet_Uses_ProgesiMetadata_Name_And_Expected_Headers()
+    {
+      using var file = new ExcelTestFile();
+      var metas = new[]
+      {
+        new ProgesiMetadataDto
+        {
+          Id = "10",
+          Hash = "mh1",
+          Info = "Project notes",
+          By = "author",
+          Ref = "ref-m",
+          LastModifiedUtc = "2026-02-01T00:00:00Z"
+        }
+      };
+
+      ExcelSerializer.Write(file.Path, System.Array.Empty<ProgesiVariableDto>(), metas, System.Array.Empty<ProgesiAxisVariableDto>());
+
+      using var wb = new XLWorkbook(file.Path);
+      wb.Worksheets.Should().Contain(ws => ws.Name == "ProgesiMetadata");
+
+      var sheet = wb.Worksheet("ProgesiMetadata");
+      sheet.Row(1).Cells(1, ExpectedHeaders.Length)
+        .Select(c => c.GetString())
+        .Should().Equal(ExpectedHeaders);
+
+      sheet.Cell(2, 1).GetString().Should().Be("10");
+      sheet.Cell(2, 3).GetString().Should().Be("Project notes");
+      sheet.Cell(2, 4).GetString().Should().Be("author");
+    }
+
+    [Fact]
+    public void Write_Empty_Metadata_List_Still_Writes_Header_Row()
+    {
+      using var file = new ExcelTestFile();
+      ExcelSerializer.Write(file.Path, new List<ProgesiVariableDto>(), new List<ProgesiMetadataDto>(), new List<ProgesiAxisVariableDto>());
+
+      using var wb = new XLWorkbook(file.Path);
+      var sheet = wb.Worksheet("ProgesiMetadata");
+      sheet.LastRowUsed()!.RowNumber().Should().Be(1);
+    }
+  }
+}

--- a/tests/ProgesiDataExchange.Tests/ExcelSerializerReadBehaviourTests.cs
+++ b/tests/ProgesiDataExchange.Tests/ExcelSerializerReadBehaviourTests.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using ClosedXML.Excel;
+using FluentAssertions;
+using Progesi.DataExchange;
+using Xunit;
+
+namespace Progesi.DataExchange.Tests
+{
+  public class ExcelSerializerReadBehaviourTests
+  {
+    [Fact]
+    public void Read_Missing_Variable_Sheet_Returns_Empty_Variable_List()
+    {
+      using var file = new ExcelTestFile();
+      using (var wb = new XLWorkbook())
+      {
+        var ws = wb.Worksheets.Add("ProgesiMetadata");
+        ws.Cell(1, 1).Value = "Id";
+        ws.Cell(1, 2).Value = "Hash";
+        ws.Cell(1, 3).Value = "Info";
+        ws.Cell(2, 1).Value = "1";
+        ws.Cell(2, 3).Value = "only-meta";
+        wb.SaveAs(file.Path);
+      }
+
+      var (vars, mets, axis) = ExcelSerializer.Read(file.Path);
+
+      vars.Should().BeEmpty();
+      mets.Should().HaveCount(1);
+      mets[0].Info.Should().Be("only-meta");
+      axis.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Read_Missing_Metadata_Sheet_Returns_Empty_Metadata_List()
+    {
+      using var file = new ExcelTestFile();
+      using (var wb = new XLWorkbook())
+      {
+        var ws = wb.Worksheets.Add("ProgesiVariable");
+        ws.Cell(1, 1).Value = "Id";
+        ws.Cell(1, 2).Value = "Hash";
+        ws.Cell(1, 3).Value = "Name";
+        ws.Cell(2, 1).Value = "1";
+        ws.Cell(2, 3).Value = "only-var";
+        wb.SaveAs(file.Path);
+      }
+
+      var (vars, mets, axis) = ExcelSerializer.Read(file.Path);
+
+      vars.Should().HaveCount(1);
+      vars[0].Name.Should().Be("only-var");
+      mets.Should().BeEmpty();
+      axis.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Read_HeaderOnly_Variable_Sheet_Returns_Empty_Variable_List()
+    {
+      using var file = new ExcelTestFile();
+      ExcelSerializer.Write(file.Path, new List<ProgesiVariableDto>(), new List<ProgesiMetadataDto>(), new List<ProgesiAxisVariableDto>());
+
+      var (vars, _, _) = ExcelSerializer.Read(file.Path);
+
+      vars.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Read_HeaderOnly_Metadata_Sheet_Returns_Empty_Metadata_List()
+    {
+      using var file = new ExcelTestFile();
+      ExcelSerializer.Write(file.Path, new List<ProgesiVariableDto>(), new List<ProgesiMetadataDto>(), new List<ProgesiAxisVariableDto>());
+
+      var (_, mets, _) = ExcelSerializer.Read(file.Path);
+
+      mets.Should().BeEmpty();
+    }
+  }
+}

--- a/tests/ProgesiDataExchange.Tests/ExcelSerializerRoundTripTests.cs
+++ b/tests/ProgesiDataExchange.Tests/ExcelSerializerRoundTripTests.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Progesi.DataExchange;
+using Xunit;
+
+namespace Progesi.DataExchange.Tests
+{
+  public class ExcelSerializerRoundTripTests
+  {
+    [Fact]
+    public void RoundTrip_Variables_Preserves_Field_Values()
+    {
+      using var file = new ExcelTestFile();
+      var original = new List<ProgesiVariableDto>
+      {
+        new ProgesiVariableDto
+        {
+          Id = "7",
+          Hash = "vh7",
+          Name = "Load",
+          Value = "42",
+          Unit = "kN",
+          By = "eng",
+          Ref = "r1",
+          LastModifiedUtc = "2026-03-01T10:00:00Z"
+        }
+      };
+
+      ExcelSerializer.Write(file.Path, original, new List<ProgesiMetadataDto>(), new List<ProgesiAxisVariableDto>());
+      var (vars, _, _) = ExcelSerializer.Read(file.Path);
+
+      vars.Should().HaveCount(1);
+      vars[0].Id.Should().Be("7");
+      vars[0].Hash.Should().Be("vh7");
+      vars[0].Name.Should().Be("Load");
+      vars[0].Value.Should().Be("42");
+      vars[0].Unit.Should().Be("kN");
+      vars[0].By.Should().Be("eng");
+      vars[0].Ref.Should().Be("r1");
+      vars[0].LastModifiedUtc.Should().Be("2026-03-01T10:00:00Z");
+    }
+
+    [Fact]
+    public void RoundTrip_Metadata_Preserves_Field_Values()
+    {
+      using var file = new ExcelTestFile();
+      var original = new List<ProgesiMetadataDto>
+      {
+        new ProgesiMetadataDto
+        {
+          Id = "3",
+          Hash = "mh3",
+          Info = "Bridge span",
+          By = "planner",
+          Ref = "doc-3",
+          LastModifiedUtc = "2026-04-01T12:00:00Z"
+        }
+      };
+
+      ExcelSerializer.Write(file.Path, new List<ProgesiVariableDto>(), original, new List<ProgesiAxisVariableDto>());
+      var (_, mets, _) = ExcelSerializer.Read(file.Path);
+
+      mets.Should().HaveCount(1);
+      mets[0].Id.Should().Be("3");
+      mets[0].Hash.Should().Be("mh3");
+      mets[0].Info.Should().Be("Bridge span");
+      mets[0].By.Should().Be("planner");
+      mets[0].Ref.Should().Be("doc-3");
+      mets[0].LastModifiedUtc.Should().Be("2026-04-01T12:00:00Z");
+    }
+
+    [Fact]
+    public void RoundTrip_Variables_Preserves_Write_Order_Not_Sorted_By_Id()
+    {
+      using var file = new ExcelTestFile();
+      var original = new List<ProgesiVariableDto>
+      {
+        new ProgesiVariableDto { Id = "30", Name = "Third", Value = "3" },
+        new ProgesiVariableDto { Id = "10", Name = "First", Value = "1" },
+        new ProgesiVariableDto { Id = "20", Name = "Second", Value = "2" }
+      };
+
+      ExcelSerializer.Write(file.Path, original, new List<ProgesiMetadataDto>(), new List<ProgesiAxisVariableDto>());
+      var (vars, _, _) = ExcelSerializer.Read(file.Path);
+
+      vars.Select(v => v.Id).Should().Equal("30", "10", "20");
+      vars.Select(v => v.Name).Should().Equal("Third", "First", "Second");
+    }
+
+    [Fact]
+    public void RoundTrip_Metadata_Preserves_Write_Order()
+    {
+      using var file = new ExcelTestFile();
+      var original = new List<ProgesiMetadataDto>
+      {
+        new ProgesiMetadataDto { Id = "9", Info = "Z" },
+        new ProgesiMetadataDto { Id = "1", Info = "A" },
+        new ProgesiMetadataDto { Id = "5", Info = "M" }
+      };
+
+      ExcelSerializer.Write(file.Path, new List<ProgesiVariableDto>(), original, new List<ProgesiAxisVariableDto>());
+      var (_, mets, _) = ExcelSerializer.Read(file.Path);
+
+      mets.Select(m => m.Id).Should().Equal("9", "1", "5");
+      mets.Select(m => m.Info).Should().Equal("Z", "A", "M");
+    }
+
+    [Fact]
+    public void RoundTrip_Var_And_Meta_Together_Preserves_Both_Collections()
+    {
+      using var file = new ExcelTestFile();
+      var vars = new List<ProgesiVariableDto>
+      {
+        new ProgesiVariableDto { Id = "1", Name = "V1", Value = "x" }
+      };
+      var mets = new List<ProgesiMetadataDto>
+      {
+        new ProgesiMetadataDto { Id = "2", Info = "M1" }
+      };
+
+      ExcelSerializer.Write(file.Path, vars, mets, new List<ProgesiAxisVariableDto>());
+      var (readVars, readMets, axis) = ExcelSerializer.Read(file.Path);
+
+      readVars.Should().HaveCount(1);
+      readMets.Should().HaveCount(1);
+      readVars[0].Name.Should().Be("V1");
+      readMets[0].Info.Should().Be("M1");
+      axis.Should().BeEmpty();
+    }
+  }
+}

--- a/tests/ProgesiDataExchange.Tests/ExcelSerializerVariableSheetTests.cs
+++ b/tests/ProgesiDataExchange.Tests/ExcelSerializerVariableSheetTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Linq;
+using ClosedXML.Excel;
+using FluentAssertions;
+using Progesi.DataExchange;
+using Xunit;
+
+namespace Progesi.DataExchange.Tests
+{
+  public class ExcelSerializerVariableSheetTests
+  {
+    private static readonly string[] ExpectedHeaders =
+    {
+      "Id", "Hash", "Name", "Value", "Unit", "By", "Ref", "LastModifiedUtc"
+    };
+
+    [Fact]
+    public void Write_VariableSheet_Uses_ProgesiVariable_Name_And_Expected_Headers()
+    {
+      using var file = new ExcelTestFile();
+      var vars = new[]
+      {
+        new ProgesiVariableDto
+        {
+          Id = "1",
+          Hash = "h1",
+          Name = "Width",
+          Value = "12.5",
+          Unit = "m",
+          By = "tester",
+          Ref = "ref-a",
+          LastModifiedUtc = "2026-01-01T00:00:00Z"
+        }
+      };
+
+      ExcelSerializer.Write(file.Path, vars, System.Array.Empty<ProgesiMetadataDto>(), System.Array.Empty<ProgesiAxisVariableDto>());
+
+      using var wb = new XLWorkbook(file.Path);
+      wb.Worksheets.Should().Contain(ws => ws.Name == "ProgesiVariable");
+
+      var sheet = wb.Worksheet("ProgesiVariable");
+      sheet.Cell(1, 1).GetString().Should().Be("Id");
+      sheet.Row(1).Cells(1, ExpectedHeaders.Length)
+        .Select(c => c.GetString())
+        .Should().Equal(ExpectedHeaders);
+
+      sheet.Cell(2, 1).GetString().Should().Be("1");
+      sheet.Cell(2, 3).GetString().Should().Be("Width");
+      sheet.Cell(2, 4).GetString().Should().Be("12.5");
+    }
+
+    [Fact]
+    public void Write_Empty_Variable_List_Still_Writes_Header_Row()
+    {
+      using var file = new ExcelTestFile();
+      ExcelSerializer.Write(file.Path, new List<ProgesiVariableDto>(), new List<ProgesiMetadataDto>(), new List<ProgesiAxisVariableDto>());
+
+      using var wb = new XLWorkbook(file.Path);
+      var sheet = wb.Worksheet("ProgesiVariable");
+      sheet.LastRowUsed()!.RowNumber().Should().Be(1);
+    }
+  }
+}

--- a/tests/ProgesiDataExchange.Tests/ExcelTestFile.cs
+++ b/tests/ProgesiDataExchange.Tests/ExcelTestFile.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+
+namespace Progesi.DataExchange.Tests
+{
+  internal sealed class ExcelTestFile : IDisposable
+  {
+    public string Path { get; }
+
+    public ExcelTestFile(string? suffix = null)
+    {
+      Path = System.IO.Path.Combine(
+        System.IO.Path.GetTempPath(),
+        $"progesi-dataex-test-{Guid.NewGuid():N}{suffix ?? ".xlsx"}");
+    }
+
+    public void Dispose()
+    {
+      try
+      {
+        if (File.Exists(Path))
+          File.Delete(Path);
+      }
+      catch
+      {
+        // best-effort temp cleanup
+      }
+    }
+  }
+}

--- a/tests/ProgesiDataExchange.Tests/ProgesiDataExchange.Tests.csproj
+++ b/tests/ProgesiDataExchange.Tests/ProgesiDataExchange.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ProgesiDataExchange\ProgesiDataExchange.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR adds the approved Option A first-pass test scaffolding and Tier 1–2 tests before EF implementation.

Scope:
- Extends ProgesiCore.Tests with additional Cluster/hash/in-memory repository coverage.
- Creates tests/ProgesiDataExchange.Tests.
- Adds DataExchange ExcelSerializer Var/Meta sheet shape and read/round-trip tests.
- Registers ProgesiDataExchange.Tests in Progesi.CI.slnf.
- Adds the new test project to Progesi.sln.

Validation:
- dotnet build -c Release passed.
- dotnet test -c Release passed: 110 total, 110 passed, 0 failed.
- ProgesiCore.Tests passed: 81.
- ProgesiDataExchange.Tests passed: 13.

This PR does not include:
- production source changes
- EF implementation
- DataExchange production consolidation
- Cluster Phase 2
- Cluster Phase 3
- AxisVar work
- Grasshopper component changes
- deployment scripts
- GitHub workflow changes
- artefacts
- main-branch interaction

Important notes:
- This is tests/scaffolding only.
- ProgesiDataExchange.Tests documents current DataExchange library sheet names and behaviour.
- It does not force ProgesiClusters into the DataExchange library.
- GH sparse-ID / ReadCell path remains deferred.