### PR TITLE
docs: reconcile governance after Functional GH Beta v0

### DIFF
--- a/.claude/agents/cursor-task-brief-writer.md
+++ b/.claude/agents/cursor-task-brief-writer.md
@@ -9,7 +9,7 @@ description: Use only when Gianluca explicitly asks for the cursor-task-brief-wr
 - AxisVar remains **frozen** and in abeyance.
 - ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
+- Current operating baseline: **main @ `d09130a` — Functional GH Beta v0 complete, 230/230 tests passing, deployment succeeded**. Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1); historical protected source-code checkpoint: **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role

--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -9,7 +9,7 @@ description: Use only when Gianluca explicitly asks for the documentation-writer
 - AxisVar remains **frozen** and in abeyance.
 - ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
+- Current operating baseline: **main @ `d09130a` — Functional GH Beta v0 complete, 230/230 tests passing, deployment succeeded**. Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1); historical protected source-code checkpoint: **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role

--- a/.claude/agents/git-governance-agent.md
+++ b/.claude/agents/git-governance-agent.md
@@ -9,7 +9,7 @@ description: Use only when Gianluca explicitly asks for the git-governance-agent
 - AxisVar remains **frozen** and in abeyance.
 - ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
+- Current operating baseline: **main @ `d09130a` — Functional GH Beta v0 complete, 230/230 tests passing, deployment succeeded**. Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1); historical protected source-code checkpoint: **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role

--- a/.claude/agents/grasshopper-manual-test-designer.md
+++ b/.claude/agents/grasshopper-manual-test-designer.md
@@ -9,7 +9,7 @@ description: Use only when Gianluca explicitly asks for the grasshopper-manual-t
 - AxisVar remains **frozen** and in abeyance.
 - ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
+- Current operating baseline: **main @ `d09130a` — Functional GH Beta v0 complete, 230/230 tests passing, deployment succeeded**. Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1); historical protected source-code checkpoint: **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role

--- a/.claude/agents/implementation-agent-disabled.md
+++ b/.claude/agents/implementation-agent-disabled.md
@@ -9,7 +9,7 @@ description: Disabled placeholder. Even if named explicitly, this agent must not
 - AxisVar remains **frozen** and in abeyance.
 - ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
+- Current operating baseline: **main @ `d09130a` — Functional GH Beta v0 complete, 230/230 tests passing, deployment succeeded**. Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1); historical protected source-code checkpoint: **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role

--- a/.claude/agents/notion-project-curator.md
+++ b/.claude/agents/notion-project-curator.md
@@ -9,7 +9,7 @@ description: Use only when Gianluca explicitly asks for the notion-project-curat
 - AxisVar remains **frozen** and in abeyance.
 - ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
+- Current operating baseline: **main @ `d09130a` — Functional GH Beta v0 complete, 230/230 tests passing, deployment succeeded**. Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1); historical protected source-code checkpoint: **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role

--- a/.claude/agents/progesi-architecture-reviewer.md
+++ b/.claude/agents/progesi-architecture-reviewer.md
@@ -9,7 +9,7 @@ description: Use only when Gianluca explicitly asks for the progesi-architecture
 - AxisVar remains **frozen** and in abeyance.
 - ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
+- Current operating baseline: **main @ `d09130a` — Functional GH Beta v0 complete, 230/230 tests passing, deployment succeeded**. Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1); historical protected source-code checkpoint: **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role

--- a/.claude/agents/progesi-strategy-planner.md
+++ b/.claude/agents/progesi-strategy-planner.md
@@ -9,7 +9,7 @@ description: Use only when Gianluca explicitly asks for the progesi-strategy-pla
 - AxisVar remains **frozen** and in abeyance.
 - ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
+- Current operating baseline: **main @ `d09130a` — Functional GH Beta v0 complete, 230/230 tests passing, deployment succeeded**. Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1); historical protected source-code checkpoint: **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role

