### PR TITLE
docs: reconcile CLAUDE.md/AGENTS.md to Autonomous Operating Charter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,3 +151,19 @@ This section records the current operating state after **Functional GH Beta v0**
 6. **Preserved.** AxisVar freeze, historical checkpoints, ADR references and posture, all human-approval gates, agent maturity limits, and protected/staged workflow language remain in force.
 
 7. **No new authorisation.** State record only; no implementation, cleanup, ADR-driven code change, Notion deletion, or scope broadening is authorised, and no agent autonomy is enabled.
+
+## Autonomous Operating Charter reconciliation — 2026-07-24
+
+This section reconciles the agent registry with the **Autonomous Operating Charter & Standing Green Authorisation** (Notion, 08 — Governance and Tooling). It **does not** raise any agent's maturity level, enable autonomous Task Board execution, re-enable `implementation-agent-disabled`, or weaken any hard limit, the AxisVar freeze, the implementation prompt guard, or the Phase 1 exception. **It grants no new authorisation and enables no agent autonomy.**
+
+1. **Where the tiers apply.** The Charter's **Green / Amber / Red** tiers govern the *ceremony* of controlled work, not agent maturity. Standing **Green** (routine Notion hygiene, Current-State / Strategic-Planning-Log / change-log maintenance, `{}` resolution) maps to work already inside the `notion-project-curator`'s Level-2 controlled-write scope — it removes the per-step prompt, not the scope boundary. **Amber** still requires one explicit human go per package. **Red** (branch/tag deletion, ADR status, schema, source code, Cursor implementation, AxisVar) still requires recorded Human Input and remains outside every agent's authority.
+
+2. **Agent maturity unchanged.** All agents remain at their documented maximum levels (see the Agent list). `implementation-agent-disabled` stays disabled. No agent may work through the Task Board autonomously or mark implementation tasks Done. The standing Green authorisation does **not** promote any agent.
+
+3. **`{@Claude …}` marker.** Agents that read Notion pages must honour the refined `{}` protocol: `{@Claude <question>}` is answered inline; `{@Claude <action>}` is executed only if Green, otherwise converted to `{⛔}` and escalated. Agents never delete or rewrite original human text.
+
+4. **Change-log obligation.** Any agent whose task changes state must ensure its Notion Curator packet feeds the dual change log (Notion *ChatGPT Sync — Change Log* + on-disk mirror), consistent with the Agent completion rule above.
+
+5. **Preserved.** All hard limits, maturity levels, the AxisVar freeze, and the human-gated posture remain in force exactly as written.
+
+6. **No new authorisation.** Governance-model record only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ If anything here conflicts with Notion, **stop and report** before acting.
 - Mode: **post-beta consolidation / Claude handover / cleanup governance**. The earlier **no-code handover / governance setup** posture is **superseded** — see the dated Post-Beta v0 reconciliation at the end of this file.
 - Historical protected checkpoint: branch **`feat/axis-variable-core`** at commit **`376d81e`** (clean tree, release build passing, 64/64 tests) — retained as a historical reference, not the current baseline.
 - Documentation/rules changes continue to run on approved docs/rules branches (e.g. the current `docs/post-beta-governance-reconciliation`). No source code, tests, solution files, or project files may be changed on such a branch.
+- **Autonomy is tiered** per the **Autonomous Operating Charter & Standing Green Authorisation** (Notion, 08 — Governance): **Green** = pre-authorised routine Notion hygiene / Current-State + change-log maintenance / `{}` marker resolution (no per-step prompt); **Amber** = one explicit human go per scoped package; **Red** = explicit Human Input recorded before acting. See the dated Charter reconciliation at the end of this file. The Charter grants **no** new source-code, cleanup, ADR, branch/tag, or AxisVar authority.
 
 ## 2. Non-negotiable rules
 - No source code changes unless explicitly approved.
@@ -149,3 +150,24 @@ This section records the current operating state after **Functional GH Beta v0**
 6. **Preserved.** The AxisVar freeze, the historical checkpoints (`6286aec`, `376d81e`), all ADR references and their acceptance posture, every human-approval/authorisation gate, and the protected/staged workflow language all remain in force exactly as written above.
 
 7. **No new authorisation.** This section records state only. It authorises no code cleanup, no ADR-driven implementation, no branch/tag cleanup, no Notion deletion, and no scope broadening.
