### PR TITLE
build: multi-target ProgesiCore for EF Core prerequisite

### DIFF
--- a/src/ProgesiCore/ProgesiCore.csproj
+++ b/src/ProgesiCore/ProgesiCore.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>


### PR DESCRIPTION
This PR implements the approved Option 0 prerequisite for future EF Core 8 / net8 infrastructure.

Scope:
- Multi-targets ProgesiCore to net48;netstandard2.0.
- Preserves the existing net48 target.
- Adds netstandard2.0 as a second target.
- Changes only src/ProgesiCore/ProgesiCore.csproj.

Validation before PR:
- dotnet build src/ProgesiCore/ProgesiCore.csproj -c Release -f net48 passed.
- dotnet build src/ProgesiCore/ProgesiCore.csproj -c Release -f netstandard2.0 passed.
- dotnet build -c Release passed.
- dotnet test -c Release passed: 132 total, 132 passed, 0 failed.

This PR does not include:
- source code changes
- test changes
- solution changes
- EF implementation
- EF package references in ProgesiCore
- DataExchange production changes
- Grasshopper changes
- Cluster Phase 2 or Phase 3
- AxisVar work
- deployment scripts
- GitHub workflow changes
- artefacts
- main-branch interaction

Important notes:
- This is the prerequisite for the later EF Core skeleton + Var/Meta parity task.
- EF Option B remains blocked until this PR is reviewed, merged, synced and post-merge verified.
- Core remains free of EF references.