--- a/.claude/agents/regression-guard.md
+++ b/.claude/agents/regression-guard.md
@@ -9,7 +9,7 @@ description: Use only when Gianluca explicitly asks for the regression-guard age
 - AxisVar remains **frozen** and in abeyance.
 - ProgesiVariableCluster: **Phase 1 recovered and closed** for submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); historical protected source-code checkpoint **64/64 at `376d81e`**.
+- Current operating baseline: **main @ `d09130a` — Functional GH Beta v0 complete, 230/230 tests passing, deployment succeeded**. Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1); historical protected source-code checkpoint: **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Role
@@ -18,7 +18,7 @@ Run and interpret build/test checks when explicitly instructed, and compare agai
 ## Allowed actions during current handover
 - No automatic execution.
 - When explicitly instructed: run `dotnet build -c Release` and `dotnet test`.
-- Compare results against the current operating baseline (**88/88 at `6286aec`**); `376d81e` (64/64) remains the historical checkpoint per ADR-010.
+- Compare results against the current operating baseline (**230/230 on `main` @ `d09130a`**, Functional GH Beta v0); **88/88 at `6286aec`** (post-Cluster Phase 1) and **64/64 at `376d81e`** remain historical checkpoints per ADR-010.
 
 ## Forbidden actions
 - No fixes. No source edits. No test edits.
@@ -33,7 +33,7 @@ Run and interpret build/test checks when explicitly instructed, and compare agai
 - the current task row
 
 ## Required output format
-- Command(s) run, pass/fail counts, comparison to the current operating baseline (88/88 at `6286aec`), and any deltas — with no remediation performed.
+- Command(s) run, pass/fail counts, comparison to the current operating baseline (230/230 on `main` @ `d09130a`), and any deltas — with no remediation performed.
 
 ## Stop conditions
 - Asked to fix failures, edit code/tests, or run without explicit instruction. Stop and report.

--- a/.cursor/rules/progesi-architecture.mdc
+++ b/.cursor/rules/progesi-architecture.mdc
@@ -11,7 +11,7 @@ These rules are authoritative for Cursor in this repository. If a request confli
 - AxisVar is **frozen** — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
 - ProgesiVariableCluster: **Phase 1 recovered and closed** for the submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) are not recovered** and remain blocked. Not full release validation.
 - DataExchange is **not** Core — it is the interchange boundary.
-- Current operating baseline is **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); the historical protected source-code checkpoint remains **64/64 at `376d81e`**.
+- Current operating baseline is **main @ `d09130a` — Functional GH Beta v0 complete, 230/230 tests passing, deployment succeeded**. Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1); historical protected source-code checkpoint: **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Core independence

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ Agents are assistants, **not autonomous project owners**. Nothing here enables a
 - AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
 - ProgesiVariableCluster: **Phase 1 recovered and closed** for the submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) are not recovered** and remain blocked. Not full release validation. See the Phase 1 exception below and the dated reconciliation section at the end of this file.
 - DataExchange is **not** a Core domain object — it is the interchange boundary.
-- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); the historical protected source-code checkpoint remains **64/64 at `376d81e`**.
-- **No code cleanup is authorised yet.**
+- Current operating baseline: **main @ `d09130a` — Functional GH Beta v0 complete, 230/230 tests passing, deployment succeeded**. Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1 checkpoint). Historical protected source-code checkpoint: **64/64 at `376d81e`**.
+- **No source-code cleanup is authorised yet** (read-only audits allowed; destructive cleanup remains gated — see the dated Post-Beta v0 reconciliation at the end of this file).
 
 ## Principles
 - Agents are **planned, not autonomous project owners**.
@@ -120,7 +120,7 @@ The Orchestrator may prepare/reroute Phase 1 prompts but must not execute implem
 
 This section reconciles the standing constraints above with the current post-Cluster-Phase-1 / post-ADR-acceptance state. Where earlier text names `376d81e` / 64/64 as the *current* baseline, treat that wording as **historical**. This section does **not** weaken any standing constraint, the AxisVar freeze, the implementation prompt guard, the Phase 1 exception, or any agent maturity/limit. It grants no new authorisation and enables no autonomy.
 