+
+## Autonomous Operating Charter reconciliation — 2026-07-24
+
+This section reconciles these operating rules with the **Autonomous Operating Charter & Standing Green Authorisation** (Notion, 08 — Governance and Tooling), created to let agents work with as little per-step ceremony as is safe while guaranteeing no information loss and safe rollback. It **does not weaken** any standing constraint, the AxisVar freeze (§5), §2's non-negotiable rules, the implementation prompt guard (§9), the ProgesiVariableCluster Phase 1 recovery exception, or any human-approval gate. **It grants no new authorisation.**
+
+1. **Autonomy tiers.** Work is classified into three tiers:
+   - **Green — pre-authorised (no per-step prompt).** Routine Notion hygiene (superseded notices, canonical pointers, archive/pointer organisation with no deletion), Current-State / Strategic-Planning-Log / change-log maintenance, and `{}` marker resolution. Green work is reversible via Notion version history and is always recorded in the change log.
+   - **Amber — one explicit human go per scoped package.** E.g. the R1 GitHub-cleanup decision package, this governance-docs reconciliation, Task Board grouping.
+   - **Red — explicit Human Input recorded before acting.** Branch/tag deletion, history rewrite, force-push, ADR status change, schema change, source-code change, Cursor implementation, and anything touching AxisVar. Red is never bundled; each Red action needs its own recorded decision.
+
+2. **`{}` protocol (refined).** In addition to `{➕}` (human-added), `{⁉️}` (check currency), and `{⛔}` (Claude-raised block), the marker **`{@Claude …}`** is now supported: a **question** (Claude answers inline, appending `{answer: …}`, leaving the original text intact) or an **in-page action request** (e.g. `{@Claude move this section elsewhere}`). Green actions are executed, logged, and marked `{done: …}`; Amber/Red actions are converted to `{⛔}` and escalated for approval. Claude never deletes human content and never rewrites the original human wording; resolution is additive.
+
+3. **No-information-loss guarantees.** Persist-then-archive, never delete; back up before any page-archive; child pages preserved as `<page>` blocks; mandatory dual change log (the Notion *ChatGPT Sync — Change Log* page and the on-disk `C:\Users\gianl\source\repos\ChatGPT_Sync_Change_Log.md` mirror, updated at the end of every controlled write).
+
+4. **Rollback.** Notion version history for pages; Git branches/commits for any repository change (docs/rules only, on an approved docs/rules branch); additive/reversible Task Board schema (`Risk Tier`).
+
+5. **Turn-end reminder.** A user-level Stop-hook (in `~/.claude/settings.json`, outside this repo) prints a change-log-update reminder when a turn ends inside the Progesi repository. It is a deterministic reminder only — it cannot compose the semantic change-log entry itself; that still requires an invoked Claude session. True recurring autonomy requires a separately approved scheduled driver.
+
+6. **Preserved.** Everything above this section remains in force exactly as written.
+
+7. **No new authorisation.** State and governance-model record only.


### PR DESCRIPTION
## Purpose
Reconcile the on-disk governance rules (`CLAUDE.md`, `AGENTS.md`) with the **Autonomous Operating Charter & Standing Green Authorisation** (Notion, 08 — Governance and Tooling).

## Changes
Adds a dated **"Autonomous Operating Charter reconciliation — 2026-07-24"** section to both files, recording:
- **Green / Amber / Red** autonomy tiers and the **standing Green** pre-authorisation scope.
- The refined **`{@Claude …}`** review-marker protocol (question / in-page action).
- No-information-loss + rollback guarantees (persist-then-archive, dual change log, Notion history / Git).
- The turn-end **Stop-hook**'s honest scope (deterministic reminder, not a semantic writer).
- AGENTS.md clarifies the tiers govern *ceremony, not agent maturity* — no agent is promoted; `implementation-agent-disabled` stays disabled.

## Scope guarantees
- **Docs-only:** 2 files, +38 lines. No source code, tests, solution/project files.
- **Additive:** no standing constraint, AxisVar freeze, non-negotiable rule, hard limit, human-approval gate, or agent maturity level is weakened.
- **No new authorisation** is granted by this change.

## Baseline
Branched from `main` @ `5fb18e3`. No functional code affected; not re-running the 230/230 suite is intentional (docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)