### PR TITLE
feat: add EF infrastructure skeleton for Var/Meta parity

### DIFF
--- a/Progesi.sln
+++ b/Progesi.sln
@@ -39,6 +39,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProgesiDataExchange.Tests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Progesi.Repositories.Conformance.Tests", "tests\Progesi.Repositories.Conformance.Tests\Progesi.Repositories.Conformance.Tests.csproj", "{D63373CE-3B8F-4173-90D0-A30B57E71CBD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Progesi.Infrastructure.EF", "src\Progesi.Infrastructure.EF\Progesi.Infrastructure.EF.csproj", "{7941D544-4004-4116-9E07-707CAFC8C724}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Progesi.Infrastructure.EF.Tests", "tests\Progesi.Infrastructure.EF.Tests\Progesi.Infrastructure.EF.Tests.csproj", "{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -229,6 +233,30 @@ Global
 		{D63373CE-3B8F-4173-90D0-A30B57E71CBD}.Release|x64.Build.0 = Release|Any CPU
 		{D63373CE-3B8F-4173-90D0-A30B57E71CBD}.Release|x86.ActiveCfg = Release|Any CPU
 		{D63373CE-3B8F-4173-90D0-A30B57E71CBD}.Release|x86.Build.0 = Release|Any CPU
+		{7941D544-4004-4116-9E07-707CAFC8C724}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7941D544-4004-4116-9E07-707CAFC8C724}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7941D544-4004-4116-9E07-707CAFC8C724}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7941D544-4004-4116-9E07-707CAFC8C724}.Debug|x64.Build.0 = Debug|Any CPU
+		{7941D544-4004-4116-9E07-707CAFC8C724}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7941D544-4004-4116-9E07-707CAFC8C724}.Debug|x86.Build.0 = Debug|Any CPU
+		{7941D544-4004-4116-9E07-707CAFC8C724}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7941D544-4004-4116-9E07-707CAFC8C724}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7941D544-4004-4116-9E07-707CAFC8C724}.Release|x64.ActiveCfg = Release|Any CPU
+		{7941D544-4004-4116-9E07-707CAFC8C724}.Release|x64.Build.0 = Release|Any CPU
+		{7941D544-4004-4116-9E07-707CAFC8C724}.Release|x86.ActiveCfg = Release|Any CPU
+		{7941D544-4004-4116-9E07-707CAFC8C724}.Release|x86.Build.0 = Release|Any CPU
+		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D}.Debug|x64.Build.0 = Debug|Any CPU
+		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D}.Debug|x86.Build.0 = Debug|Any CPU
+		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D}.Release|x64.ActiveCfg = Release|Any CPU
+		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D}.Release|x64.Build.0 = Release|Any CPU
+		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D}.Release|x86.ActiveCfg = Release|Any CPU
+		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -238,6 +266,8 @@ Global
 		{91AB0E1A-4CD4-4241-89B6-AE08AC1CBD9B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{6F442F5F-93C3-4F8C-BE2B-790D74A40AB1} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{D63373CE-3B8F-4173-90D0-A30B57E71CBD} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{7941D544-4004-4116-9E07-707CAFC8C724} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C753CED5-7508-4B2A-A107-C1E530FD786B}

--- a/src/Progesi.Infrastructure.EF/Entities/MetadataEntity.cs
+++ b/src/Progesi.Infrastructure.EF/Entities/MetadataEntity.cs
@@ -1,0 +1,9 @@
+namespace Progesi.Infrastructure.EF.Entities;
+
+public sealed class MetadataEntity
+{
+  public int Id { get; set; }
+  public string Json { get; set; } = string.Empty;
+  public string LastModified { get; set; } = string.Empty;
+  public string ContentHash { get; set; } = string.Empty;
+}

--- a/src/Progesi.Infrastructure.EF/Entities/VariableEntity.cs
+++ b/src/Progesi.Infrastructure.EF/Entities/VariableEntity.cs
@@ -1,0 +1,12 @@
+namespace Progesi.Infrastructure.EF.Entities;
+
+public sealed class VariableEntity
+{
+  public int Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public string ValueType { get; set; } = string.Empty;
+  public string Value { get; set; } = string.Empty;
+  public int? MetadataId { get; set; }
+  public string DependsJson { get; set; } = "[]";
+  public string ContentHash { get; set; } = string.Empty;
+}