-1. **Baselines.** Current operating baseline: **88/88 tests passing at `6286aec`** (after PR #63 / Cluster Phase 1). Historical protected source-code checkpoint: **64/64 at `376d81e`** on `feat/axis-variable-core`.
+1. **Baselines.** *(Superseded 2026-07-23 — the current baseline is now `main` @ `d09130a`, 230/230; see the Post-Beta v0 reconciliation below.)* As recorded on 2026-07-15, the operating baseline was **88/88 tests passing at `6286aec`** (after PR #63 / Cluster Phase 1), with the historical protected source-code checkpoint **64/64 at `376d81e`** on `feat/axis-variable-core`.
 
 2. **ProgesiVariableCluster.** Phase 1 is **recovered and closed** for the submitted/manual-validation scenarios (GH-CLUSTER-001..004 recorded Passed). **Phase 2 (SQLite) and Phase 3 (EF / DataExchange) are not recovered and remain blocked** until separately approved. Not a full release-validation sign-off. The Phase 1 exception above remains in force; the Orchestrator still must not execute implementation.
 
@@ -130,6 +130,24 @@ This section reconciles the standing constraints above with the current post-Clu
 
 5. **Agents and Notion Curator.** All agents remain **controlled and human-gated** at their documented maturity levels; no autonomous Task Board execution; `implementation-agent-disabled` stays disabled; the Notion Curator operates only within its approved controlled-write scope.
 
-6. **`main` and any beta/release line.** Future-only — no merge to `main` and no release tagging is authorised here.
+6. **`main` and any beta/release line.** *(Superseded 2026-07-23.)* At the 2026-07-15 reconciliation this was future-only with no merge to `main`. **This no longer holds:** Functional GH Beta v0 is now integrated into `main` at `d09130a` (via PR #72). See the Post-Beta v0 reconciliation section below.
 
 7. **No new authorisation.** This section records state only; it authorises no implementation, cleanup, ADR-driven code change, branch/tag cleanup, or scope broadening.
+
+## Post-Beta v0 reconciliation — 2026-07-23
+
+This section records the current operating state after **Functional GH Beta v0** was integrated into `main`. It supersedes earlier wording that treats `main` as untouched/future-only or the mode as "no-code handover". It does **not** weaken the AxisVar freeze, the implementation prompt guard, the Phase 1 exception, any agent maturity level, or any hard limit. **It grants no new authorisation and enables no autonomy.**
+
+1. **Baselines (retiered).** Current operating baseline: `main` @ `d09130a` — Functional GH Beta v0 complete, **230/230 tests passing**, deployment succeeded. Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1). Historical protected source-code checkpoint: **64/64 at `376d81e`**.
+
+2. **Current-State source of truth.** The Notion page **"Progesi Current State — Post Functional GH Beta v0"** is canonical. Agents and future Claude sessions should start from that page, the active Task Board rows, the Architecture Map, the Roadmap, and `git status`.
+
+3. **Posture.** The earlier no-code handover posture is **superseded**; the current posture is post-beta consolidation / Claude handover / cleanup governance. Agents remain **controlled and human-gated** at their documented maturity levels; no autonomous Task Board execution; `implementation-agent-disabled` stays disabled.
+
+4. **`main` status.** `main` is no longer untouched — Functional GH Beta v0 is integrated at `d09130a` (PR #72). Item 6 of the 2026-07-15 reconciliation ("future-only") is historical and superseded here.
+
+5. **GitHub / Notion cleanup.** Audit-first. Safe first passes and read-only audits have occurred (GitHub Cleanup Audit 366, settings verification 369A). Destructive cleanup remains gated: no branch/tag deletion, no Notion archive/delete/move, no ADR status change, no schema change, no AxisVar work without explicit approval. No agent may perform GitHub or code cleanup.
+
+6. **Preserved.** AxisVar freeze, historical checkpoints, ADR references and posture, all human-approval gates, agent maturity limits, and protected/staged workflow language remain in force.
+
+7. **No new authorisation.** State record only; no implementation, cleanup, ADR-driven code change, Notion deletion, or scope broadening is authorised, and no agent autonomy is enabled.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,20 +7,20 @@ If anything here conflicts with Notion, **stop and report** before acting.
 - AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
 - ProgesiVariableCluster: **Phase 1 recovered and closed** for the submitted/manual-validation scenarios (Core model/service, InMemory repository, narrow Rhino support repository, ClusterDef/ClusterOut components, `ProgesiClusters` Excel export, and Cluster tests). **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) are not recovered** and remain blocked. This is not full release validation. See the Phase 1 recovery exception below and the dated reconciliation section at the end of this file.
 - DataExchange is **not** a Core domain object — it is the interchange boundary.
-- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1). The historical protected source-code checkpoint remains **64/64 at `376d81e`** on `feat/axis-variable-core`.
-- **No code cleanup is authorised yet.**
+- Current operating baseline: **main @ `d09130a` — Functional GH Beta v0 complete, 230/230 tests passing, deployment succeeded**. Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1 checkpoint). Historical protected source-code checkpoint: **64/64 at `376d81e`** on `feat/axis-variable-core`.
+- **No source-code cleanup is authorised yet** (read-only audits are allowed; destructive cleanup remains gated — see the dated Post-Beta v0 reconciliation at the end of this file).
 
 ## 1. Current mode
