### PR TITLE
test: extract GH Excel read-contract helper

### DIFF
--- a/Progesi.sln
+++ b/Progesi.sln
@@ -43,6 +43,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Progesi.Infrastructure.EF",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Progesi.Infrastructure.EF.Tests", "tests\Progesi.Infrastructure.EF.Tests\Progesi.Infrastructure.EF.Tests.csproj", "{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Progesi.GhExcelReadContract", "src\Progesi.GhExcelReadContract\Progesi.GhExcelReadContract.csproj", "{795D3F7B-F675-4612-928D-0640996D7149}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Progesi.GhExcelReadContract.Tests", "tests\Progesi.GhExcelReadContract.Tests\Progesi.GhExcelReadContract.Tests.csproj", "{91B56D43-36DD-4821-8D6E-0CD2461D1FAF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -257,6 +261,30 @@ Global
 		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D}.Release|x64.Build.0 = Release|Any CPU
 		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D}.Release|x86.ActiveCfg = Release|Any CPU
 		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D}.Release|x86.Build.0 = Release|Any CPU
+		{795D3F7B-F675-4612-928D-0640996D7149}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{795D3F7B-F675-4612-928D-0640996D7149}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{795D3F7B-F675-4612-928D-0640996D7149}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{795D3F7B-F675-4612-928D-0640996D7149}.Debug|x64.Build.0 = Debug|Any CPU
+		{795D3F7B-F675-4612-928D-0640996D7149}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{795D3F7B-F675-4612-928D-0640996D7149}.Debug|x86.Build.0 = Debug|Any CPU
+		{795D3F7B-F675-4612-928D-0640996D7149}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{795D3F7B-F675-4612-928D-0640996D7149}.Release|Any CPU.Build.0 = Release|Any CPU
+		{795D3F7B-F675-4612-928D-0640996D7149}.Release|x64.ActiveCfg = Release|Any CPU
+		{795D3F7B-F675-4612-928D-0640996D7149}.Release|x64.Build.0 = Release|Any CPU
+		{795D3F7B-F675-4612-928D-0640996D7149}.Release|x86.ActiveCfg = Release|Any CPU
+		{795D3F7B-F675-4612-928D-0640996D7149}.Release|x86.Build.0 = Release|Any CPU
+		{91B56D43-36DD-4821-8D6E-0CD2461D1FAF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{91B56D43-36DD-4821-8D6E-0CD2461D1FAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91B56D43-36DD-4821-8D6E-0CD2461D1FAF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{91B56D43-36DD-4821-8D6E-0CD2461D1FAF}.Debug|x64.Build.0 = Debug|Any CPU
+		{91B56D43-36DD-4821-8D6E-0CD2461D1FAF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{91B56D43-36DD-4821-8D6E-0CD2461D1FAF}.Debug|x86.Build.0 = Debug|Any CPU
+		{91B56D43-36DD-4821-8D6E-0CD2461D1FAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{91B56D43-36DD-4821-8D6E-0CD2461D1FAF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{91B56D43-36DD-4821-8D6E-0CD2461D1FAF}.Release|x64.ActiveCfg = Release|Any CPU
+		{91B56D43-36DD-4821-8D6E-0CD2461D1FAF}.Release|x64.Build.0 = Release|Any CPU
+		{91B56D43-36DD-4821-8D6E-0CD2461D1FAF}.Release|x86.ActiveCfg = Release|Any CPU
+		{91B56D43-36DD-4821-8D6E-0CD2461D1FAF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -268,6 +296,8 @@ Global
 		{D63373CE-3B8F-4173-90D0-A30B57E71CBD} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{7941D544-4004-4116-9E07-707CAFC8C724} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{795D3F7B-F675-4612-928D-0640996D7149} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{91B56D43-36DD-4821-8D6E-0CD2461D1FAF} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C753CED5-7508-4B2A-A107-C1E530FD786B}

--- a/src/Progesi.GhExcelReadContract/GhExcelAliasMaps.cs
+++ b/src/Progesi.GhExcelReadContract/GhExcelAliasMaps.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+namespace Progesi.GhExcelReadContract
+{
+  public static class GhExcelAliasMaps
+  {
+    public static (Dictionary<string, HashSet<string>> VariableAliases,
+                   Dictionary<string, HashSet<string>> MetadataAliases)
+      Build(string mapJson)
+    {
+      var variableAliases = CreateDefaultVariableAliases();
+      var metadataAliases = CreateDefaultMetadataAliases();
+
+      if (!string.IsNullOrWhiteSpace(mapJson))
+      {
+        try
+        {
+          var json = JObject.Parse(mapJson);
+          if (json["Variables"] is JObject variableOverrides)
+            MergeAliases(variableOverrides, variableAliases);
+          if (json["Metadata"] is JObject metadataOverrides)
+            MergeAliases(metadataOverrides, metadataAliases);
+        }
+        catch
+        {
+          // ignore malformed map JSON (same behaviour as GH component)
+        }
+      }
+
+      return (variableAliases, metadataAliases);
+    }
+
+    public static Dictionary<string, HashSet<string>> CreateDefaultVariableAliases()
+    {
+      return new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
+      {
+        ["ID"] = new HashSet<string>(new[] { "ID", "IDVAR", "VARID" }, StringComparer.OrdinalIgnoreCase),
+        ["HASH"] = new HashSet<string>(new[] { "HASH", "DIGEST", "SHA" }, StringComparer.OrdinalIgnoreCase),
+        ["NAME"] = new HashSet<string>(new[] { "NAME", "VAR", "VARIABLE", "NOME", "FIELD" }, StringComparer.OrdinalIgnoreCase),
+        ["VALUE"] = new HashSet<string>(new[] { "VALUE", "VAL", "VALORE" }, StringComparer.OrdinalIgnoreCase),
+        ["VALC"] = new HashSet<string>(new[] { "VALC", "VALUECANONICAL", "VAL_CANONICAL", "CANONICAL" }, StringComparer.OrdinalIgnoreCase),
+        ["METAID"] = new HashSet<string>(new[] { "METAID", "MID", "METADATAID", "META_ID" }, StringComparer.OrdinalIgnoreCase),
+        ["DEPENDS"] = new HashSet<string>(new[] { "DEPENDS", "DEPENDENCIES", "DEPS", "DEP", "PARENT_IDS" }, StringComparer.OrdinalIgnoreCase),
+        ["ASSUMPTION"] = new HashSet<string>(new[] { "ASSUMPTION", "ASS", "ISASSUMPTION", "ASSUME" }, StringComparer.OrdinalIgnoreCase)
+      };
+    }
+
+    public static Dictionary<string, HashSet<string>> CreateDefaultMetadataAliases()
+    {
+      return new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
+      {
+        ["ID"] = new HashSet<string>(new[] { "ID", "METAID" }, StringComparer.OrdinalIgnoreCase),
+        ["HASH"] = new HashSet<string>(new[] { "HASH", "DIGEST" }, StringComparer.OrdinalIgnoreCase),
+        ["BY"] = new HashSet<string>(new[] { "BY", "AUTHOR", "CREATEDBY", "CREATED_BY", "OWNER" }, StringComparer.OrdinalIgnoreCase),
+        ["DESCRIPTION"] = new HashSet<string>(new[] { "DESCRIPTION", "DESC", "DESCR", "INFO", "NOTE", "NOTES" }, StringComparer.OrdinalIgnoreCase),
+        ["REFS"] = new HashSet<string>(new[] { "REFS", "REF", "REFERENCE", "REFERENCES", "URLS", "LINKS" }, StringComparer.OrdinalIgnoreCase),
+        ["SNIPS"] = new HashSet<string>(new[] { "SNIPS", "SNIP", "ATTACHMENTS", "IMAGES" }, StringComparer.OrdinalIgnoreCase),
+        ["LM"] = new HashSet<string>(new[] { "LM", "LASTMODIFIED", "LAST_MODIFIED", "UPDATED", "LASTUPDATE", "LAST_UPDATE" }, StringComparer.OrdinalIgnoreCase)
+      };
+    }
+
+    public static Dictionary<string, HashSet<string>> CreateDefaultClusterAliases()
+    {
+      return new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
+      {
+        ["ID"] = new HashSet<string>(new[] { "ID", "CLUSTERID", "CID" }, StringComparer.OrdinalIgnoreCase),
+        ["HASH"] = new HashSet<string>(new[] { "HASH", "DIGEST", "HASHTAG" }, StringComparer.OrdinalIgnoreCase),
+        ["NAME"] = new HashSet<string>(new[] { "NAME", "CLUSTER", "CLUSTERNAME", "NOME" }, StringComparer.OrdinalIgnoreCase),
+        ["DESCRIPTION"] = new HashSet<string>(new[] { "DESCRIPTION", "DESC", "DESCR", "INFO", "NOTE", "NOTES" }, StringComparer.OrdinalIgnoreCase),
+        ["VARIABLEIDS"] = new HashSet<string>(new[] { "VARIABLEIDS", "VARIDS", "VARIABLES", "VARS", "MEMBERIDS", "MEMBERS" }, StringComparer.OrdinalIgnoreCase)
+      };
+    }
+
+    public static string NormalizeKey(string value)
+    {
+      if (string.IsNullOrEmpty(value))
+        return string.Empty;
+
+      var upper = value.Trim().ToUpperInvariant();
+      var buffer = new StringBuilder(upper.Length);
+      for (int i = 0; i < upper.Length; i++)
+      {
+        if (char.IsLetterOrDigit(upper[i]))
+          buffer.Append(upper[i]);
+      }
+
+      return buffer.ToString();
+    }
+
+    private static void MergeAliases(JObject source, Dictionary<string, HashSet<string>> target)
+    {
+      foreach (var property in source.Properties())
+      {
+        var key = NormalizeKey(property.Name);
+        if (string.IsNullOrEmpty(key))
+          continue;
+
+        if (!target.ContainsKey(key))
+          target[key] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (property.Value is JArray array)
+        {
+          foreach (var token in array)
+          {
+            var alias = token?.ToString();
+            if (!string.IsNullOrWhiteSpace(alias))
+              target[key].Add(NormalizeKey(alias));
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Progesi.GhExcelReadContract/GhExcelCellReader.cs
+++ b/src/Progesi.GhExcelReadContract/GhExcelCellReader.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using ClosedXML.Excel;
+
+namespace Progesi.GhExcelReadContract
+{
+  public static class GhExcelCellReader
+  {
+    public static string ReadCell(IXLWorksheet worksheet, int row, Dictionary<string, int> map, string key)
+    {
+      if (!map.TryGetValue(key, out int column))
+        return string.Empty;
+
+      var cell = worksheet.Cell(row, column);
+
+      var text = cell.GetString();
+      if (!string.IsNullOrWhiteSpace(text))
+        return text;
+
+      text = cell.GetFormattedString();
+      if (!string.IsNullOrWhiteSpace(text))
+        return text;
+
+      try { return cell.Value.ToString(); }
+      catch { return string.Empty; }
+    }
+  }
+}

--- a/src/Progesi.GhExcelReadContract/GhExcelClusterSheet.cs
+++ b/src/Progesi.GhExcelReadContract/GhExcelClusterSheet.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using ClosedXML.Excel;
+using ProgesiCore;
+
+namespace Progesi.GhExcelReadContract
+{
+  public static class GhExcelClusterSheet
+  {
+    public static bool TryParseClusterRow(
+      IXLWorksheet worksheet,
+      int row,
+      Dictionary<string, int> columnMap,
+      out int id,
+      out string name,
+      out string description,
+      out int[] variableIds,
+      out string hash,
+      out string warn)
+    {
+      if (worksheet == null) throw new ArgumentNullException(nameof(worksheet));
+      if (columnMap == null) throw new ArgumentNullException(nameof(columnMap));
+
+      return ClusterImportParser.TryParseClusterRow(
+        key => GhExcelCellReader.ReadCell(worksheet, row, columnMap, key),
+        out id,
+        out name,
+        out description,
+        out variableIds,
+        out hash,
+        out warn);
+    }
+
+    public static Dictionary<string, int> ResolveClusterColumns(Dictionary<string, int> header)
+    {
+      return GhExcelColumnMap.ResolveColumns(header, GhExcelAliasMaps.CreateDefaultClusterAliases());
+    }
+  }
+}

--- a/src/Progesi.GhExcelReadContract/GhExcelColumnMap.cs
+++ b/src/Progesi.GhExcelReadContract/GhExcelColumnMap.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+namespace Progesi.GhExcelReadContract
+{
+  public static class GhExcelColumnMap
+  {
+    public static Dictionary<string, int> ResolveColumns(
+      Dictionary<string, int> header,
+      Dictionary<string, HashSet<string>> aliases)
+    {
+      if (header == null) throw new ArgumentNullException(nameof(header));
+      if (aliases == null) throw new ArgumentNullException(nameof(aliases));
+
+      var result = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+      foreach (var pair in aliases)
+      {
+        string canonical = pair.Key;
+        if (header.TryGetValue(canonical, out int column))
+        {
+          result[canonical] = column;
+          continue;
+        }
+
+        foreach (var alternate in pair.Value)
+        {
+          if (header.TryGetValue(alternate, out column))
+          {
+            result[canonical] = column;
+            break;
+          }
+        }
+      }
+
+      return result;
+    }
+
+    public static List<string> MissingRequired(Dictionary<string, int> map, IEnumerable<string> required)
+    {
+      if (map == null) throw new ArgumentNullException(nameof(map));
+      if (required == null) throw new ArgumentNullException(nameof(required));
+
+      var missing = new List<string>();
+      foreach (var requiredKey in required)
+      {
+        if (!map.ContainsKey(requiredKey))
+          missing.Add(requiredKey);
+      }
+
+      return missing;
+    }
+  }
+}

--- a/src/Progesi.GhExcelReadContract/GhExcelHeaderMap.cs
+++ b/src/Progesi.GhExcelReadContract/GhExcelHeaderMap.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using ClosedXML.Excel;
+
+namespace Progesi.GhExcelReadContract
+{
+  public static class GhExcelHeaderMap
+  {
+    public static Dictionary<string, int> Build(IXLWorksheet worksheet, out int firstRow, out int lastRow)
+    {
+      if (worksheet == null) throw new ArgumentNullException(nameof(worksheet));
+
+      var used = worksheet.RangeUsed();
+      if (used == null)
+      {
+        firstRow = 1;
+        lastRow = 0;
+        return new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+      }
+
+      firstRow = used.RangeAddress.FirstAddress.RowNumber;
+      lastRow = used.RangeAddress.LastAddress.RowNumber;
+
+      var map = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+      var headerRow = worksheet.Row(firstRow);
+      foreach (var cell in headerRow.CellsUsed())
+      {
+        var key = GhExcelAliasMaps.NormalizeKey(cell.GetString());
+        if (!string.IsNullOrEmpty(key) && !map.ContainsKey(key))
+          map[key] = cell.Address.ColumnNumber;
+      }
+
+      return map;
+    }
+  }
+}

--- a/src/Progesi.GhExcelReadContract/GhExcelSheetNames.cs
+++ b/src/Progesi.GhExcelReadContract/GhExcelSheetNames.cs
@@ -1,0 +1,12 @@
+namespace Progesi.GhExcelReadContract
+{
+  public static class GhExcelSheetNames
+  {
+    public const string Variables = "ProgesiVariables";
+    public const string VariablesAlias = "Variables";
+    public const string Metadata = "ProgesiMetadata";
+    public const string MetadataAlias = "Metadata";
+    public const string Clusters = "ProgesiClusters";
+    public const string ClustersAlias = "Clusters";
+  }
+}

--- a/src/Progesi.GhExcelReadContract/GhExcelValueParsing.cs
+++ b/src/Progesi.GhExcelReadContract/GhExcelValueParsing.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Progesi.GhExcelReadContract
+{
+  public static class GhExcelValueParsing
+  {
+    public static bool IsBlank(string value) => string.IsNullOrWhiteSpace(value);
+
+    public static int ToInt(string value)
+    {
+      int number;
+      return int.TryParse((value ?? string.Empty).Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out number)
+        ? number
+        : 0;
+    }
+
+    public static bool ToBool(string value)
+    {
+      var trimmed = (value ?? string.Empty).Trim();
+      if (trimmed == "1") return true;
+      if (trimmed == "0") return false;
+      bool parsed;
+      return bool.TryParse(trimmed, out parsed) && parsed;
+    }
+
+    public static int[] ParseDepends(string value)
+    {
+      if (string.IsNullOrWhiteSpace(value))
+        return Array.Empty<int>();
+
+      var tokens = value.Split(new[] { ',', ';', '|', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+      var list = new List<int>();
+      foreach (var token in tokens)
+      {
+        int number;
+        if (int.TryParse(token.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out number) && number > 0)
+          list.Add(number);
+      }
+
+      list.Sort();
+      return list.ToArray();
+    }
+  }
+}

--- a/src/Progesi.GhExcelReadContract/GhExcelWorksheetLocator.cs
+++ b/src/Progesi.GhExcelReadContract/GhExcelWorksheetLocator.cs
@@ -1,0 +1,25 @@
+using System;
+using ClosedXML.Excel;
+
+namespace Progesi.GhExcelReadContract
+{
+  public static class GhExcelWorksheetLocator
+  {
+    public static IXLWorksheet TryGetWorksheet(IXLWorkbook workbook, params string[] names)
+    {
+      if (workbook == null) throw new ArgumentNullException(nameof(workbook));
+      if (names == null || names.Length == 0) return null;
+
+      foreach (var name in names)
+      {
+        foreach (var worksheet in workbook.Worksheets)
+        {
+          if (string.Equals(worksheet.Name, name, StringComparison.OrdinalIgnoreCase))
+            return worksheet;
+        }
+      }
+
+      return null;
+    }
+  }
+}

--- a/src/Progesi.GhExcelReadContract/Progesi.GhExcelReadContract.csproj
+++ b/src/Progesi.GhExcelReadContract/Progesi.GhExcelReadContract.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>disable</Nullable>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ProgesiCore\ProgesiCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ClosedXML" Version="0.104.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>

--- a/src/ProgesiGrasshopperAssembly/Components/ProgesiDataExchangeComponent.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/ProgesiDataExchangeComponent.cs
@@ -12,6 +12,7 @@ using Grasshopper.Kernel.Types;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ProgesiCore;
+using Progesi.GhExcelReadContract;
 using ProgesiGrasshopperAssembly.Infrastructure; // ServiceHub, ProgesiIcons, MetadataRepositoryCompatExtensions
 using Rhino;
 using Rhino.DocObjects.Tables;
@@ -388,7 +389,7 @@ namespace ProgesiGrasshopperAssembly.Components
         throw new InvalidOperationException("RHINO repository not available.");
 
       // alias
-      var (varAliases, metaAliases) = BuildAliasMaps(mapJson);
+      var (varAliases, metaAliases) = GhExcelAliasMaps.Build(mapJson);
 
       // limiti/regex
       const int NAME_MAX = 128;
@@ -404,7 +405,7 @@ namespace ProgesiGrasshopperAssembly.Components
       using (var wb = new XLWorkbook(p))
       {
         // ========== METADATA ==========
-        var wsM = TryGetWorksheet(wb, "ProgesiMetadata", "Metadata");
+        var wsM = GhExcelWorksheetLocator.TryGetWorksheet(wb, GhExcelSheetNames.Metadata, GhExcelSheetNames.MetadataAlias);
         bool metaHeaderError = false;
         Dictionary<string, int> mapM = null;
         int r0M = 1, rNM = 0;
@@ -417,9 +418,9 @@ namespace ProgesiGrasshopperAssembly.Components
         }
         else
         {
-          var headerM = BuildHeaderMap(wsM, out r0M, out rNM);
-          mapM = ResolveColumns(headerM, metaAliases);
-          var missingMeta = MissingRequired(mapM, new[] { "BY", "DESCRIPTION" });
+          var headerM = GhExcelHeaderMap.Build(wsM, out r0M, out rNM);
+          mapM = GhExcelColumnMap.ResolveColumns(headerM, metaAliases);
+          var missingMeta = GhExcelColumnMap.MissingRequired(mapM, new[] { "BY", "DESCRIPTION" });
           if (missingMeta.Count > 0)
           {
             string m = "Missing headers (Meta): " + string.Join(",", missingMeta);
@@ -432,12 +433,12 @@ namespace ProgesiGrasshopperAssembly.Components
         {
           for (int r = r0M + 1; r <= rNM; r++)
           {
-            string by = ReadCell(wsM, r, mapM, "BY");
-            string desc = ReadCell(wsM, r, mapM, "DESCRIPTION");
-            string refs = ReadCell(wsM, r, mapM, "REFS");
-            int id = ToInt(ReadCell(wsM, r, mapM, "ID"));
+            string by = GhExcelCellReader.ReadCell(wsM, r, mapM, "BY");
+            string desc = GhExcelCellReader.ReadCell(wsM, r, mapM, "DESCRIPTION");
+            string refs = GhExcelCellReader.ReadCell(wsM, r, mapM, "REFS");
+            int id = GhExcelValueParsing.ToInt(GhExcelCellReader.ReadCell(wsM, r, mapM, "ID"));
 
-            if (IsBlank(by) && IsBlank(desc) && IsBlank(refs))
+            if (GhExcelValueParsing.IsBlank(by) && GhExcelValueParsing.IsBlank(desc) && GhExcelValueParsing.IsBlank(refs))
             { WARN(0, $"[Meta R{r}] empty row → skip"); metaWarn++; metaRows++; continue; }
 
             // controlli extra
@@ -474,7 +475,7 @@ namespace ProgesiGrasshopperAssembly.Components
         }
 
         // ========== VARIABLES ==========
-        var wsV = TryGetWorksheet(wb, "ProgesiVariables", "Variables");
+        var wsV = GhExcelWorksheetLocator.TryGetWorksheet(wb, GhExcelSheetNames.Variables, GhExcelSheetNames.VariablesAlias);
         bool varHeaderError = false;
         Dictionary<string, int> mapV = null;
         int r0V = 1, rNV = 0;
@@ -487,9 +488,9 @@ namespace ProgesiGrasshopperAssembly.Components
         }
         else
         {
-          var headerV = BuildHeaderMap(wsV, out r0V, out rNV);
-          mapV = ResolveColumns(headerV, varAliases);
-          var missingVar = MissingRequired(mapV, new[] { "NAME", "VALUE" });
+          var headerV = GhExcelHeaderMap.Build(wsV, out r0V, out rNV);
+          mapV = GhExcelColumnMap.ResolveColumns(headerV, varAliases);
+          var missingVar = GhExcelColumnMap.MissingRequired(mapV, new[] { "NAME", "VALUE" });
           if (missingVar.Count > 0)
           {
             string m = "Missing headers (Vars): " + string.Join(",", missingVar);
@@ -502,14 +503,14 @@ namespace ProgesiGrasshopperAssembly.Components
         {
           for (int r = r0V + 1; r <= rNV; r++)
           {
-            string name = ReadCell(wsV, r, mapV, "NAME");
-            string value = ReadCell(wsV, r, mapV, "VALUE");
-            string deps = ReadCell(wsV, r, mapV, "DEPENDS");
-            string asS = ReadCell(wsV, r, mapV, "ASSUMPTION");
-            int id = ToInt(ReadCell(wsV, r, mapV, "ID"));
-            int mid = ToInt(ReadCell(wsV, r, mapV, "METAID"));
+            string name = GhExcelCellReader.ReadCell(wsV, r, mapV, "NAME");
+            string value = GhExcelCellReader.ReadCell(wsV, r, mapV, "VALUE");
+            string deps = GhExcelCellReader.ReadCell(wsV, r, mapV, "DEPENDS");
+            string asS = GhExcelCellReader.ReadCell(wsV, r, mapV, "ASSUMPTION");
+            int id = GhExcelValueParsing.ToInt(GhExcelCellReader.ReadCell(wsV, r, mapV, "ID"));
+            int mid = GhExcelValueParsing.ToInt(GhExcelCellReader.ReadCell(wsV, r, mapV, "METAID"));
 
-            if (IsBlank(name) && IsBlank(value) && IsBlank(deps) && IsBlank(asS))
+            if (GhExcelValueParsing.IsBlank(name) && GhExcelValueParsing.IsBlank(value) && GhExcelValueParsing.IsBlank(deps) && GhExcelValueParsing.IsBlank(asS))
             { WARN(1, $"[Var R{r}] empty row → skip"); varWarn++; varRows++; continue; }
 
             // extra checks
@@ -526,8 +527,8 @@ namespace ProgesiGrasshopperAssembly.Components
               { var msg = $"[Var R{r}] METAID not found: {mid}"; (strict ? ERR : WARN)(1, msg); AddErrRC(1, r, mapV.TryGetValue("METAID", out var c) ? c : 0); if (strict) { varErr++; continue; } else { varWarn++; mid = 0; } }
             }
 
-            int[] depArr = ParseDepends(deps);
-            bool ass = ToBool(asS);
+            int[] depArr = GhExcelValueParsing.ParseDepends(deps);
+            bool ass = GhExcelValueParsing.ToBool(asS);
 
             if (!dryRun)
             {
@@ -1150,62 +1151,6 @@ CREATE TABLE IF NOT EXISTS ClusterVariables (
       return (db, logPath, warnTree, errTree, counts, errRC, info);
     }
 
-    private static (Dictionary<string, HashSet<string>> varAliases,
-                    Dictionary<string, HashSet<string>> metaAliases)
-      BuildAliasMaps(string mapJson)
-    {
-      var varA = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
-      {
-        ["ID"] = new HashSet<string>(new[] { "ID", "IDVAR", "VARID" }, StringComparer.OrdinalIgnoreCase),
-        ["HASH"] = new HashSet<string>(new[] { "HASH", "DIGEST", "SHA" }, StringComparer.OrdinalIgnoreCase),
-        ["NAME"] = new HashSet<string>(new[] { "NAME", "VAR", "VARIABLE", "NOME", "FIELD" }, StringComparer.OrdinalIgnoreCase),
-        ["VALUE"] = new HashSet<string>(new[] { "VALUE", "VAL", "VALORE" }, StringComparer.OrdinalIgnoreCase),
-        ["VALC"] = new HashSet<string>(new[] { "VALC", "VALUECANONICAL", "VAL_CANONICAL", "CANONICAL" }, StringComparer.OrdinalIgnoreCase),
-        ["METAID"] = new HashSet<string>(new[] { "METAID", "MID", "METADATAID", "META_ID" }, StringComparer.OrdinalIgnoreCase),
-        ["DEPENDS"] = new HashSet<string>(new[] { "DEPENDS", "DEPENDENCIES", "DEPS", "DEP", "PARENT_IDS" }, StringComparer.OrdinalIgnoreCase),
-        ["ASSUMPTION"] = new HashSet<string>(new[] { "ASSUMPTION", "ASS", "ISASSUMPTION", "ASSUME" }, StringComparer.OrdinalIgnoreCase)
-      };
-      var metaA = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
-      {
-        ["ID"] = new HashSet<string>(new[] { "ID", "METAID" }, StringComparer.OrdinalIgnoreCase),
-        ["HASH"] = new HashSet<string>(new[] { "HASH", "DIGEST" }, StringComparer.OrdinalIgnoreCase),
-        ["BY"] = new HashSet<string>(new[] { "BY", "AUTHOR", "CREATEDBY", "CREATED_BY", "OWNER" }, StringComparer.OrdinalIgnoreCase),
-        ["DESCRIPTION"] = new HashSet<string>(new[] { "DESCRIPTION", "DESC", "DESCR", "INFO", "NOTE", "NOTES" }, StringComparer.OrdinalIgnoreCase),
-        ["REFS"] = new HashSet<string>(new[] { "REFS", "REF", "REFERENCE", "REFERENCES", "URLS", "LINKS" }, StringComparer.OrdinalIgnoreCase),
-        ["SNIPS"] = new HashSet<string>(new[] { "SNIPS", "SNIP", "ATTACHMENTS", "IMAGES" }, StringComparer.OrdinalIgnoreCase),
-        ["LM"] = new HashSet<string>(new[] { "LM", "LASTMODIFIED", "LAST_MODIFIED", "UPDATED", "LASTUPDATE", "LAST_UPDATE" }, StringComparer.OrdinalIgnoreCase)
-      };
-      if (!string.IsNullOrWhiteSpace(mapJson))
-      {
-        try
-        {
-          var j = JObject.Parse(mapJson);
-          if (j["Variables"] is JObject vj) MergeAliases(vj, varA);
-          if (j["Metadata"] is JObject mj) MergeAliases(mj, metaA);
-        }
-        catch { /* ignore malformed */ }
-      }
-      return (varA, metaA);
-
-      static void MergeAliases(JObject obj, Dictionary<string, HashSet<string>> target)
-      {
-        foreach (var prop in obj.Properties())
-        {
-          var key = NormalizeKey(prop.Name);
-          if (string.IsNullOrEmpty(key)) continue;
-          if (!target.ContainsKey(key)) target[key] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-          if (prop.Value is JArray arr)
-          {
-            foreach (var t in arr)
-            {
-              var s = t?.ToString();
-              if (!string.IsNullOrWhiteSpace(s))
-                target[key].Add(NormalizeKey(s));
-            }
-          }
-        }
-      }
-    }
     private static string ResolveSqlitePath(string inputPath)
     {
       // Se è una directory, metti dentro un default filename
@@ -1217,108 +1162,6 @@ CREATE TABLE IF NOT EXISTS ClusterVariables (
         return inputPath + ".db";
 
       return inputPath;
-    }
-
-    private static string NormalizeKey(string s)
-    {
-      if (string.IsNullOrEmpty(s)) return "";
-      var up = s.Trim().ToUpperInvariant();
-      var buf = new StringBuilder(up.Length);
-      for (int i = 0; i < up.Length; i++) if (char.IsLetterOrDigit(up[i])) buf.Append(up[i]);
-      return buf.ToString();
-    }
-
-    private static IXLWorksheet TryGetWorksheet(IXLWorkbook wb, params string[] names)
-    {
-      foreach (var n in names)
-        foreach (var ws in wb.Worksheets)
-          if (string.Equals(ws.Name, n, StringComparison.OrdinalIgnoreCase))
-            return ws;
-      return null;
-    }
-
-    private static Dictionary<string, int> BuildHeaderMap(IXLWorksheet ws, out int firstRow, out int lastRow)
-    {
-      var used = ws.RangeUsed();
-      if (used == null)
-      {
-        firstRow = 1; lastRow = 0;
-        return new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-      }
-      firstRow = used.RangeAddress.FirstAddress.RowNumber;
-      lastRow = used.RangeAddress.LastAddress.RowNumber;
-
-      var map = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-      var hdr = ws.Row(firstRow);
-      foreach (var c in hdr.CellsUsed())
-      {
-        var key = NormalizeKey(c.GetString());
-        if (!string.IsNullOrEmpty(key) && !map.ContainsKey(key))
-          map[key] = c.Address.ColumnNumber;
-      }
-      return map;
-    }
-
-    private static Dictionary<string, int> ResolveColumns(Dictionary<string, int> header, Dictionary<string, HashSet<string>> aliases)
-    {
-      var result = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-      foreach (var kv in aliases)
-      {
-        string canonical = kv.Key;
-        if (header.TryGetValue(canonical, out int col)) { result[canonical] = col; continue; }
-        foreach (var alt in kv.Value) if (header.TryGetValue(alt, out col)) { result[canonical] = col; break; }
-      }
-      return result;
-    }
-
-    private static List<string> MissingRequired(Dictionary<string, int> map, IEnumerable<string> required)
-    {
-      var miss = new List<string>();
-      foreach (var r in required) if (!map.ContainsKey(r)) miss.Add(r);
-      return miss;
-    }
-
-    private static string ReadCell(IXLWorksheet ws, int row, Dictionary<string, int> map, string key)
-    {
-      if (!map.TryGetValue(key, out int col)) return "";
-      var cell = ws.Cell(row, col);
-
-      var s = cell.GetString();
-      if (!string.IsNullOrWhiteSpace(s)) return s;
-
-      s = cell.GetFormattedString();
-      if (!string.IsNullOrWhiteSpace(s)) return s;
-
-      try { return cell.Value.ToString(); }
-      catch { return ""; }
-    }
-
-    private static bool IsBlank(string s) => string.IsNullOrWhiteSpace(s);
-
-    private static int ToInt(string s)
-    {
-      int n; return int.TryParse((s ?? "").Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out n) ? n : 0;
-    }
-
-    private static bool ToBool(string s)
-    {
-      var t = (s ?? "").Trim();
-      if (t == "1") return true;
-      if (t == "0") return false;
-      bool b; return bool.TryParse(t, out b) && b;
-    }
-
-    private static int[] ParseDepends(string s)
-    {
-      if (string.IsNullOrWhiteSpace(s)) return Array.Empty<int>();
-      var tokens = s.Split(new[] { ',', ';', '|', ' ' }, StringSplitOptions.RemoveEmptyEntries);
-      var list = new List<int>();
-      foreach (var t in tokens)
-      {
-        int n; if (int.TryParse(t.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out n) && n > 0) list.Add(n);
-      }
-      list.Sort();
-      return list.ToArray();
     }
 
     private static void ReadPersistedId(object persisted, ref int target)

--- a/src/ProgesiGrasshopperAssembly/ProgesiGrasshopperAssembly.csproj
+++ b/src/ProgesiGrasshopperAssembly/ProgesiGrasshopperAssembly.csproj
@@ -34,6 +34,7 @@
 
   <!-- Librerie Progesi usate dal plugin -->
   <ItemGroup>
+    <ProjectReference Include="..\Progesi.GhExcelReadContract\Progesi.GhExcelReadContract.csproj" />
     <ProjectReference Include="..\ProgesiCore\ProgesiCore.csproj" />
     <ProjectReference Include="..\ProgesiDataExchange\ProgesiDataExchange.csproj" />
     <ProjectReference Include="..\ProgesiRepositories.Rhino\ProgesiRepositories.Rhino.csproj" />

--- a/tests/Progesi.GhExcelReadContract.Tests/ExcelTestFile.cs
+++ b/tests/Progesi.GhExcelReadContract.Tests/ExcelTestFile.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+
+namespace Progesi.GhExcelReadContract.Tests
+{
+  internal sealed class ExcelTestFile : IDisposable
+  {
+    public string Path { get; }
+
+    public ExcelTestFile()
+    {
+      Path = System.IO.Path.Combine(
+        System.IO.Path.GetTempPath(),
+        $"progesi-gh-readcontract-{Guid.NewGuid():N}.xlsx");
+    }
+
+    public void Dispose()
+    {
+      try
+      {
+        if (File.Exists(Path))
+          File.Delete(Path);
+      }
+      catch
+      {
+        // best-effort temp cleanup
+      }
+    }
+  }
+}

--- a/tests/Progesi.GhExcelReadContract.Tests/GhExcelAliasMapsTests.cs
+++ b/tests/Progesi.GhExcelReadContract.Tests/GhExcelAliasMapsTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Progesi.GhExcelReadContract.Tests
+{
+  public class GhExcelAliasMapsTests
+  {
+    [Fact]
+    public void NormalizeKey_Strips_Non_Alphanumeric()
+    {
+      GhExcelAliasMaps.NormalizeKey(" meta-id ").Should().Be("METAID");
+      GhExcelAliasMaps.NormalizeKey("Var Name").Should().Be("VARNAME");
+    }
+
+    [Fact]
+    public void Build_Merges_Custom_Variable_Aliases_From_MapJson()
+    {
+      const string mapJson = @"{ ""Variables"": { ""NAME"": [""FieldName""] } }";
+
+      var (variableAliases, _) = GhExcelAliasMaps.Build(mapJson);
+
+      variableAliases["NAME"].Should().Contain("FIELDNAME");
+      variableAliases["NAME"].Should().Contain("NAME");
+    }
+
+    [Fact]
+    public void Build_Ignores_Malformed_MapJson()
+    {
+      var (variableAliases, metadataAliases) = GhExcelAliasMaps.Build("{ not-json");
+
+      variableAliases.Should().ContainKey("NAME");
+      metadataAliases.Should().ContainKey("BY");
+    }
+
+    [Fact]
+    public void CreateDefaultClusterAliases_Includes_VariableIds()
+    {
+      var aliases = GhExcelAliasMaps.CreateDefaultClusterAliases();
+
+      aliases.Should().ContainKey("VARIABLEIDS");
+      aliases["VARIABLEIDS"].Should().Contain("VARIDS");
+    }
+  }
+}

--- a/tests/Progesi.GhExcelReadContract.Tests/GhExcelCellReaderTests.cs
+++ b/tests/Progesi.GhExcelReadContract.Tests/GhExcelCellReaderTests.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using ClosedXML.Excel;
+using FluentAssertions;
+using Xunit;
+
+namespace Progesi.GhExcelReadContract.Tests
+{
+  public class GhExcelCellReaderTests
+  {
+    [Fact]
+    public void ReadCell_Uses_GetString_Then_GetFormattedString_Fallback()
+    {
+      using var wb = new XLWorkbook();
+      var ws = wb.Worksheets.Add("Sheet1");
+      ws.Cell(2, 1).Value = 42;
+      ws.Cell(2, 1).Style.NumberFormat.Format = "0.00";
+
+      var map = new Dictionary<string, int> { ["VALUE"] = 1 };
+      var text = GhExcelCellReader.ReadCell(ws, 2, map, "VALUE");
+
+      text.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void ReadCell_Returns_Empty_When_Column_Not_Mapped()
+    {
+      using var wb = new XLWorkbook();
+      var ws = wb.Worksheets.Add("Sheet1");
+      ws.Cell(2, 1).Value = "x";
+
+      GhExcelCellReader.ReadCell(ws, 2, new Dictionary<string, int>(), "NAME").Should().BeEmpty();
+    }
+  }
+}

--- a/tests/Progesi.GhExcelReadContract.Tests/GhExcelClusterSheetTests.cs
+++ b/tests/Progesi.GhExcelReadContract.Tests/GhExcelClusterSheetTests.cs
@@ -1,0 +1,61 @@
+using ClosedXML.Excel;
+using FluentAssertions;
+using Xunit;
+
+namespace Progesi.GhExcelReadContract.Tests
+{
+  public class GhExcelClusterSheetTests
+  {
+    [Fact]
+    public void TryParseClusterRow_Reads_ProgesiClusters_Row_Through_ClosedXML()
+    {
+      using var wb = new XLWorkbook();
+      var ws = wb.Worksheets.Add(GhExcelSheetNames.Clusters);
+      ws.Cell(1, 1).Value = "Id";
+      ws.Cell(1, 2).Value = "Name";
+      ws.Cell(1, 3).Value = "Description";
+      ws.Cell(1, 4).Value = "Hash";
+      ws.Cell(1, 5).Value = "VariableIds";
+      ws.Cell(2, 1).Value = 7;
+      ws.Cell(2, 2).Value = "SpanSet";
+      ws.Cell(2, 3).Value = "Notes";
+      ws.Cell(2, 4).Value = "h7";
+      ws.Cell(2, 5).Value = "3,4";
+
+      var header = GhExcelHeaderMap.Build(ws, out _, out _);
+      var columns = GhExcelClusterSheet.ResolveClusterColumns(header);
+
+      var ok = GhExcelClusterSheet.TryParseClusterRow(
+        ws,
+        2,
+        columns,
+        out var id,
+        out var name,
+        out var description,
+        out var variableIds,
+        out var hash,
+        out var warn);
+
+      ok.Should().BeTrue();
+      id.Should().Be(7);
+      name.Should().Be("SpanSet");
+      description.Should().Be("Notes");
+      hash.Should().Be("h7");
+      variableIds.Should().Equal(3, 4);
+      warn.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ResolveClusterColumns_Maps_VarIds_Alias()
+    {
+      var header = new System.Collections.Generic.Dictionary<string, int>
+      {
+        ["VARIDS"] = 5
+      };
+
+      var columns = GhExcelClusterSheet.ResolveClusterColumns(header);
+
+      columns["VARIABLEIDS"].Should().Be(5);
+    }
+  }
+}

--- a/tests/Progesi.GhExcelReadContract.Tests/GhExcelColumnMapTests.cs
+++ b/tests/Progesi.GhExcelReadContract.Tests/GhExcelColumnMapTests.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace Progesi.GhExcelReadContract.Tests
+{
+  public class GhExcelColumnMapTests
+  {
+    [Fact]
+    public void ResolveColumns_Uses_Alias_When_Canonical_Header_Missing()
+    {
+      var header = new Dictionary<string, int> { ["VALORE"] = 4 };
+      var aliases = GhExcelAliasMaps.CreateDefaultVariableAliases();
+
+      var resolved = GhExcelColumnMap.ResolveColumns(header, aliases);
+
+      resolved["VALUE"].Should().Be(4);
+    }
+
+    [Fact]
+    public void MissingRequired_Reports_Absent_Headers()
+    {
+      var map = new Dictionary<string, int> { ["NAME"] = 2 };
+
+      var missing = GhExcelColumnMap.MissingRequired(map, new[] { "NAME", "VALUE", "BY" });
+
+      missing.Should().Equal("VALUE", "BY");
+    }
+  }
+}

--- a/tests/Progesi.GhExcelReadContract.Tests/GhExcelHeaderMapTests.cs
+++ b/tests/Progesi.GhExcelReadContract.Tests/GhExcelHeaderMapTests.cs
@@ -1,0 +1,42 @@
+using ClosedXML.Excel;
+using FluentAssertions;
+using Xunit;
+
+namespace Progesi.GhExcelReadContract.Tests
+{
+  public class GhExcelHeaderMapTests
+  {
+    [Fact]
+    public void Build_Normalizes_Header_Keys_And_Returns_Row_Bounds()
+    {
+      using var wb = new XLWorkbook();
+      var ws = wb.Worksheets.Add("Sheet1");
+      ws.Cell(1, 1).Value = "Var Name";
+      ws.Cell(1, 2).Value = "meta-id";
+      ws.Cell(2, 1).Value = "A";
+      ws.Cell(3, 2).Value = "B";
+
+      var map = GhExcelHeaderMap.Build(ws, out var firstRow, out var lastRow);
+
+      firstRow.Should().Be(1);
+      lastRow.Should().Be(3);
+      map.Should().ContainKey("VARNAME");
+      map.Should().ContainKey("METAID");
+      map["VARNAME"].Should().Be(1);
+      map["METAID"].Should().Be(2);
+    }
+
+    [Fact]
+    public void Build_Empty_Sheet_Returns_Empty_Map()
+    {
+      using var wb = new XLWorkbook();
+      var ws = wb.Worksheets.Add("Empty");
+
+      var map = GhExcelHeaderMap.Build(ws, out var firstRow, out var lastRow);
+
+      firstRow.Should().Be(1);
+      lastRow.Should().Be(0);
+      map.Should().BeEmpty();
+    }
+  }
+}

--- a/tests/Progesi.GhExcelReadContract.Tests/GhExcelValueParsingTests.cs
+++ b/tests/Progesi.GhExcelReadContract.Tests/GhExcelValueParsingTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Progesi.GhExcelReadContract.Tests
+{
+  public class GhExcelValueParsingTests
+  {
+    [Theory]
+    [InlineData("1, 3;2|4", new[] { 1, 2, 3, 4 })]
+    [InlineData("", new int[0])]
+    [InlineData("0,-1,abc", new int[0])]
+    public void ParseDepends_Parses_And_Sorts_Positive_Ids(string raw, int[] expected)
+    {
+      GhExcelValueParsing.ParseDepends(raw).Should().Equal(expected);
+    }
+
+    [Theory]
+    [InlineData("1", true)]
+    [InlineData("0", false)]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    [InlineData("", false)]
+    public void ToBool_Matches_GH_Contract(string raw, bool expected)
+    {
+      GhExcelValueParsing.ToBool(raw).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("12", 12)]
+    [InlineData("bad", 0)]
+    [InlineData(" 7 ", 7)]
+    public void ToInt_Parses_Integer_Or_Zero(string raw, int expected)
+    {
+      GhExcelValueParsing.ToInt(raw).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData(" ", true)]
+    [InlineData("x", false)]
+    public void IsBlank_Matches_Whitespace_Rules(string raw, bool expected)
+    {
+      GhExcelValueParsing.IsBlank(raw).Should().Be(expected);
+    }
+  }
+}

--- a/tests/Progesi.GhExcelReadContract.Tests/GhExcelWorksheetLocatorTests.cs
+++ b/tests/Progesi.GhExcelReadContract.Tests/GhExcelWorksheetLocatorTests.cs
@@ -1,0 +1,40 @@
+using ClosedXML.Excel;
+using FluentAssertions;
+using Xunit;
+
+namespace Progesi.GhExcelReadContract.Tests
+{
+  public class GhExcelWorksheetLocatorTests
+  {
+    [Fact]
+    public void TryGetWorksheet_Matches_Case_Insensitive_And_Alias()
+    {
+      using var file = new ExcelTestFile();
+      using (var wb = new XLWorkbook())
+      {
+        wb.Worksheets.Add("progesivariables");
+        wb.SaveAs(file.Path);
+      }
+
+      using (var wb = new XLWorkbook(file.Path))
+      {
+        var sheet = GhExcelWorksheetLocator.TryGetWorksheet(
+          wb,
+          GhExcelSheetNames.Variables,
+          GhExcelSheetNames.VariablesAlias);
+
+        sheet.Should().NotBeNull();
+        sheet.Name.Should().Be("progesivariables");
+      }
+    }
+
+    [Fact]
+    public void TryGetWorksheet_Returns_Null_When_No_Match()
+    {
+      using var wb = new XLWorkbook();
+      wb.Worksheets.Add("Other");
+
+      GhExcelWorksheetLocator.TryGetWorksheet(wb, GhExcelSheetNames.Metadata).Should().BeNull();
+    }
+  }
+}

--- a/tests/Progesi.GhExcelReadContract.Tests/Progesi.GhExcelReadContract.Tests.csproj
+++ b/tests/Progesi.GhExcelReadContract.Tests/Progesi.GhExcelReadContract.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Progesi.GhExcelReadContract\Progesi.GhExcelReadContract.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="ClosedXML" Version="0.104.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR implements the approved GH read-contract helper extraction first slice.

Scope:
- Adds a new Rhino-free helper project: src/Progesi.GhExcelReadContract.
- Adds tests: tests/Progesi.GhExcelReadContract.Tests.
- Moves pure ClosedXML/string read-contract logic into the helper.
- Updates ProgesiDataExchangeComponent minimally to delegate import/read-contract helper logic.
- Updates ProgesiGrasshopperAssembly.csproj to reference the helper.
- Registers the helper and test projects in Progesi.sln.
- Leaves Progesi.CI.slnf unchanged.

Validation:
- dotnet build -c Release passed.
- dotnet test -c Release passed: 190 total, 190 passed, 0 failed.
- Progesi.GhExcelReadContract.Tests passed: 28 total, 28 passed, 0 failed.
- Manual GH smoke passed for the intended helper-extraction scope.

This PR does not include:
- DataExchange production library changes
- EF changes
- ProgesiCore changes
- Cluster Phase 2 or Cluster Phase 3
- AxisVar work
- GH UI/input/output changes
- Rhino StringTable extraction
- Progesi.CI.slnf changes
- deployment scripts
- GitHub workflow changes
- artefacts
- main-branch interaction

Important notes:
- Workbook semantics are intended unchanged.
- Rhino StringTable / EnumerateIds / ReadAll* path remains deferred.
- A separate beta investigation task was created for Rhino-object value Excel serialization.
- That issue is not fixed in this PR and does not block this helper-extraction PR per Gianluca's direction.