--- a/src/Progesi.Infrastructure.EF/Internal/MetadataSerialization.cs
+++ b/src/Progesi.Infrastructure.EF/Internal/MetadataSerialization.cs
@@ -1,0 +1,76 @@
+using System.Globalization;
+using Newtonsoft.Json;
+using ProgesiCore;
+
+namespace Progesi.Infrastructure.EF.Internal;
+
+internal static class MetadataSerialization
+{
+  internal sealed class MetadataDto
+  {
+    public int Id { get; set; }
+    public DateTime LastModifiedUtc { get; set; }
+    public string? CreatedBy { get; set; }
+    public string? AdditionalInfo { get; set; }
+    public List<string>? References { get; set; }
+    public List<SnipDto>? Snips { get; set; }
+
+    public static MetadataDto FromDomain(ProgesiMetadata m)
+    {
+      return new MetadataDto
+      {
+        Id = m.Id,
+        LastModifiedUtc = m.LastModified.ToUniversalTime(),
+        CreatedBy = m.CreatedBy,
+        AdditionalInfo = m.AdditionalInfo,
+        References = m.References?.Select(u => u.ToString()).ToList(),
+        Snips = m.Snips?.Select(s => new SnipDto
+        {
+          Id = s.Id,
+          MimeType = s.MimeType,
+          Caption = s.Caption,
+          Source = s.Source,
+          ContentBase64 = Convert.ToBase64String(s.Content ?? Array.Empty<byte>())
+        }).ToList()
+      };
+    }
+  }
+
+  internal sealed class SnipDto
+  {
+    public Guid Id { get; set; }
+    public string MimeType { get; set; } = "image/png";
+    public string Caption { get; set; } = string.Empty;
+    public string? Source { get; set; }
+    public string ContentBase64 { get; set; } = string.Empty;
+  }
+
+  public static string ToJson(ProgesiMetadata metadata)
+  {
+    var dto = MetadataDto.FromDomain(metadata);
+    return JsonConvert.SerializeObject(dto);
+  }
+
+  public static ProgesiMetadata? FromStoredJson(string json, string lastModifiedStr, int id)
+  {
+    var dto = JsonConvert.DeserializeObject<MetadataDto>(json);
+    if (dto is null) return null;
+
+    var lastModified = DateTime.Parse(lastModifiedStr, null, DateTimeStyles.RoundtripKind);
+
+    var refs = dto.References?.Select(s => new Uri(s, UriKind.RelativeOrAbsolute));
+    var snips = dto.Snips?.Select(s => ProgesiSnip.Create(
+      Convert.FromBase64String(s.ContentBase64 ?? string.Empty),
+      s.MimeType ?? "application/octet-stream",
+      s.Caption,
+      string.IsNullOrWhiteSpace(s.Source) ? null : new Uri(s.Source, UriKind.RelativeOrAbsolute)));
+
+    return ProgesiMetadata.Create(
+      dto.CreatedBy ?? string.Empty,
+      dto.AdditionalInfo,
+      refs,
+      snips,
+      lastModified,
+      id);
+  }
+}

--- a/src/Progesi.Infrastructure.EF/Internal/ValueSerialization.cs
+++ b/src/Progesi.Infrastructure.EF/Internal/ValueSerialization.cs
@@ -1,0 +1,53 @@
+using System.Globalization;
+using Newtonsoft.Json;
+
+namespace Progesi.Infrastructure.EF.Internal;
+
+internal static class ValueSerialization
+{
+  public static string TypeOf(object? obj)
+  {
+    if (obj == null) return "null";
+    return obj switch
+    {
+      string => "string",
+      int => "int",
+      double => "double",
+      bool => "bool",
+      _ => obj.GetType().AssemblyQualifiedName ?? "object"
+    };
+  }
+
+  public static string Stringify(object? obj)
+  {
+    if (obj == null) return "null";
+    return obj switch
+    {
+      string s => s,
+      int i => i.ToString(),
+      double d => d.ToString(CultureInfo.InvariantCulture),
+      bool b => b ? "true" : "false",
+      _ => JsonConvert.SerializeObject(obj) ?? string.Empty
+    };
+  }
+
+  public static object? ParseValue(string value, string valueType)
+  {
+    if (valueType == "null") return null;
+    return valueType switch
+    {
+      "string" => value,
+      "int" => int.Parse(value),
+      "double" => double.Parse(value, CultureInfo.InvariantCulture),
+      "bool" => value == "true",
+      _ => DeserializeOrReturn(value, valueType)
+    };
+  }
+
+  private static object DeserializeOrReturn(string value, string typeName)
+  {
+    var t = Type.GetType(typeName, throwOnError: false);
+    if (t == null) return value;
+    return JsonConvert.DeserializeObject(value, t) ?? (object)value;
+  }
+}