-- Mode: **no-code handover / governance setup**.
-- Protected checkpoint: branch **`feat/axis-variable-core`** at commit **`376d81e`** (clean tree, release build passing, 64/64 tests).
-- The current branch **`docs/claude-handover-rules`** is for **documentation/rules only**. No source code, tests, solution files, or project files may be changed on it.
+- Mode: **post-beta consolidation / Claude handover / cleanup governance**. The earlier **no-code handover / governance setup** posture is **superseded** — see the dated Post-Beta v0 reconciliation at the end of this file.
+- Historical protected checkpoint: branch **`feat/axis-variable-core`** at commit **`376d81e`** (clean tree, release build passing, 64/64 tests) — retained as a historical reference, not the current baseline.
+- Documentation/rules changes continue to run on approved docs/rules branches (e.g. the current `docs/post-beta-governance-reconciliation`). No source code, tests, solution files, or project files may be changed on such a branch.
 
 ## 2. Non-negotiable rules
 - No source code changes unless explicitly approved.
 - No tests modified unless explicitly approved.
 - No AxisVar work of any kind.
 - No legacy removal (code or files).
-- No GitHub cleanup (no branch/tag deletion, no history rewrite, no force-push).
+- No destructive GitHub cleanup (no branch/tag deletion, no history rewrite, no force-push) without explicit approval. Read-only audits are allowed, and audit-first passes have already occurred (see the dated Post-Beta v0 reconciliation below).
 - No autonomous Task Board execution.
 - Do not mark implementation tasks **Done** without human approval and test evidence.
 - Do not broaden task scope or perform opportunistic refactors.
@@ -68,7 +68,7 @@ Read-only inspection and documentation are allowed. The freeze lifts only after 
 
 ## 7. Build/test commands
 - Run build/test **only when explicitly instructed**.
-- Canonical commands: `dotnet build -c Release` then `dotnet test`. Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1). Historical protected source-code checkpoint: **64/64 at `376d81e`**.
+- Canonical commands: `dotnet build -c Release` then `dotnet test`. Current operating baseline: **230/230 passing on `main` @ `d09130a`** (Functional GH Beta v0). Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1). Historical protected source-code checkpoint: **64/64 at `376d81e`**.
 - Never run Rhino or Grasshopper from here.
 
 ## 8. Reporting requirements
@@ -111,7 +111,7 @@ Phase 2 and Phase 3 remain blocked until separately approved.
 
 This section reconciles the standing constraints and mode notes above with the current post-Cluster-Phase-1 / post-ADR-acceptance state. Where earlier text names `376d81e` / 64/64 as the *current* baseline, or describes the mode as "no-code handover", treat that wording as **historical**; the current operating state is recorded here. This section does **not** weaken any standing constraint, the AxisVar freeze, the implementation prompt guard (§9), or the ProgesiVariableCluster Phase 1 recovery exception above. It grants no new authorisation.
 
