### PR TITLE
fix: guard Rhino-object Excel value round-trip

### DIFF
--- a/src/Progesi.GhExcelReadContract/GhExcelVariableValueSupport.cs
+++ b/src/Progesi.GhExcelReadContract/GhExcelVariableValueSupport.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+
+namespace Progesi.GhExcelReadContract
+{
+  public enum GhExcelVariableValueKind
+  {
+    Primitive,
+    UnsupportedMarker,
+    NonPrimitiveJsonLeak,
+    ReferencedObjectDisplayString
+  }
+
+  /// <summary>
+  /// GH Excel variable Value/ValC contract: primitives round-trip; Rhino/non-primitive values are explicit unsupported.
+  /// </summary>
+  public static class GhExcelVariableValueSupport
+  {
+    public const string UnsupportedPrefix = "@UNSUPPORTED:";
+
+    private static readonly HashSet<string> KnownRhinoReferenceDisplayValues =
+      new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+      {
+        "Referenced Brep",
+        "Referenced Planar Curve",
+        "Referenced Curve",
+        "Referenced Mesh",
+        "Referenced Surface",
+        "Referenced Point",
+        "Referenced Polyline",
+        "Referenced Arc",
+        "Referenced Circle",
+        "Referenced Line",
+        "Referenced Extrusion",
+        "Referenced SubD",
+        "Referenced Polysurface",
+        "Referenced Hatch",
+      };
+
+    public static bool IsPrimitiveValueType(string valueType)
+    {
+      var normalized = (valueType ?? "string").Trim().ToLowerInvariant();
+      return normalized == "string"
+          || normalized == "int"
+          || normalized == "long"
+          || normalized == "double"
+          || normalized == "bool"
+          || normalized == "null";
+    }
+
+    public static bool IsRhinoObjectLikeValueType(string valueType)
+    {
+      if (string.IsNullOrWhiteSpace(valueType))
+        return false;
+
+      var typeName = valueType.Trim();
+      return typeName.IndexOf("Rhino.", StringComparison.OrdinalIgnoreCase) >= 0
+          || typeName.IndexOf("ObjectRef", StringComparison.OrdinalIgnoreCase) >= 0
+          || typeName.IndexOf("Geometry", StringComparison.OrdinalIgnoreCase) >= 0
+          || typeName.IndexOf("DocObjects", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    public static bool RequiresUnsupportedExportHandling(string valueType)
+    {
+      return !IsPrimitiveValueType(valueType);
+    }
+
+    /// <summary>
+    /// True when export must emit an explicit unsupported marker instead of the raw stored value.
+    /// </summary>
+    public static bool RequiresUnsupportedExportHandling(string valueType, string rawValue)
+    {
+      if (RequiresUnsupportedExportHandling(valueType))
+        return true;
+
+      return IsPrimitiveValueType(valueType) && IsKnownRhinoReferenceDisplayValue(rawValue);
+    }
+
+    /// <summary>
+    /// Known Grasshopper/Rhino object-reference display placeholders (manual smoke: Referenced Brep, Referenced Planar Curve).
+    /// Only whitelisted "Referenced &lt;Rhino type&gt;" values are classified; ordinary user strings are not.
+    /// </summary>
+    public static bool IsKnownRhinoReferenceDisplayValue(string value)
+    {
+      if (string.IsNullOrWhiteSpace(value))
+        return false;
+
+      return KnownRhinoReferenceDisplayValues.Contains(value.Trim());
+    }
+
+    /// <summary>
+    /// Maps stored variable payload to the GH Excel Value cell. Non-primitives become an explicit marker.
+    /// </summary>
+    public static string FormatExportValue(string valueType, string rawValue, string valC)
+    {
+      if (!RequiresUnsupportedExportHandling(valueType, rawValue))
+        return rawValue ?? string.Empty;
+
+      if (IsRhinoObjectLikeValueType(valueType) || IsKnownRhinoReferenceDisplayValue(rawValue))
+        return UnsupportedPrefix + "RhinoObject";
+
+      return UnsupportedPrefix + "NonPrimitive";
+    }
+
+    public static bool IsImportSupported(string excelValue, out GhExcelVariableValueKind kind, out string detail)
+    {
+      kind = GhExcelVariableValueKind.Primitive;
+      detail = string.Empty;
+
+      var value = excelValue ?? string.Empty;
+      if (value.StartsWith(UnsupportedPrefix, StringComparison.OrdinalIgnoreCase))
+      {
+        kind = GhExcelVariableValueKind.UnsupportedMarker;
+        detail = value.Substring(UnsupportedPrefix.Length).Trim();
+        return false;
+      }
+
+      if (IsKnownRhinoReferenceDisplayValue(value))
+      {
+        kind = GhExcelVariableValueKind.ReferencedObjectDisplayString;
+        detail = "RhinoObject";
+        return false;
+      }
+
+      var trimmed = value.TrimStart();
+      if (trimmed.StartsWith("{") || trimmed.StartsWith("["))
+      {
+        kind = GhExcelVariableValueKind.NonPrimitiveJsonLeak;
+        detail = "JSON-like";
+        return false;
+      }
+
+      return true;
+    }
+
+    public static string BuildImportSkipMessage(int row, GhExcelVariableValueKind kind, string detail)
+    {
+      switch (kind)
+      {
+        case GhExcelVariableValueKind.UnsupportedMarker:
+          return $"[Var R{row}] VALUE unsupported for Excel import ({detail}) → skip";
+        case GhExcelVariableValueKind.NonPrimitiveJsonLeak:
+          return $"[Var R{row}] VALUE non-primitive JSON not supported for Excel import → skip";
+        case GhExcelVariableValueKind.ReferencedObjectDisplayString:
+          return $"[Var R{row}] VALUE unsupported for Excel import ({detail}) → skip";
+        default:
+          return $"[Var R{row}] VALUE unsupported for Excel import → skip";
+      }
+    }
+  }
+}

--- a/src/ProgesiGrasshopperAssembly/Components/ProgesiDataExchangeComponent.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/ProgesiDataExchangeComponent.cs
@@ -262,6 +262,7 @@ namespace ProgesiGrasshopperAssembly.Components
       var vars = ReadAllVarsFromTable(table);
       var metas = ReadAllMetasFromTable(table);
       var clusters = ReadAllClustersFromTable(table);
+      int unsupportedVarExports = vars.Count(v => v.IsExcelUnsupported);
       using (var wb = new XLWorkbook())
       {
         // Variables
@@ -335,6 +336,8 @@ namespace ProgesiGrasshopperAssembly.Components
       }
 
       string info = $"OK ExportExcel → {p} (Vars:{vars.Length}, Meta:{metas.Length}, Clusters:{clusters.Length})";
+      if (unsupportedVarExports > 0)
+        info += $" | UnsupportedVarValues:{unsupportedVarExports}";
       return (p, info);
     }
     private static string NormalizeExportPath(string inPath)
@@ -529,6 +532,15 @@ namespace ProgesiGrasshopperAssembly.Components
 
             int[] depArr = GhExcelValueParsing.ParseDepends(deps);
             bool ass = GhExcelValueParsing.ToBool(asS);
+
+            if (!GhExcelVariableValueSupport.IsImportSupported(value, out var unsupportedKind, out var unsupportedDetail))
+            {
+              var msg = GhExcelVariableValueSupport.BuildImportSkipMessage(r, unsupportedKind, unsupportedDetail);
+              if (strict) { ERR(1, msg); AddErrRC(1, r, mapV.TryGetValue("VALUE", out var c) ? c : 0); varErr++; }
+              else { WARN(1, msg); AddErrRC(1, r, mapV.TryGetValue("VALUE", out var c) ? c : 0); varWarn++; }
+              varRows++;
+              continue;
+            }
 
             if (!dryRun)
             {
@@ -1213,6 +1225,7 @@ CREATE TABLE IF NOT EXISTS ClusterVariables (
       public int MetaId;
       public int[] Depends;
       public bool Assumption;
+      public bool IsExcelUnsupported;
     }
 
     private sealed class MetaRow
@@ -1300,6 +1313,9 @@ CREATE TABLE IF NOT EXISTS ClusterVariables (
         string valc = ProgesiHash.CanonicalValue(typed);
         int[] deps = dto.Depends ?? Array.Empty<int>();
         bool ass = dto.IsAssumption ?? false;
+        string valueType = dto.ValueType ?? "string";
+        string excelValue = GhExcelVariableValueSupport.FormatExportValue(valueType, dto.Value ?? "", valc);
+        bool isExcelUnsupported = GhExcelVariableValueSupport.RequiresUnsupportedExportHandling(valueType, dto.Value ?? "");
 
         var pv = new ProgesiVariable(id, dto.Name ?? "", typed, deps, dto.MetadataId, ass);
         string hash = ProgesiHash.Compute(pv);
@@ -1309,11 +1325,12 @@ CREATE TABLE IF NOT EXISTS ClusterVariables (
           Id = id,
           Hash = hash,
           Name = dto.Name ?? "",
-          Value = dto.Value ?? "",
+          Value = excelValue,
           ValC = valc,
           MetaId = dto.MetadataId ?? 0,
           Depends = deps,
-          Assumption = ass
+          Assumption = ass,
+          IsExcelUnsupported = isExcelUnsupported
         });
       }
       return list.ToArray();

--- a/tests/Progesi.GhExcelReadContract.Tests/GhExcelVariableValueSupportTests.cs
+++ b/tests/Progesi.GhExcelReadContract.Tests/GhExcelVariableValueSupportTests.cs
@@ -1,0 +1,147 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Progesi.GhExcelReadContract.Tests
+{
+  public class GhExcelVariableValueSupportTests
+  {
+    [Theory]
+    [InlineData("string", true)]
+    [InlineData("int", true)]
+    [InlineData("double", true)]
+    [InlineData("Rhino.Geometry.Point3d, RhinoCommon", false)]
+    [InlineData("System.Guid", false)]
+    public void IsPrimitiveValueType_Classifies_Known_Types(string valueType, bool expectedPrimitive)
+    {
+      GhExcelVariableValueSupport.IsPrimitiveValueType(valueType).Should().Be(expectedPrimitive);
+    }
+
+    [Fact]
+    public void FormatExportValue_Preserves_Primitive_String()
+    {
+      GhExcelVariableValueSupport.FormatExportValue("string", "12.5", "12.5")
+        .Should().Be("12.5");
+    }
+
+    [Fact]
+    public void FormatExportValue_Marks_Rhino_Object_Type_As_Unsupported()
+    {
+      GhExcelVariableValueSupport.FormatExportValue(
+          "Rhino.Geometry.Point3d, RhinoCommon, Version=8.0.0.0, Culture=neutral, PublicKeyToken=...",
+          "{\"X\":1}",
+          "1")
+        .Should().Be("@UNSUPPORTED:RhinoObject");
+    }
+
+    [Fact]
+    public void FormatExportValue_Marks_Generic_NonPrimitive_As_Unsupported()
+    {
+      GhExcelVariableValueSupport.FormatExportValue("System.Guid", "abc", "abc")
+        .Should().Be("@UNSUPPORTED:NonPrimitive");
+    }
+
+    [Theory]
+    [InlineData("42")]
+    [InlineData("hello")]
+    [InlineData("true")]
+    [InlineData("Pippo")]
+    public void IsImportSupported_Accepts_Primitive_Strings(string value)
+    {
+      GhExcelVariableValueSupport.IsImportSupported(value, out var kind, out _)
+        .Should().BeTrue();
+      kind.Should().Be(GhExcelVariableValueKind.Primitive);
+    }
+
+    [Fact]
+    public void IsImportSupported_Rejects_Unsupported_Marker()
+    {
+      GhExcelVariableValueSupport.IsImportSupported("@UNSUPPORTED:RhinoObject", out var kind, out var detail)
+        .Should().BeFalse();
+      kind.Should().Be(GhExcelVariableValueKind.UnsupportedMarker);
+      detail.Should().Be("RhinoObject");
+    }
+
+    [Theory]
+    [InlineData("{\"X\":1}")]
+    [InlineData("[1,2,3]")]
+    public void IsImportSupported_Rejects_Json_Like_Values(string value)
+    {
+      GhExcelVariableValueSupport.IsImportSupported(value, out var kind, out _)
+        .Should().BeFalse();
+      kind.Should().Be(GhExcelVariableValueKind.NonPrimitiveJsonLeak);
+    }
+
+    [Theory]
+    [InlineData("Referenced Brep")]
+    [InlineData("Referenced Planar Curve")]
+    [InlineData("Referenced Curve")]
+    [InlineData("Referenced Mesh")]
+    [InlineData("Referenced Surface")]
+    [InlineData("Referenced Point")]
+    public void FormatExportValue_Marks_Known_Rhino_Reference_Placeholders_As_Unsupported(string value)
+    {
+      GhExcelVariableValueSupport.FormatExportValue("string", value, value)
+        .Should().Be("@UNSUPPORTED:RhinoObject");
+    }
+
+    [Theory]
+    [InlineData("Referenced document")]
+    [InlineData("Referenced documentation")]
+    [InlineData("A long user description about referenced items")]
+    [InlineData("Pippo")]
+    public void FormatExportValue_Preserves_Ordinary_User_Strings(string value)
+    {
+      GhExcelVariableValueSupport.FormatExportValue("string", value, value)
+        .Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData("Referenced Brep")]
+    [InlineData("Referenced Planar Curve")]
+    [InlineData("referenced brep")]
+    public void IsKnownRhinoReferenceDisplayValue_Detects_Manual_Smoke_And_Legacy_Values(string value)
+    {
+      GhExcelVariableValueSupport.IsKnownRhinoReferenceDisplayValue(value).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("Referenced document")]
+    [InlineData("Referenced documentation")]
+    [InlineData("hello")]
+    [InlineData("Referenced something custom")]
+    public void IsKnownRhinoReferenceDisplayValue_Rejects_Non_Placeholder_Strings(string value)
+    {
+      GhExcelVariableValueSupport.IsKnownRhinoReferenceDisplayValue(value).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("Referenced Brep")]
+    [InlineData("Referenced Planar Curve")]
+    public void IsImportSupported_Rejects_Legacy_Rhino_Reference_Placeholders(string value)
+    {
+      GhExcelVariableValueSupport.IsImportSupported(value, out var kind, out var detail)
+        .Should().BeFalse();
+      kind.Should().Be(GhExcelVariableValueKind.ReferencedObjectDisplayString);
+      detail.Should().Be("RhinoObject");
+    }
+
+    [Fact]
+    public void RequiresUnsupportedExportHandling_Includes_Known_Placeholder_On_Primitive_Type()
+    {
+      GhExcelVariableValueSupport.RequiresUnsupportedExportHandling("string", "Referenced Brep")
+        .Should().BeTrue();
+      GhExcelVariableValueSupport.RequiresUnsupportedExportHandling("string", "12.5")
+        .Should().BeFalse();
+      GhExcelVariableValueSupport.RequiresUnsupportedExportHandling("string", "Referenced document")
+        .Should().BeFalse();
+    }
+
+    [Fact]
+    public void BuildImportSkipMessage_Includes_Row_And_Kind()
+    {
+      GhExcelVariableValueSupport.BuildImportSkipMessage(9, GhExcelVariableValueKind.UnsupportedMarker, "RhinoObject")
+        .Should().Contain("R9")
+        .And.Contain("RhinoObject");
+    }
+  }
+}

--- a/tests/Progesi.GhExcelReadContract.Tests/GhExcelVariableValueWorkbookTests.cs
+++ b/tests/Progesi.GhExcelReadContract.Tests/GhExcelVariableValueWorkbookTests.cs
@@ -1,0 +1,64 @@
+using ClosedXML.Excel;
+using FluentAssertions;
+using Xunit;
+
+namespace Progesi.GhExcelReadContract.Tests
+{
+  public class GhExcelVariableValueWorkbookTests
+  {
+    [Fact]
+    public void Primitive_Value_Written_To_Workbook_RoundTrips_For_Import_Check()
+    {
+      using var wb = new XLWorkbook();
+      var ws = wb.Worksheets.Add(GhExcelSheetNames.Variables);
+      ws.Cell(1, 1).Value = "Name";
+      ws.Cell(1, 2).Value = "Value";
+      ws.Cell(2, 1).Value = "Width";
+      ws.Cell(2, 2).Value = GhExcelVariableValueSupport.FormatExportValue("string", "12.5", "12.5");
+
+      var exported = ws.Cell(2, 2).GetString();
+      GhExcelVariableValueSupport.IsImportSupported(exported, out var kind, out _)
+        .Should().BeTrue();
+      kind.Should().Be(GhExcelVariableValueKind.Primitive);
+      exported.Should().Be("12.5");
+    }
+
+    [Fact]
+    public void Unsupported_Export_Marker_Is_Rejected_On_Import_Check()
+    {
+      var marker = GhExcelVariableValueSupport.FormatExportValue(
+        "Rhino.Geometry.Point3d, RhinoCommon",
+        "{\"X\":1}",
+        "1");
+
+      GhExcelVariableValueSupport.IsImportSupported(marker, out var kind, out var detail)
+        .Should().BeFalse();
+      kind.Should().Be(GhExcelVariableValueKind.UnsupportedMarker);
+      detail.Should().Be("RhinoObject");
+    }
+
+    [Fact]
+    public void Referenced_Brep_Export_Marker_Is_Rejected_On_Import_Check()
+    {
+      var marker = GhExcelVariableValueSupport.FormatExportValue(
+        "string",
+        "Referenced Brep",
+        "Referenced Brep");
+
+      marker.Should().Be("@UNSUPPORTED:RhinoObject");
+      GhExcelVariableValueSupport.IsImportSupported(marker, out var kind, out var detail)
+        .Should().BeFalse();
+      kind.Should().Be(GhExcelVariableValueKind.UnsupportedMarker);
+      detail.Should().Be("RhinoObject");
+    }
+
+    [Fact]
+    public void Legacy_Referenced_Display_String_Is_Rejected_On_Import_Check()
+    {
+      GhExcelVariableValueSupport.IsImportSupported("Referenced Planar Curve", out var kind, out var detail)
+        .Should().BeFalse();
+      kind.Should().Be(GhExcelVariableValueKind.ReferencedObjectDisplayString);
+      detail.Should().Be("RhinoObject");
+    }
+  }
+}


### PR DESCRIPTION
This PR implements the approved beta-safe Option A behaviour for Rhino-object-like Excel values.

Scope:
- Adds whitelist handling for known Rhino-reference display placeholders such as Referenced Brep and Referenced Planar Curve.
- Exports those values as @UNSUPPORTED:RhinoObject.
- Rejects unsupported markers, JSON-like legacy values, and legacy plain Rhino-reference placeholders on import.
- Preserves primitive strings and ordinary user strings.
- Adds tests for unsupported placeholder export/import and primitive preservation.

Validation:
- dotnet build -c Release passed.
- dotnet test -c Release passed: 230 total, 230 passed, 0 failed.
- ProgesiDataExchange.Tests passed: 23 total, 23 passed, 0 failed.
- Progesi.GhExcelReadContract.Tests passed: 68 total, 68 passed, 0 failed.
- Manual GH smoke passed with expected warnings:
  unsupported Rhino-object-like values export as @UNSUPPORTED:RhinoObject and do not silently import as strings.

This PR does not include:
- full Rhino geometry serialization
- broad GUID/document-object round-trip
- Core redesign
- AxisVar work
- Cluster Phase 3
- EF changes
- DataExchange consolidation
- Progesi.sln or Progesi.CI.slnf changes
- deployment scripts
- GitHub workflow changes
- artefacts
- main-branch interaction

Important notes:
- Dependency warnings for rows depending on skipped unsupported values are expected under Option A.
- AxisVar remains frozen.
- This fix is intended as beta-safe anti-corruption behaviour, not full Rhino-object serialization.