--- a/src/Progesi.Infrastructure.EF/Progesi.Infrastructure.EF.csproj
+++ b/src/Progesi.Infrastructure.EF/Progesi.Infrastructure.EF.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ProgesiCore\ProgesiCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>

--- a/src/Progesi.Infrastructure.EF/ProgesiDbContext.cs
+++ b/src/Progesi.Infrastructure.EF/ProgesiDbContext.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using Progesi.Infrastructure.EF.Entities;
+
+namespace Progesi.Infrastructure.EF;
+
+public sealed class ProgesiDbContext : DbContext
+{
+  public ProgesiDbContext(DbContextOptions<ProgesiDbContext> options)
+      : base(options)
+  {
+  }
+
+  public DbSet<VariableEntity> Variables => Set<VariableEntity>();
+  public DbSet<MetadataEntity> Metadata => Set<MetadataEntity>();
+
+  protected override void OnModelCreating(ModelBuilder modelBuilder)
+  {
+    modelBuilder.Entity<VariableEntity>(entity =>
+    {
+      entity.ToTable("Variables");
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.Name).IsRequired();
+      entity.Property(e => e.ValueType).IsRequired();
+      entity.Property(e => e.Value).IsRequired();
+      entity.Property(e => e.DependsJson).IsRequired();
+      entity.Property(e => e.ContentHash).IsRequired();
+      entity.HasIndex(e => e.ContentHash).IsUnique();
+    });
+
+    modelBuilder.Entity<MetadataEntity>(entity =>
+    {
+      entity.ToTable("Metadata");
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.Json).IsRequired();
+      entity.Property(e => e.LastModified).IsRequired();
+      entity.Property(e => e.ContentHash).IsRequired();
+      entity.HasIndex(e => e.ContentHash).IsUnique();
+    });
+  }
+}

--- a/src/Progesi.Infrastructure.EF/ProgesiDbContextFactory.cs
+++ b/src/Progesi.Infrastructure.EF/ProgesiDbContextFactory.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Progesi.Infrastructure.EF;
+
+public static class ProgesiDbContextFactory
+{
+  public static ProgesiDbContext Create(string connectionString, bool resetSchema = false)
+  {
+    var options = new DbContextOptionsBuilder<ProgesiDbContext>()
+        .UseSqlite(connectionString)
+        .Options;
+
+    var context = new ProgesiDbContext(options);
+    EnsureSchema(context, resetSchema);
+    return context;
+  }
+
+  public static void EnsureSchema(ProgesiDbContext context, bool resetSchema = false)
+  {
+    if (resetSchema)
+    {
+      context.Database.EnsureDeleted();
+    }
+
+    context.Database.EnsureCreated();
+  }
+}