-1. **Baselines.** Current operating baseline: **88/88 tests passing at `6286aec`** (state after the PR #63 / Cluster Phase 1 merge). Historical protected source-code checkpoint: **64/64 at `376d81e`** on `feat/axis-variable-core` — retained as the pre-Cluster reference, not the current count. §1 "Current mode" predates ADR acceptance and Cluster Phase 1 and is superseded by this section for current-state purposes.
+1. **Baselines.** *(Superseded 2026-07-23 — the current baseline is now `main` @ `d09130a`, 230/230; see the Post-Beta v0 reconciliation below.)* As recorded on 2026-07-15, the operating baseline was **88/88 tests passing at `6286aec`** (state after the PR #63 / Cluster Phase 1 merge), with the historical protected source-code checkpoint **64/64 at `376d81e`** on `feat/axis-variable-core`. §1 "Current mode" predates ADR acceptance and Cluster Phase 1 and is superseded by this section for current-state purposes.
 
 2. **ProgesiVariableCluster.** Phase 1 is **recovered and closed** for the submitted and manually validated scenarios (Core model/service, InMemory repository, narrow Rhino support repository, ClusterDef/ClusterOut Grasshopper components, `ProgesiClusters` Excel export, Cluster tests; GH-CLUSTER-001..004 recorded Passed). **Phase 2 (SQLite persistence) and Phase 3 (EF / DataExchange) are not recovered and remain blocked** until separately approved. This is not a full release-validation sign-off. The Phase 1 recovery exception above remains in force exactly as written.
 
@@ -125,6 +125,27 @@ This section reconciles the standing constraints and mode notes above with the c
 
 5. **Agents and Notion Curator.** All agents remain **controlled and human-gated** at their documented maturity levels (see `AGENTS.md`); no autonomous Task Board execution; implementation agents remain disabled; the Notion Curator operates only within its approved controlled-write scope.
 
-6. **`main` and any beta/release line.** Untouched by this work and **future-only** — no merge to `main` and no release tagging is authorised by this reconciliation.
+6. **`main` and any beta/release line.** *(Superseded 2026-07-23.)* At the time of the 2026-07-15 reconciliation, `main` was untouched and this work was future-only. **This no longer holds:** Functional GH Beta v0 is now integrated into `main` at `d09130a` (via PR #72). See the Post-Beta v0 reconciliation section below.
 
 7. **No new authorisation.** This section records state; it authorises no code cleanup, no ADR-driven implementation, no branch/tag cleanup, and no scope broadening.
+
+## Post-Beta v0 reconciliation — 2026-07-23
+
+This section records the current operating state after **Functional GH Beta v0** was integrated into `main`. It supersedes any earlier wording — including §1 "Current mode" and the 2026-07-15 reconciliation — that describes the mode as "no-code handover" or `main` as untouched/future-only. It does **not** weaken the AxisVar freeze, the implementation prompt guard (§9), the ProgesiVariableCluster Phase 1 recovery exception, or any authorisation gate. **It grants no new authorisation.**
+
+1. **Baselines (retiered).**
+   - **Current operating baseline:** `main` @ `d09130a` — Functional GH Beta v0 complete, **230/230 tests passing**, deployment succeeded.
+   - **Historical baseline:** **88/88 at `6286aec`** — post-Cluster Phase 1 checkpoint.
+   - **Historical protected source-code checkpoint:** **64/64 at `376d81e`** on `feat/axis-variable-core`.
+
+2. **Current-State source of truth.** The Notion page **"Progesi Current State — Post Functional GH Beta v0"** is canonical. Future Claude sessions should start from that page, the active Task Board rows, the Architecture Map, the Roadmap, and `git status` — not from prior chat/session memory.
+
+3. **Posture.** The earlier **no-code handover / governance setup** posture is **superseded**. The current posture is **post-beta consolidation / Claude handover / cleanup governance**.
+
+4. **`main` status.** `main` is **no longer untouched**. Functional GH Beta v0 is integrated into `main` at `d09130a` (via PR #72). Any statement elsewhere in this file that `main` is untouched or future-only is historical and superseded by this section.
+
+5. **GitHub / Notion cleanup.** Cleanup remains **audit-first**. Safe first passes and read-only audits have occurred (e.g. GitHub Cleanup Audit 366 and branch-protection settings verification 369A). **Destructive cleanup remains gated:** no branch/tag deletion, no Notion archive/delete/move, no ADR status change, no schema change, and no AxisVar work without explicit approval.
+
+6. **Preserved.** The AxisVar freeze, the historical checkpoints (`6286aec`, `376d81e`), all ADR references and their acceptance posture, every human-approval/authorisation gate, and the protected/staged workflow language all remain in force exactly as written above.
+
+7. **No new authorisation.** This section records state only. It authorises no code cleanup, no ADR-driven implementation, no branch/tag cleanup, no Notion deletion, and no scope broadening.

--- a/docs/claude-governance.md
+++ b/docs/claude-governance.md
@@ -6,7 +6,7 @@ Detailed governance for Claude Code on the Progesi Toolkit, derived from the Not
 - AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
 - ProgesiVariableCluster: **Phase 1 recovered and closed** for the submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) are not recovered** and remain blocked. Not full release validation. See the Phase 1 recovery exception in `CLAUDE.md`.
 - DataExchange is **not** a Core domain object — it is the interchange boundary.
-- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); the historical protected source-code checkpoint remains **64/64 at `376d81e`**.
+- Current operating baseline: **main @ `d09130a` — Functional GH Beta v0 complete, 230/230 tests passing, deployment succeeded**. Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1); historical protected source-code checkpoint: **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Tool roles

--- a/docs/cursor-interface-protocol.md
+++ b/docs/cursor-interface-protocol.md
@@ -6,7 +6,7 @@ This document defines the boundary between Claude and Cursor. It complements `do
 - AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
 - ProgesiVariableCluster: **Phase 1 recovered and closed** for the submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) are not recovered** and remain blocked. Not full release validation. See the Phase 1 recovery exception in `CLAUDE.md`.
 - DataExchange is **not** a Core domain object — it is the interchange boundary.
-- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); the historical protected source-code checkpoint remains **64/64 at `376d81e`**.
+- Current operating baseline: **main @ `d09130a` — Functional GH Beta v0 complete, 230/230 tests passing, deployment succeeded**. Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1); historical protected source-code checkpoint: **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## No direct control requirement

--- a/docs/repository-cleanup-protocol.md
+++ b/docs/repository-cleanup-protocol.md
@@ -1,12 +1,12 @@
 # Progesi Toolkit — Repository Cleanup Protocol
 
-Safe, staged process for any future repository cleanup (source or GitHub). Nothing here authorises cleanup now — it defines how cleanup must happen **when** it is approved.
+Safe, staged process for any future repository cleanup (source or GitHub). Nothing here authorises destructive cleanup now — it defines how cleanup must happen **when** it is approved. Post-beta, read-only **audit-first passes have already occurred** (e.g. GitHub Cleanup Audit 366 and branch-protection settings verification 369A); destructive cleanup (branch/tag deletion, Notion archive/delete/move, ADR/schema changes, AxisVar work) remains **gated** pending explicit approval.
 
 ## Standing constraints (apply to all work)
 - AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
 - ProgesiVariableCluster: **Phase 1 recovered and closed** for the submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) are not recovered** and remain blocked. Not full release validation. See the Phase 1 recovery exception in `CLAUDE.md`.
 - DataExchange is **not** a Core domain object — it is the interchange boundary.
-- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); the historical protected source-code checkpoint remains **64/64 at `376d81e`**.
+- Current operating baseline: **main @ `d09130a` — Functional GH Beta v0 complete, 230/230 tests passing, deployment succeeded**. Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1); historical protected source-code checkpoint: **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ## Core principles
@@ -20,7 +20,7 @@ Safe, staged process for any future repository cleanup (source or GitHub). Nothi
 ## Source cleanup requirements
 Any source cleanup requires:
 - an approved branch and explicit scope (allowed/forbidden files),
-- tests to run (current operating baseline 88/88 at `6286aec` must be preserved unless a change is explicitly approved),
+- tests to run (current operating baseline 230/230 on `main` @ `d09130a` must be preserved unless a change is explicitly approved),
 - manual Grasshopper validation if any GH-facing code is affected,
 - a rollback plan,
 - human approval.

--- a/docs/task-brief-template.md
+++ b/docs/task-brief-template.md
@@ -7,7 +7,7 @@ Copy this template per task. A brief is only actionable after **Human approval s
 - AxisVar remains **frozen** and in abeyance — no modification, deletion, DTO consolidation, persistence move, or Grasshopper wiring.
 - ProgesiVariableCluster: **Phase 1 recovered and closed** for the submitted/manual-validation scenarios; **Phase 2 (SQLite) and Phase 3 (EF/DataExchange) are not recovered** and remain blocked. Not full release validation. See the Phase 1 recovery exception in `CLAUDE.md`.
 - DataExchange is **not** a Core domain object — it is the interchange boundary.
-- Current operating baseline: **88/88 passing at `6286aec`** (after PR #63 / Cluster Phase 1); the historical protected source-code checkpoint remains **64/64 at `376d81e`**.
+- Current operating baseline: **main @ `d09130a` — Functional GH Beta v0 complete, 230/230 tests passing, deployment succeeded**. Historical baseline: **88/88 at `6286aec`** (post-Cluster Phase 1); historical protected source-code checkpoint: **64/64 at `376d81e`**.
 - **No code cleanup is authorised yet.**
 
 ---
@@ -43,7 +43,7 @@ Copy this template per task. A brief is only actionable after **Human approval s
 <bullet list of objectively checkable outcomes>
 
 ## Tests to run
-<exact commands, e.g. `dotnet build -c Release`, `dotnet test`; expected: current operating baseline **88/88 at `6286aec`** unless the task adds tests (historical checkpoint: 64/64 at `376d81e`)>
+<exact commands, e.g. `dotnet build -c Release`, `dotnet test`; expected: current operating baseline **230/230 on `main` @ `d09130a`** unless the task adds tests (historical baselines: 88/88 at `6286aec`; 64/64 at `376d81e`)>
 
 ## Manual validation required
 <Grasshopper Manual Test Matrix rows / procedures, if GH is affected; otherwise "None">


### PR DESCRIPTION
This PR reconciles governance and agent documentation after Functional GH Beta v0 was completed on main.

Scope:
- Retiers the operating baseline:
  - Current: main @ d09130a, Functional GH Beta v0, 230/230 tests, deployment succeeded.
  - Historical: 88/88 @ 6286aec.
  - Historical protected: 64/64 @ 376d81e.
- Points Claude sessions to the Progesi Current State page as the canonical rehydration source.
- Marks old no-code handover / main untouched / old no-cleanup language as historical or superseded.
- Reframes GitHub/Notion cleanup as audit-first and destructive-cleanup gated.
- Preserves AxisVar freeze language and historical checkpoints.

Changed files:
- CLAUDE.md
- AGENTS.md
- docs/*.md governance files
- .cursor/rules/progesi-architecture.mdc
- approved .claude/agents/*.md files

This PR does not include:
- source code changes
- tests
- project/solution changes
- deployment/workflow changes
- binaries or artefacts
- AxisVar changes
- ADR status changes
- cleanup execution
- branch/tag deletion
- Notion archive/delete/move

Validation:
- Repository Verification 377 passed.
- Changed files are exactly the 16 approved docs/governance files.
- No files staged beyond approved list before commit.
- No build/test required because this is docs-only.