### PR TITLE
test: expand DataExchange ExcelSerializer coverage

### DIFF
--- a/tests/ProgesiDataExchange.Tests/ExcelSerializerMalformedRowTests.cs
+++ b/tests/ProgesiDataExchange.Tests/ExcelSerializerMalformedRowTests.cs
@@ -1,0 +1,173 @@
+using System.Collections.Generic;
+using System.Linq;
+using ClosedXML.Excel;
+using FluentAssertions;
+using Progesi.DataExchange;
+using Xunit;
+
+namespace Progesi.DataExchange.Tests
+{
+  public class ExcelSerializerMalformedRowTests
+  {
+    [Fact]
+    public void Read_Variable_Row_With_Only_Id_Fills_Remaining_Fields_With_Empty_Strings()
+    {
+      using var file = new ExcelTestFile();
+      using (var wb = new XLWorkbook())
+      {
+        var ws = wb.Worksheets.Add("ProgesiVariable");
+        ws.Cell(1, 1).Value = "Id";
+        ws.Cell(1, 2).Value = "Hash";
+        ws.Cell(1, 3).Value = "Name";
+        ws.Cell(1, 4).Value = "Value";
+        ws.Cell(2, 1).Value = "42";
+        wb.SaveAs(file.Path);
+      }
+
+      var (vars, _, _) = ExcelSerializer.Read(file.Path);
+
+      vars.Should().HaveCount(1);
+      vars[0].Id.Should().Be("42");
+      vars[0].Hash.Should().BeEmpty();
+      vars[0].Name.Should().BeEmpty();
+      vars[0].Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Read_Variable_Sheet_Ignores_Unknown_Header_Columns()
+    {
+      using var file = new ExcelTestFile();
+      using (var wb = new XLWorkbook())
+      {
+        var ws = wb.Worksheets.Add("ProgesiVariable");
+        ws.Cell(1, 1).Value = "Id";
+        ws.Cell(1, 2).Value = "ExtraColumn";
+        ws.Cell(1, 3).Value = "Name";
+        ws.Cell(2, 1).Value = "1";
+        ws.Cell(2, 2).Value = "ignored";
+        ws.Cell(2, 3).Value = "Width";
+        wb.SaveAs(file.Path);
+      }
+
+      var (vars, _, _) = ExcelSerializer.Read(file.Path);
+
+      vars.Should().HaveCount(1);
+      vars[0].Id.Should().Be("1");
+      vars[0].Name.Should().Be("Width");
+    }
+
+    [Fact]
+    public void Read_Variable_Sheet_With_Reordered_Columns_Maps_By_Header_Name()
+    {
+      using var file = new ExcelTestFile();
+      using (var wb = new XLWorkbook())
+      {
+        var ws = wb.Worksheets.Add("ProgesiVariable");
+        ws.Cell(1, 1).Value = "Name";
+        ws.Cell(1, 2).Value = "Id";
+        ws.Cell(1, 3).Value = "Value";
+        ws.Cell(2, 1).Value = "Depth";
+        ws.Cell(2, 2).Value = "9";
+        ws.Cell(2, 3).Value = "3.5";
+        wb.SaveAs(file.Path);
+      }
+
+      var (vars, _, _) = ExcelSerializer.Read(file.Path);
+
+      vars.Should().HaveCount(1);
+      vars[0].Id.Should().Be("9");
+      vars[0].Name.Should().Be("Depth");
+      vars[0].Value.Should().Be("3.5");
+    }
+
+    [Fact]
+    public void Read_Variable_Sheet_Includes_Blank_Data_Row_As_Default_Dto()
+    {
+      using var file = new ExcelTestFile();
+      using (var wb = new XLWorkbook())
+      {
+        var ws = wb.Worksheets.Add("ProgesiVariable");
+        ws.Cell(1, 1).Value = "Id";
+        ws.Cell(1, 2).Value = "Name";
+        ws.Cell(3, 1).Value = "2";
+        ws.Cell(3, 2).Value = "AfterBlank";
+        wb.SaveAs(file.Path);
+      }
+
+      var (vars, _, _) = ExcelSerializer.Read(file.Path);
+
+      vars.Should().HaveCount(2);
+      vars[0].Id.Should().BeEmpty();
+      vars[0].Name.Should().BeEmpty();
+      vars[1].Id.Should().Be("2");
+      vars[1].Name.Should().Be("AfterBlank");
+    }
+
+    [Fact]
+    public void Read_Metadata_Row_With_Partial_Columns_Preserves_Provided_Fields()
+    {
+      using var file = new ExcelTestFile();
+      using (var wb = new XLWorkbook())
+      {
+        var ws = wb.Worksheets.Add("ProgesiMetadata");
+        ws.Cell(1, 1).Value = "Id";
+        ws.Cell(1, 2).Value = "Info";
+        ws.Cell(1, 3).Value = "By";
+        ws.Cell(2, 2).Value = "notes-only";
+        wb.SaveAs(file.Path);
+      }
+
+      var (_, mets, _) = ExcelSerializer.Read(file.Path);
+
+      mets.Should().HaveCount(1);
+      mets[0].Id.Should().BeEmpty();
+      mets[0].Info.Should().Be("notes-only");
+      mets[0].By.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Read_Metadata_Sheet_Ignores_Unknown_Header_Columns()
+    {
+      using var file = new ExcelTestFile();
+      using (var wb = new XLWorkbook())
+      {
+        var ws = wb.Worksheets.Add("ProgesiMetadata");
+        ws.Cell(1, 1).Value = "Id";
+        ws.Cell(1, 2).Value = "Unknown";
+        ws.Cell(1, 3).Value = "Info";
+        ws.Cell(2, 1).Value = "5";
+        ws.Cell(2, 2).Value = "drop-me";
+        ws.Cell(2, 3).Value = "kept";
+        wb.SaveAs(file.Path);
+      }
+
+      var (_, mets, _) = ExcelSerializer.Read(file.Path);
+
+      mets.Should().HaveCount(1);
+      mets[0].Id.Should().Be("5");
+      mets[0].Info.Should().Be("kept");
+    }
+
+    [Fact]
+    public void Read_Hand_Built_Workbook_Preserves_Row_Order_On_Import()
+    {
+      using var file = new ExcelTestFile();
+      using (var wb = new XLWorkbook())
+      {
+        var ws = wb.Worksheets.Add("ProgesiVariable");
+        ws.Cell(1, 1).Value = "Id";
+        ws.Cell(1, 2).Value = "Name";
+        ws.Cell(2, 1).Value = "100";
+        ws.Cell(2, 2).Value = "RowA";
+        ws.Cell(3, 1).Value = "50";
+        ws.Cell(3, 2).Value = "RowB";
+        wb.SaveAs(file.Path);
+      }
+
+      var (vars, _, _) = ExcelSerializer.Read(file.Path);
+
+      vars.Select(v => v.Id).Should().Equal("100", "50");
+      vars.Select(v => v.Name).Should().Equal("RowA", "RowB");
+    }
+  }
+}

--- a/tests/ProgesiDataExchange.Tests/ExcelSerializerWorkbookShapeTests.cs
+++ b/tests/ProgesiDataExchange.Tests/ExcelSerializerWorkbookShapeTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Linq;
+using ClosedXML.Excel;
+using FluentAssertions;
+using Progesi.DataExchange;
+using Xunit;
+
+namespace Progesi.DataExchange.Tests
+{
+  public class ExcelSerializerWorkbookShapeTests
+  {
+    [Fact]
+    public void Write_Always_Creates_Three_Progesi_Sheets_With_Expected_Names()
+    {
+      using var file = new ExcelTestFile();
+      ExcelSerializer.Write(
+        file.Path,
+        new List<ProgesiVariableDto>(),
+        new List<ProgesiMetadataDto>(),
+        new List<ProgesiAxisVariableDto>());
+
+      using var wb = new XLWorkbook(file.Path);
+      wb.Worksheets.Select(ws => ws.Name).Should().Equal(
+        "ProgesiVariable",
+        "ProgesiMetadata",
+        "ProgesiAxisVariable");
+    }
+
+    [Fact]
+    public void Write_Empty_Axis_Collection_Still_Writes_ProgesiAxisVariable_Header_Row()
+    {
+      using var file = new ExcelTestFile();
+      ExcelSerializer.Write(
+        file.Path,
+        new List<ProgesiVariableDto>(),
+        new List<ProgesiMetadataDto>(),
+        new List<ProgesiAxisVariableDto>());
+
+      using var wb = new XLWorkbook(file.Path);
+      var sheet = wb.Worksheet("ProgesiAxisVariable");
+      sheet.Cell(1, 1).GetString().Should().Be("Id");
+      sheet.Cell(1, 4).GetString().Should().Be("ValueTypeKey");
+      sheet.LastRowUsed()!.RowNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void Read_Workbook_With_Unrelated_Sheet_Only_Returns_Empty_Collections()
+    {
+      using var file = new ExcelTestFile();
+      using (var wb = new XLWorkbook())
+      {
+        wb.Worksheets.Add("OtherSheet");
+        wb.SaveAs(file.Path);
+      }
+
+      var (vars, mets, axis) = ExcelSerializer.Read(file.Path);
+
+      vars.Should().BeEmpty();
+      mets.Should().BeEmpty();
+      axis.Should().BeEmpty();
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the approved Option A first slice of the DataExchange/GH read-contract work: DataExchange-library-only tests.

Scope:
- Adds workbook-shape tests for the current DataExchange library ExcelSerializer contract.
- Adds malformed-row / read edge-case tests.
- Changes only tests/ProgesiDataExchange.Tests.

Validation before PR:
- dotnet build -c Release passed.
- dotnet test -c Release passed: 162 total, 162 passed, 0 failed.
- ProgesiDataExchange.Tests passed: 23 total, 23 passed, 0 failed.

This PR does not include:
- production code changes
- src/ProgesiDataExchange changes
- Grasshopper/Rhino changes
- GH helper extraction
- ProgesiClusters in the DataExchange library
- EF changes
- Core changes
- Cluster changes
- AxisVar behaviour expansion
- Progesi.sln changes
- Progesi.CI.slnf changes
- deployment scripts
- GitHub workflow changes
- artefacts
- main-branch interaction

Important notes:
- The DataExchange library contract remains distinct from the Grasshopper workbook contract.
- GH sparse-ID / ReadCell / EnumerateIds / ProgesiClusters automation remains a future separately-approved task.
- Empty AxisVar collections are only used where required by the existing ExcelSerializer signature; AxisVar behaviour is not expanded.
- ClosedXML cannot save a workbook with zero worksheets, so the equivalent unrelated-sheet-only workbook case is covered.