--- a/src/Progesi.Infrastructure.EF/Repositories/EfMetadataRepository.cs
+++ b/src/Progesi.Infrastructure.EF/Repositories/EfMetadataRepository.cs
@@ -1,0 +1,123 @@
+using Microsoft.EntityFrameworkCore;
+using ProgesiCore;
+using Progesi.Infrastructure.EF.Entities;
+using Progesi.Infrastructure.EF.Internal;
+
+namespace Progesi.Infrastructure.EF.Repositories;
+
+public sealed class EfMetadataRepository : IMetadataRepository
+{
+  private readonly ProgesiDbContext _context;
+  private readonly bool _ownsContext;
+
+  public EfMetadataRepository(ProgesiDbContext context, bool ownsContext = false)
+  {
+    _context = context ?? throw new ArgumentNullException(nameof(context));
+    _ownsContext = ownsContext;
+  }
+
+  public EfMetadataRepository(string connectionString, bool resetSchema = false)
+      : this(ProgesiDbContextFactory.Create(connectionString, resetSchema), ownsContext: true)
+  {
+  }
+
+  public async Task<ProgesiMetadata?> GetAsync(int id, CancellationToken ct = default)
+  {
+    var entity = await _context.Metadata
+        .AsNoTracking()
+        .FirstOrDefaultAsync(m => m.Id == id, ct);
+
+    if (entity == null) return null;
+
+    return MetadataSerialization.FromStoredJson(entity.Json, entity.LastModified, entity.Id);
+  }
+
+  public async Task UpsertAsync(ProgesiMetadata metadata, CancellationToken ct = default)
+  {
+    if (metadata is null) throw new ArgumentNullException(nameof(metadata));
+
+    var contentHash = ProgesiHash.Compute(metadata);
+    var json = MetadataSerialization.ToJson(metadata);
+    var lastMod = metadata.LastModified.ToUniversalTime().ToString("o");
+
+    var existingId = await GetIdByHashAsync(contentHash, ct);
+    if (existingId > 0)
+    {
+      var existing = await _context.Metadata.FindAsync(new object[] { existingId }, ct);
+      if (existing != null)
+      {
+        existing.LastModified = lastMod;
+        await _context.SaveChangesAsync(ct);
+      }
+
+      return;
+    }
+
+    if (metadata.Id > 0)
+    {
+      var tracked = await _context.Metadata.FindAsync(new object[] { metadata.Id }, ct);
+      if (tracked == null)
+      {
+        _context.Metadata.Add(new MetadataEntity
+        {
+          Id = metadata.Id,
+          Json = json,
+          LastModified = lastMod,
+          ContentHash = contentHash
+        });
+        await _context.SaveChangesAsync(ct);
+      }
+    }
+    else
+    {
+      _context.Metadata.Add(new MetadataEntity
+      {
+        Json = json,
+        LastModified = lastMod,
+        ContentHash = contentHash
+      });
+      await _context.SaveChangesAsync(ct);
+    }
+  }
+
+  public async Task<bool> DeleteAsync(int id, CancellationToken ct = default)
+  {
+    var entity = await _context.Metadata.FindAsync(new object[] { id }, ct);
+    if (entity == null) return false;
+
+    _context.Metadata.Remove(entity);
+    await _context.SaveChangesAsync(ct);
+    return true;
+  }
+
+  public async Task<IReadOnlyList<ProgesiMetadata>> ListAsync(int skip = 0, int take = 100, CancellationToken ct = default)
+  {
+    var ids = await _context.Metadata
+        .AsNoTracking()
+        .OrderBy(m => m.Id)
+        .Skip(skip)
+        .Take(take)
+        .Select(m => m.Id)
+        .ToListAsync(ct);
+
+    var list = new List<ProgesiMetadata>(ids.Count);
+    foreach (var id in ids)
+    {
+      var metadata = await GetAsync(id, ct);
+      if (metadata != null) list.Add(metadata);
+    }
+
+    return list;
+  }
+
+  private async Task<int> GetIdByHashAsync(string contentHash, CancellationToken ct)
+  {
+    var id = await _context.Metadata
+        .AsNoTracking()
+        .Where(m => m.ContentHash == contentHash)
+        .Select(m => (int?)m.Id)
+        .FirstOrDefaultAsync(ct);
+
+    return id ?? 0;
+  }
+}

