### PR TITLE
test: add repository conformance suite

### DIFF
--- a/Progesi.sln
+++ b/Progesi.sln
@@ -37,6 +37,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProgesiDataExchange.Tests", "tests\ProgesiDataExchange.Tests\ProgesiDataExchange.Tests.csproj", "{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Progesi.Repositories.Conformance.Tests", "tests\Progesi.Repositories.Conformance.Tests\Progesi.Repositories.Conformance.Tests.csproj", "{D63373CE-3B8F-4173-90D0-A30B57E71CBD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -215,6 +217,18 @@ Global
 		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1}.Release|x64.Build.0 = Release|Any CPU
 		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1}.Release|x86.ActiveCfg = Release|Any CPU
 		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1}.Release|x86.Build.0 = Release|Any CPU
+		{D63373CE-3B8F-4173-90D0-A30B57E71CBD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D63373CE-3B8F-4173-90D0-A30B57E71CBD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D63373CE-3B8F-4173-90D0-A30B57E71CBD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D63373CE-3B8F-4173-90D0-A30B57E71CBD}.Debug|x64.Build.0 = Debug|Any CPU
+		{D63373CE-3B8F-4173-90D0-A30B57E71CBD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D63373CE-3B8F-4173-90D0-A30B57E71CBD}.Debug|x86.Build.0 = Debug|Any CPU
+		{D63373CE-3B8F-4173-90D0-A30B57E71CBD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D63373CE-3B8F-4173-90D0-A30B57E71CBD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D63373CE-3B8F-4173-90D0-A30B57E71CBD}.Release|x64.ActiveCfg = Release|Any CPU
+		{D63373CE-3B8F-4173-90D0-A30B57E71CBD}.Release|x64.Build.0 = Release|Any CPU
+		{D63373CE-3B8F-4173-90D0-A30B57E71CBD}.Release|x86.ActiveCfg = Release|Any CPU
+		{D63373CE-3B8F-4173-90D0-A30B57E71CBD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -223,6 +237,7 @@ Global
 		{B79C1976-E4EC-4AAD-B77D-8CE2F5F7A673} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
 		{91AB0E1A-4CD4-4241-89B6-AE08AC1CBD9B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{D63373CE-3B8F-4173-90D0-A30B57E71CBD} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C753CED5-7508-4B2A-A107-C1E530FD786B}

--- a/tests/Progesi.Repositories.Conformance.Tests/IVariableRepositoryConformanceStore.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/IVariableRepositoryConformanceStore.cs
@@ -1,0 +1,10 @@
+using ProgesiCore;
+
+namespace Progesi.Repositories.Conformance.Tests
+{
+  public interface IVariableRepositoryConformanceStore : System.IDisposable
+  {
+    string StoreName { get; }
+    IVariableRepository Repository { get; }
+  }
+}

--- a/tests/Progesi.Repositories.Conformance.Tests/InMemoryVariableRepositoryConformanceStore.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/InMemoryVariableRepositoryConformanceStore.cs
@@ -1,0 +1,16 @@
+using ProgesiCore;
+using ProgesiRepositories.InMemory;
+
+namespace Progesi.Repositories.Conformance.Tests
+{
+  public sealed class InMemoryVariableRepositoryConformanceStore : IVariableRepositoryConformanceStore
+  {
+    public string StoreName => "InMemory";
+
+    public IVariableRepository Repository { get; } = new InMemoryVariableRepository();
+
+    public void Dispose()
+    {
+    }
+  }
+}

--- a/tests/Progesi.Repositories.Conformance.Tests/Progesi.Repositories.Conformance.Tests.csproj
+++ b/tests/Progesi.Repositories.Conformance.Tests/Progesi.Repositories.Conformance.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ProgesiCore\ProgesiCore.csproj" />
+    <ProjectReference Include="..\..\src\ProgesiRepositories.InMemory\ProgesiRepositories.InMemory.csproj" />
+    <ProjectReference Include="..\..\src\ProgesiRepositories.Sqlite\ProgesiRepositories.Sqlite.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="SQLitePCLRaw.core" Version="2.1.10" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.10" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
+    <PackageReference Include="SQLitePCLRaw.provider.e_sqlite3" Version="2.1.10" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+  </ItemGroup>
+</Project>

--- a/tests/Progesi.Repositories.Conformance.Tests/SqliteTestBootstrap.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/SqliteTestBootstrap.cs
@@ -1,0 +1,15 @@
+using SQLitePCL;
+
+namespace Progesi.Repositories.Conformance.Tests
+{
+  internal static class SqliteTestBootstrap
+  {
+    static SqliteTestBootstrap()
+    {
+      raw.SetProvider(new SQLite3Provider_e_sqlite3());
+      Batteries_V2.Init();
+    }
+
+    public static void EnsureInitialized() { }
+  }
+}

--- a/tests/Progesi.Repositories.Conformance.Tests/SqliteVariableRepositoryConformanceStore.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/SqliteVariableRepositoryConformanceStore.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using ProgesiCore;
+using ProgesiRepositories.Sqlite;
+
+namespace Progesi.Repositories.Conformance.Tests
+{
+  public sealed class SqliteVariableRepositoryConformanceStore : IVariableRepositoryConformanceStore
+  {
+    private readonly string _dbPath;
+
+    public string StoreName => "Sqlite";
+
+    public IVariableRepository Repository { get; }
+
+    public SqliteVariableRepositoryConformanceStore()
+    {
+      SqliteTestBootstrap.EnsureInitialized();
+      _dbPath = Path.Combine(Path.GetTempPath(), $"progesi_conf_{Guid.NewGuid():N}.sqlite");
+      Repository = new SqliteVariableRepository(_dbPath, resetSchema: true);
+    }
+
+    public void Dispose()
+    {
+      try
+      {
+        if (File.Exists(_dbPath))
+          File.Delete(_dbPath);
+      }
+      catch
+      {
+        // best-effort temp cleanup
+      }
+    }
+  }
+}

--- a/tests/Progesi.Repositories.Conformance.Tests/VariableRepositoryConformanceStoreProvider.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/VariableRepositoryConformanceStoreProvider.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace Progesi.Repositories.Conformance.Tests
+{
+  public static class VariableRepositoryConformanceStoreProvider
+  {
+    public static IEnumerable<object[]> StoreFactories()
+    {
+      yield return new object[]
+      {
+        "InMemory",
+        (System.Func<IVariableRepositoryConformanceStore>)(() => new InMemoryVariableRepositoryConformanceStore())
+      };
+      yield return new object[]
+      {
+        "Sqlite",
+        (System.Func<IVariableRepositoryConformanceStore>)(() => new SqliteVariableRepositoryConformanceStore())
+      };
+    }
+  }
+}

--- a/tests/Progesi.Repositories.Conformance.Tests/VariableRepositoryConformanceTests.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/VariableRepositoryConformanceTests.cs
@@ -1,0 +1,159 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ProgesiCore;
+using Xunit;
+
+namespace Progesi.Repositories.Conformance.Tests
+{
+  public class VariableRepositoryConformanceTests
+  {
+    [Theory]
+    [MemberData(nameof(VariableRepositoryConformanceStoreProvider.StoreFactories), MemberType = typeof(VariableRepositoryConformanceStoreProvider))]
+    public async Task GetAllAsync_EmptyStore_Returns_Empty(string storeName, System.Func<IVariableRepositoryConformanceStore> createStore)
+    {
+      using var store = createStore();
+      var all = await store.Repository.GetAllAsync();
+
+      all.Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(VariableRepositoryConformanceStoreProvider.StoreFactories), MemberType = typeof(VariableRepositoryConformanceStoreProvider))]
+    public async Task SaveAsync_Then_GetByIdAsync_RoundTrips_Explicit_Id(string storeName, System.Func<IVariableRepositoryConformanceStore> createStore)
+    {
+      using var store = createStore();
+      var repo = store.Repository;
+      var original = new ProgesiVariable(5, "Span", 12.5, new[] { 1, 2 }, metadataId: 3);
+
+      await repo.SaveAsync(original);
+      var loaded = await repo.GetByIdAsync(5);
+
+      loaded.Should().NotBeNull();
+      loaded!.Id.Should().Be(5);
+      loaded.Name.Should().Be("Span");
+      loaded.Value.Should().Be(12.5);
+      loaded.DependsFrom.Should().BeEquivalentTo(new[] { 1, 2 });
+      loaded.MetadataId.Should().Be(3);
+    }
+
+    [Theory]
+    [MemberData(nameof(VariableRepositoryConformanceStoreProvider.StoreFactories), MemberType = typeof(VariableRepositoryConformanceStoreProvider))]
+    public async Task GetByIdAsync_Missing_Id_Returns_Null(string storeName, System.Func<IVariableRepositoryConformanceStore> createStore)
+    {
+      using var store = createStore();
+      var loaded = await store.Repository.GetByIdAsync(999);
+
+      loaded.Should().BeNull();
+    }
+
+    [Theory]
+    [MemberData(nameof(VariableRepositoryConformanceStoreProvider.StoreFactories), MemberType = typeof(VariableRepositoryConformanceStoreProvider))]
+    public async Task GetAllAsync_Returns_All_Saved_Variables(string storeName, System.Func<IVariableRepositoryConformanceStore> createStore)
+    {
+      using var store = createStore();
+      var repo = store.Repository;
+      await repo.SaveAsync(new ProgesiVariable(1, "A", 1));
+      await repo.SaveAsync(new ProgesiVariable(2, "B", 2));
+
+      var all = await store.Repository.GetAllAsync();
+
+      all.Should().HaveCount(2);
+      all.Select(v => v.Id).Should().BeEquivalentTo(new[] { 1, 2 });
+    }
+
+    [Theory]
+    [MemberData(nameof(VariableRepositoryConformanceStoreProvider.StoreFactories), MemberType = typeof(VariableRepositoryConformanceStoreProvider))]
+    public async Task SaveAsync_Overwrite_Same_Id_Replaces_Stored_Variable(string storeName, System.Func<IVariableRepositoryConformanceStore> createStore)
+    {
+      using var store = createStore();
+      var repo = store.Repository;
+      await repo.SaveAsync(new ProgesiVariable(7, "Before", 1));
+      await repo.SaveAsync(new ProgesiVariable(7, "After", 9));
+
+      var loaded = await repo.GetByIdAsync(7);
+
+      loaded.Should().NotBeNull();
+      loaded!.Name.Should().Be("After");
+      loaded.Value.Should().Be(9);
+      (await repo.GetAllAsync()).Should().HaveCount(1);
+    }
+
+    [Theory]
+    [MemberData(nameof(VariableRepositoryConformanceStoreProvider.StoreFactories), MemberType = typeof(VariableRepositoryConformanceStoreProvider))]
+    public async Task SaveAsync_Preserves_Hash_Computable_Content(string storeName, System.Func<IVariableRepositoryConformanceStore> createStore)
+    {
+      using var store = createStore();
+      var repo = store.Repository;
+      var original = new ProgesiVariable(11, "Load", 42, new[] { 3, 1, 2 }, metadataId: 4);
+
+      await repo.SaveAsync(original);
+      var loaded = await repo.GetByIdAsync(11);
+
+      loaded.Should().NotBeNull();
+      ProgesiHash.Compute(loaded!).Should().Be(ProgesiHash.Compute(original));
+    }
+
+    [Theory]
+    [MemberData(nameof(VariableRepositoryConformanceStoreProvider.StoreFactories), MemberType = typeof(VariableRepositoryConformanceStoreProvider))]
+    public async Task DeleteAsync_Existing_Id_Removes_Variable(string storeName, System.Func<IVariableRepositoryConformanceStore> createStore)
+    {
+      using var store = createStore();
+      var repo = store.Repository;
+      await repo.SaveAsync(new ProgesiVariable(8, "Del", 0));
+
+      (await repo.DeleteAsync(8)).Should().BeTrue();
+      (await repo.GetByIdAsync(8)).Should().BeNull();
+      (await repo.GetAllAsync()).Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(VariableRepositoryConformanceStoreProvider.StoreFactories), MemberType = typeof(VariableRepositoryConformanceStoreProvider))]
+    public async Task DeleteAsync_Missing_Id_Returns_False(string storeName, System.Func<IVariableRepositoryConformanceStore> createStore)
+    {
+      using var store = createStore();
+      (await store.Repository.DeleteAsync(404)).Should().BeFalse();
+    }
+
+    [Theory]
+    [MemberData(nameof(VariableRepositoryConformanceStoreProvider.StoreFactories), MemberType = typeof(VariableRepositoryConformanceStoreProvider))]
+    public async Task DeleteManyAsync_Removes_Existing_Ids(string storeName, System.Func<IVariableRepositoryConformanceStore> createStore)
+    {
+      using var store = createStore();
+      var repo = store.Repository;
+      await repo.SaveAsync(new ProgesiVariable(1, "A", 1));
+      await repo.SaveAsync(new ProgesiVariable(2, "B", 2));
+      await repo.SaveAsync(new ProgesiVariable(3, "C", 3));
+
+      var removed = await repo.DeleteManyAsync(new[] { 1, 3, 99 });
+
+      removed.Should().Be(2);
+      (await repo.GetAllAsync()).Select(v => v.Id).Should().Equal(2);
+    }
+
+    [Theory]
+    [MemberData(nameof(VariableRepositoryConformanceStoreProvider.StoreFactories), MemberType = typeof(VariableRepositoryConformanceStoreProvider))]
+    public async Task DeleteManyAsync_Empty_Ids_Returns_Zero(string storeName, System.Func<IVariableRepositoryConformanceStore> createStore)
+    {
+      using var store = createStore();
+      var removed = await store.Repository.DeleteManyAsync(System.Array.Empty<int>());
+
+      removed.Should().Be(0);
+    }
+
+    [Theory]
+    [MemberData(nameof(VariableRepositoryConformanceStoreProvider.StoreFactories), MemberType = typeof(VariableRepositoryConformanceStoreProvider))]
+    public async Task SaveAsync_With_CancellationToken_Completes(string storeName, System.Func<IVariableRepositoryConformanceStore> createStore)
+    {
+      using var store = createStore();
+      using var cts = new CancellationTokenSource();
+      var variable = new ProgesiVariable(20, "Tok", "x");
+
+      var saved = await store.Repository.SaveAsync(variable, cts.Token);
+
+      saved.Should().NotBeNull();
+      saved.Id.Should().Be(20);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the approved Option B green repository conformance first pass.

Scope:
- Adds tests/Progesi.Repositories.Conformance.Tests.
- Adds shared IVariableRepository conformance tests.
- Runs the conformance suite against current InMemory and SQLite implementations.
- Registers the conformance test project in Progesi.sln.
- Leaves Progesi.CI.slnf unchanged because the conformance tests require SQLite native bootstrap, consistent with ProgesiRepositories.Sqlite.Tests being outside the fast CI filter.

Validation:
- dotnet build -c Release passed.
- dotnet test -c Release passed: 132 total, 132 passed, 0 failed.
- Progesi.Repositories.Conformance.Tests passed: 22 total, 22 passed, 0 failed.

This PR does not include:
- production source changes
- EF implementation
- EF tests
- DataExchange production consolidation
- Metadata repository implementation
- Cluster repository implementation
- Cluster Phase 2
- Cluster Phase 3
- AxisVar work
- Grasshopper component changes
- deployment scripts
- GitHub workflow changes
- artefacts
- Progesi.CI.slnf changes
- main-branch interaction

Important notes:
- No expected-red tests are added to the default build.
- Metadata parity is deferred until a matching implementation exists.
- Cluster parity is deferred until SQLite/EF Cluster repositories exist.
- EF parity is deferred until EF skeleton exists.