--- a/src/Progesi.Infrastructure.EF/Repositories/EfVariableRepository.cs
+++ b/src/Progesi.Infrastructure.EF/Repositories/EfVariableRepository.cs
@@ -1,0 +1,119 @@
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using ProgesiCore;
+using Progesi.Infrastructure.EF.Entities;
+using Progesi.Infrastructure.EF.Internal;
+
+namespace Progesi.Infrastructure.EF.Repositories;
+
+public sealed class EfVariableRepository : IVariableRepository
+{
+  private readonly ProgesiDbContext _context;
+  private readonly bool _ownsContext;
+
+  public EfVariableRepository(ProgesiDbContext context, bool ownsContext = false)
+  {
+    _context = context ?? throw new ArgumentNullException(nameof(context));
+    _ownsContext = ownsContext;
+  }
+
+  public EfVariableRepository(string connectionString, bool resetSchema = false)
+      : this(ProgesiDbContextFactory.Create(connectionString, resetSchema), ownsContext: true)
+  {
+  }
+
+  public async Task<ProgesiVariable> SaveAsync(ProgesiVariable variable, CancellationToken ct = default)
+  {
+    var hash = ProgesiHash.Compute(variable);
+
+    var existing = await _context.Variables
+        .AsNoTracking()
+        .Where(v => v.ContentHash == hash)
+        .Select(v => new { v.Id })
+        .FirstOrDefaultAsync(ct);
+
+    if (existing != null && existing.Id != variable.Id)
+    {
+      return await GetByIdAsync(existing.Id, ct) ?? variable;
+    }
+
+    var depends = (variable.DependsFrom ?? Array.Empty<int>()).ToArray();
+    var entity = await _context.Variables.FindAsync(new object[] { variable.Id }, ct);
+
+    if (entity == null)
+    {
+      entity = new VariableEntity { Id = variable.Id };
+      _context.Variables.Add(entity);
+    }
+
+    entity.Name = variable.Name ?? string.Empty;
+    entity.ValueType = ValueSerialization.TypeOf(variable.Value);
+    entity.Value = ValueSerialization.Stringify(variable.Value);
+    entity.MetadataId = variable.MetadataId;
+    entity.DependsJson = JsonConvert.SerializeObject(depends);
+    entity.ContentHash = hash;
+
+    await _context.SaveChangesAsync(ct);
+
+    return await GetByIdAsync(variable.Id, ct) ?? variable;
+  }
+
+  public async Task<ProgesiVariable> GetByIdAsync(int id, CancellationToken ct = default)
+  {
+    var entity = await _context.Variables
+        .AsNoTracking()
+        .FirstOrDefaultAsync(v => v.Id == id, ct);
+
+    if (entity == null) return null!;
+
+    var depends = JsonConvert.DeserializeObject<int[]>(entity.DependsJson) ?? Array.Empty<int>();
+    var value = ValueSerialization.ParseValue(entity.Value, entity.ValueType);
+    return new ProgesiVariable(entity.Id, entity.Name, value, depends, entity.MetadataId);
+  }
+
+  public async Task<IReadOnlyList<ProgesiVariable>> GetAllAsync(CancellationToken ct = default)
+  {
+    var ids = await _context.Variables
+        .AsNoTracking()
+        .OrderBy(v => v.Id)
+        .Select(v => v.Id)
+        .ToListAsync(ct);
+
+    var list = new List<ProgesiVariable>(ids.Count);
+    foreach (var id in ids)
+    {
+      var variable = await GetByIdAsync(id, ct);
+      if (variable != null) list.Add(variable);
+    }
+
+    return list;
+  }
+
+  public async Task<bool> DeleteAsync(int id, CancellationToken ct = default)
+  {
+    var entity = await _context.Variables.FindAsync(new object[] { id }, ct);
+    if (entity == null) return false;
+
+    _context.Variables.Remove(entity);
+    await _context.SaveChangesAsync(ct);
+    return true;
+  }
+
+  public async Task<int> DeleteManyAsync(IEnumerable<int> idsToDelete, CancellationToken ct = default)
+  {
+    if (idsToDelete == null) return 0;
+
+    var ids = idsToDelete.ToArray();
+    if (ids.Length == 0) return 0;
+
+    var entities = await _context.Variables
+        .Where(v => ids.Contains(v.Id))
+        .ToListAsync(ct);
+
+    if (entities.Count == 0) return 0;
+
+    _context.Variables.RemoveRange(entities);
+    await _context.SaveChangesAsync(ct);
+    return entities.Count;
+  }
+}

--- a/tests/Progesi.Infrastructure.EF.Tests/EfMetadataRepositoryTests.cs
+++ b/tests/Progesi.Infrastructure.EF.Tests/EfMetadataRepositoryTests.cs
@@ -1,0 +1,125 @@
+using FluentAssertions;
+using ProgesiCore;
+using Progesi.Infrastructure.EF.Repositories;
+
+namespace Progesi.Infrastructure.EF.Tests;
+
+public sealed class EfMetadataRepositoryTests : IDisposable
+{
+  private readonly string _connectionString;
+  private readonly EfMetadataRepository _repo;
+
+  public EfMetadataRepositoryTests()
+  {
+    _connectionString = EfTestBootstrap.CreateTempFileConnectionString();
+    _repo = new EfMetadataRepository(_connectionString, resetSchema: true);
+  }
+
+  [Fact]
+  public async Task ListAsync_EmptyStore_Returns_Empty()
+  {
+    var all = await _repo.ListAsync();
+    all.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task Upsert_Deduplicates_By_ContentHash()
+  {
+    var r1 = new Uri("https://example.com/A");
+    var r2 = new Uri("https://example.com/B");
+
+    var m1 = ProgesiMetadata.Create("usr", "info", new[] { r1, r2 }, id: 1);
+    m1.AddSnip(new byte[] { 1, 2, 3 }, "image/png", "cap");
+
+    await _repo.UpsertAsync(m1);
+
+    var m2 = ProgesiMetadata.Create("usr", "info", new[] { r2, r1 }, id: 2);
+    m2.AddSnip(new byte[] { 1, 2, 3 }, "image/png", "caption changes ok");
+
+    await _repo.UpsertAsync(m2);
+
+    var got1 = await _repo.GetAsync(1);
+    var got2 = await _repo.GetAsync(2);
+
+    got1.Should().NotBeNull();
+    got2.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task Roundtrip_Metadata_With_Snips_And_References()
+  {
+    var m = ProgesiMetadata.Create("me", "meta", new[] { new Uri("https://a") }, id: 5);
+    m.AddSnip(new byte[] { 9, 9, 9 }, "image/jpeg", "pic");
+
+    await _repo.UpsertAsync(m);
+    var back = await _repo.GetAsync(5);
+
+    back.Should().NotBeNull();
+    back!.CreatedBy.Should().Be("me");
+    back.References.Should().HaveCount(1);
+    back.Snips.Should().HaveCount(1);
+  }
+
+  [Fact]
+  public async Task GetAsync_Missing_Id_Returns_Null()
+  {
+    var back = await _repo.GetAsync(404);
+    back.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task DeleteAsync_Existing_Id_Removes_Metadata()
+  {
+    var m = ProgesiMetadata.Create("usr", id: 3);
+    await _repo.UpsertAsync(m);
+
+    (await _repo.DeleteAsync(3)).Should().BeTrue();
+    (await _repo.GetAsync(3)).Should().BeNull();
+    (await _repo.ListAsync()).Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task DeleteAsync_Missing_Id_Returns_False()
+  {
+    (await _repo.DeleteAsync(999)).Should().BeFalse();
+  }
+
+  [Fact]
+  public async Task ListAsync_Returns_Multiple_Records_In_Order()
+  {
+    await _repo.UpsertAsync(ProgesiMetadata.Create("a", id: 2));
+    await _repo.UpsertAsync(ProgesiMetadata.Create("b", id: 1));
+
+    var list = await _repo.ListAsync();
+
+    list.Should().HaveCount(2);
+    list.Select(m => m.Id).Should().Equal(1, 2);
+  }
+
+  [Fact]
+  public async Task Upsert_Preserves_Hash_Key_Semantics_For_Duplicate_Content()
+  {
+    var m1 = ProgesiMetadata.Create("same", "payload", id: 10);
+    await _repo.UpsertAsync(m1);
+
+    var m2 = ProgesiMetadata.Create("same", "payload", id: 11);
+    await _repo.UpsertAsync(m2);
+
+    (await _repo.GetAsync(10)).Should().NotBeNull();
+    (await _repo.GetAsync(11)).Should().BeNull();
+    (await _repo.ListAsync()).Should().HaveCount(1);
+  }
+
+  public void Dispose()
+  {
+    var path = _connectionString.Replace("Data Source=", string.Empty);
+    try
+    {
+      if (File.Exists(path)) File.Delete(path);
+    }
+    catch
+    {
+      // best-effort cleanup
+    }
+  }
+}

--- a/tests/Progesi.Infrastructure.EF.Tests/EfTestBootstrap.cs
+++ b/tests/Progesi.Infrastructure.EF.Tests/EfTestBootstrap.cs
@@ -1,0 +1,28 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Progesi.Infrastructure.EF;
+
+namespace Progesi.Infrastructure.EF.Tests;
+
+internal static class EfTestBootstrap
+{
+  public static (ProgesiDbContext Context, SqliteConnection Connection) CreateIsolatedContext()
+  {
+    var connection = new SqliteConnection($"Data Source=ef_test_{Guid.NewGuid():N};Mode=Memory;Cache=Shared");
+    connection.Open();
+
+    var options = new DbContextOptionsBuilder<ProgesiDbContext>()
+        .UseSqlite(connection)
+        .Options;
+
+    var context = new ProgesiDbContext(options);
+    ProgesiDbContextFactory.EnsureSchema(context, resetSchema: true);
+    return (context, connection);
+  }
+
+  public static string CreateTempFileConnectionString()
+  {
+    var path = Path.Combine(Path.GetTempPath(), $"progesi_ef_{Guid.NewGuid():N}.sqlite");
+    return $"Data Source={path}";
+  }
+}

--- a/tests/Progesi.Infrastructure.EF.Tests/EfVariableRepositoryTests.cs
+++ b/tests/Progesi.Infrastructure.EF.Tests/EfVariableRepositoryTests.cs
@@ -1,0 +1,149 @@
+using FluentAssertions;
+using ProgesiCore;
+using Progesi.Infrastructure.EF.Repositories;
+
+namespace Progesi.Infrastructure.EF.Tests;
+
+public sealed class EfVariableRepositoryTests : IDisposable
+{
+  private readonly string _connectionString;
+  private readonly EfVariableRepository _repo;
+
+  public EfVariableRepositoryTests()
+  {
+    _connectionString = EfTestBootstrap.CreateTempFileConnectionString();
+    _repo = new EfVariableRepository(_connectionString, resetSchema: true);
+  }
+
+  [Fact]
+  public async Task GetAllAsync_EmptyStore_Returns_Empty()
+  {
+    var all = await _repo.GetAllAsync();
+    all.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task SaveAsync_Then_GetByIdAsync_RoundTrips_Fields()
+  {
+    var original = new ProgesiVariable(5, "Span", 12.5, new[] { 1, 2 }, metadataId: 3);
+
+    await _repo.SaveAsync(original);
+    var loaded = await _repo.GetByIdAsync(5);
+
+    loaded.Should().NotBeNull();
+    loaded!.Id.Should().Be(5);
+    loaded.Name.Should().Be("Span");
+    loaded.Value.Should().Be(12.5);
+    loaded.DependsFrom.Should().BeEquivalentTo(new[] { 1, 2 });
+    loaded.MetadataId.Should().Be(3);
+  }
+
+  [Fact]
+  public async Task GetByIdAsync_Missing_Id_Returns_Null()
+  {
+    var loaded = await _repo.GetByIdAsync(999);
+    loaded.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task GetAllAsync_Returns_All_Saved_Variables()
+  {
+    await _repo.SaveAsync(new ProgesiVariable(1, "A", 1));
+    await _repo.SaveAsync(new ProgesiVariable(2, "B", 2));
+
+    var all = await _repo.GetAllAsync();
+
+    all.Should().HaveCount(2);
+    all.Select(v => v.Id).Should().BeEquivalentTo(new[] { 1, 2 });
+  }
+
+  [Fact]
+  public async Task SaveAsync_Overwrite_Same_Id_Replaces_Stored_Variable()
+  {
+    await _repo.SaveAsync(new ProgesiVariable(7, "Before", 1));
+    await _repo.SaveAsync(new ProgesiVariable(7, "After", 9));
+
+    var loaded = await _repo.GetByIdAsync(7);
+
+    loaded.Should().NotBeNull();
+    loaded!.Name.Should().Be("After");
+    loaded.Value.Should().Be(9);
+    (await _repo.GetAllAsync()).Should().HaveCount(1);
+  }
+
+  [Fact]
+  public async Task SaveAsync_Preserves_Hash_Computable_Content()
+  {
+    var original = new ProgesiVariable(11, "Load", 42, new[] { 3, 1, 2 }, metadataId: 4);
+
+    await _repo.SaveAsync(original);
+    var loaded = await _repo.GetByIdAsync(11);
+
+    loaded.Should().NotBeNull();
+    ProgesiHash.Compute(loaded!).Should().Be(ProgesiHash.Compute(original));
+  }
+
+  [Fact]
+  public async Task Save_Deduplicates_By_ContentHash()
+  {
+    var v1 = new ProgesiVariable(1, "A", 42, new[] { 3, 1, 2 }, metadataId: 7);
+    await _repo.SaveAsync(v1);
+
+    var v2 = new ProgesiVariable(2, "A", 42, new[] { 2, 3, 1 }, metadataId: 7);
+    var ret = await _repo.SaveAsync(v2);
+
+    ret.Id.Should().Be(1);
+
+    var all = await _repo.GetAllAsync();
+    all.Select(x => x.Id).Should().Contain(1).And.NotContain(2);
+  }
+
+  [Fact]
+  public async Task DeleteAsync_Existing_Id_Removes_Variable()
+  {
+    await _repo.SaveAsync(new ProgesiVariable(8, "Del", 0));
+
+    (await _repo.DeleteAsync(8)).Should().BeTrue();
+    (await _repo.GetByIdAsync(8)).Should().BeNull();
+    (await _repo.GetAllAsync()).Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task DeleteAsync_Missing_Id_Returns_False()
+  {
+    (await _repo.DeleteAsync(404)).Should().BeFalse();
+  }
+
+  [Fact]
+  public async Task DeleteManyAsync_Removes_Existing_Ids()
+  {
+    await _repo.SaveAsync(new ProgesiVariable(1, "A", 1));
+    await _repo.SaveAsync(new ProgesiVariable(2, "B", 2));
+    await _repo.SaveAsync(new ProgesiVariable(3, "C", 3));
+
+    var removed = await _repo.DeleteManyAsync(new[] { 1, 3, 99 });
+
+    removed.Should().Be(2);
+    (await _repo.GetAllAsync()).Select(v => v.Id).Should().Equal(2);
+  }
+
+  [Fact]
+  public async Task DeleteManyAsync_Empty_Ids_Returns_Zero()
+  {
+    var removed = await _repo.DeleteManyAsync(Array.Empty<int>());
+    removed.Should().Be(0);
+  }
+
+  public void Dispose()
+  {
+    var path = _connectionString.Replace("Data Source=", string.Empty);
+    try
+    {
+      if (File.Exists(path)) File.Delete(path);
+    }
+    catch
+    {
+      // best-effort cleanup
+    }
+  }
+}

--- a/tests/Progesi.Infrastructure.EF.Tests/Progesi.Infrastructure.EF.Tests.csproj
+++ b/tests/Progesi.Infrastructure.EF.Tests/Progesi.Infrastructure.EF.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ProgesiCore\ProgesiCore.csproj" />
+    <ProjectReference Include="..\..\src\Progesi.Infrastructure.EF\Progesi.Infrastructure.EF.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+</Project>

--- a/tests/Progesi.Infrastructure.EF.Tests/ProgesiDbContextTests.cs
+++ b/tests/Progesi.Infrastructure.EF.Tests/ProgesiDbContextTests.cs
@@ -1,0 +1,32 @@
+using FluentAssertions;
+using Progesi.Infrastructure.EF;
+
+namespace Progesi.Infrastructure.EF.Tests;
+
+public sealed class ProgesiDbContextTests : IDisposable
+{
+  private readonly ProgesiDbContext _context;
+  private readonly Microsoft.Data.Sqlite.SqliteConnection _connection;
+
+  public ProgesiDbContextTests()
+  {
+    (_context, _connection) = EfTestBootstrap.CreateIsolatedContext();
+  }
+
+  [Fact]
+  public void EnsureCreated_Creates_Variable_And_Metadata_Tables()
+  {
+    _context.Variables.Should().NotBeNull();
+    _context.Metadata.Should().NotBeNull();
+
+    _context.Database.CanConnect().Should().BeTrue();
+    _context.Variables.Count().Should().Be(0);
+    _context.Metadata.Count().Should().Be(0);
+  }
+
+  public void Dispose()
+  {
+    _context.Dispose();
+    _connection.Dispose();
+  }
+}


### PR DESCRIPTION
This PR adds the approved EF Option B first slice: EF Core infrastructure skeleton + Variable/Metadata parity.

Scope:
- Adds src/Progesi.Infrastructure.EF targeting net8.0.
- Adds tests/Progesi.Infrastructure.EF.Tests targeting net8.0.
- Adds EF Core 8 DbContext, entities, serialization helpers and repositories for Variable and Metadata only.
- Adds EF tests covering Var/Meta persistence and behaviour.
- Registers the new projects in Progesi.sln.
- Leaves Progesi.CI.slnf unchanged.

Validation before PR:
- dotnet build -c Release passed.
- dotnet test -c Release passed: 152 total, 152 passed, 0 failed.
- Progesi.Infrastructure.EF.Tests passed: 20 total, 20 passed, 0 failed.

This PR does not include:
- ProgesiCore changes
- EF references inside ProgesiCore
- DataExchange production changes
- Grasshopper/Rhino changes
- Cluster Phase 2 or Phase 3
- AxisVar work
- legacy Progesi.Data.EF / Progesi.EF.Tool changes
- Progesi.CI.slnf changes
- deployment scripts
- GitHub workflow changes
- artefacts
- main-branch interaction

Important notes:
- This is new infrastructure only. It is not wired into Grasshopper or DataExchange.
- SQLite remains the interim canonical path until adoption/migration is separately approved.
- Cluster Phase 3 remains future work.
- DataExchange consolidation remains future work.