### PR TITLE
fix(r2a): Excel cluster-import - cross-file ClusterOut rehydration

### DIFF
--- a/src/Progesi.GhExcelReadContract/GhExcelClusterImport.cs
+++ b/src/Progesi.GhExcelReadContract/GhExcelClusterImport.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using ClosedXML.Excel;
+using ProgesiCore;
+
+namespace Progesi.GhExcelReadContract
+{
+  /// <summary>
+  /// Pure Excel cluster sheet → DTO helper (no Rhino/GH). Used by ImportExcelValidated.
+  /// </summary>
+  public sealed class GhExcelClusterRowDto
+  {
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+    public string Description { get; set; } = "";
+    public int[] VariableIds { get; set; } = Array.Empty<int>();
+    public string Hashtag { get; set; } = "";
+    public string ParseWarning { get; set; } = "";
+  }
+
+  public static class GhExcelClusterImport
+  {
+    public static bool IsBlankDataRow(
+      IXLWorksheet worksheet,
+      int row,
+      Dictionary<string, int> columnMap)
+    {
+      if (worksheet == null) throw new ArgumentNullException(nameof(worksheet));
+      if (columnMap == null) throw new ArgumentNullException(nameof(columnMap));
+
+      string id = GhExcelCellReader.ReadCell(worksheet, row, columnMap, "ID");
+      string name = GhExcelCellReader.ReadCell(worksheet, row, columnMap, "NAME");
+      string desc = GhExcelCellReader.ReadCell(worksheet, row, columnMap, "DESCRIPTION");
+      string varIds = GhExcelCellReader.ReadCell(worksheet, row, columnMap, "VARIABLEIDS");
+      string hash = GhExcelCellReader.ReadCell(worksheet, row, columnMap, "HASH");
+
+      return GhExcelValueParsing.IsBlank(id)
+          && GhExcelValueParsing.IsBlank(name)
+          && GhExcelValueParsing.IsBlank(desc)
+          && GhExcelValueParsing.IsBlank(varIds)
+          && GhExcelValueParsing.IsBlank(hash);
+    }
+
+    /// <summary>
+    /// Parses one cluster row via GhExcelClusterSheet + ClusterImportParser and builds a DTO
+    /// with domain hashtag when VariableIds are present.
+    /// </summary>
+    public static bool TryBuildRowDto(
+      IXLWorksheet worksheet,
+      int row,
+      Dictionary<string, int> columnMap,
+      out GhExcelClusterRowDto dto,
+      out string error)
+    {
+      dto = null;
+      error = "";
+
+      if (!GhExcelClusterSheet.TryParseClusterRow(
+            worksheet,
+            row,
+            columnMap,
+            out int id,
+            out string name,
+            out string description,
+            out int[] variableIds,
+            out string hash,
+            out string warn))
+      {
+        error = string.IsNullOrWhiteSpace(warn) ? "cluster row parse failed" : warn;
+        return false;
+      }
+
+      variableIds = variableIds ?? Array.Empty<int>();
+      string hashtag = hash ?? "";
+
+      if (variableIds.Length > 0)
+      {
+        var cluster = ProgesiVariableCluster.Rehydrate(
+          id,
+          name ?? "",
+          variableIds,
+          description,
+          string.IsNullOrWhiteSpace(hash) ? null : hash);
+        hashtag = cluster.Hashtag ?? "";
+      }
+
+      dto = new GhExcelClusterRowDto
+      {
+        Id = id,
+        Name = name ?? "",
+        Description = description ?? "",
+        VariableIds = variableIds,
+        Hashtag = hashtag ?? "",
+        ParseWarning = warn ?? ""
+      };
+
+      return true;
+    }
+
+    /// <summary>
+    /// Reads all non-blank cluster data rows from a worksheet (header row excluded).
+    /// </summary>
+    public static IReadOnlyList<GhExcelClusterRowDto> ReadAllRowDtos(
+      IXLWorksheet worksheet,
+      Dictionary<string, int> columnMap,
+      int headerRow,
+      int lastRow)
+    {
+      if (worksheet == null) throw new ArgumentNullException(nameof(worksheet));
+      if (columnMap == null) throw new ArgumentNullException(nameof(columnMap));
+
+      var rows = new List<GhExcelClusterRowDto>();
+      for (int r = headerRow + 1; r <= lastRow; r++)
+      {
+        if (IsBlankDataRow(worksheet, r, columnMap))
+          continue;
+
+        if (!TryBuildRowDto(worksheet, r, columnMap, out var dto, out _))
+          continue;
+
+        rows.Add(dto);
+      }
+
+      return rows;
+    }
+  }
+}

--- a/src/ProgesiGrasshopperAssembly/Components/ProgesiDataExchangeComponent.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/ProgesiDataExchangeComponent.cs
@@ -404,6 +404,7 @@ namespace ProgesiGrasshopperAssembly.Components
       // contatori
       int metaRows = 0, metaOk = 0, metaWarn = 0, metaErr = 0, maxMetaId = 0;
       int varRows = 0, varOk = 0, varWarn = 0, varErr = 0, maxVarId = 0;
+      int clusterRows = 0, clusterOk = 0, clusterWarn = 0, clusterErr = 0;
 
       using (var wb = new XLWorkbook(p))
       {
@@ -567,6 +568,109 @@ namespace ProgesiGrasshopperAssembly.Components
             varOk++; varRows++;
           }
         }
+
+        // ========== CLUSTERS ==========
+        var wsC = GhExcelWorksheetLocator.TryGetWorksheet(wb, GhExcelSheetNames.Clusters, GhExcelSheetNames.ClustersAlias);
+        bool clusterHeaderError = false;
+        Dictionary<string, int> mapC = null;
+        int r0C = 1, rNC = 0;
+
+        if (wsC == null)
+        {
+          string m = "Sheet 'ProgesiClusters' not found.";
+          if (strict) { ERR(2, m); clusterHeaderError = true; }
+          else { WARN(2, m); }
+        }
+        else
+        {
+          var headerC = GhExcelHeaderMap.Build(wsC, out r0C, out rNC);
+          mapC = GhExcelClusterSheet.ResolveClusterColumns(headerC);
+          var missingCluster = GhExcelColumnMap.MissingRequired(mapC, new[] { "ID" });
+          if (missingCluster.Count > 0)
+          {
+            string m = "Missing headers (Clusters): " + string.Join(",", missingCluster);
+            if (strict) { ERR(2, m); clusterHeaderError = true; AddErrRC(2, r0C, -1); }
+            else { WARN(2, m); clusterWarn += missingCluster.Count; }
+          }
+        }
+
+        StringTable clusterTable = null;
+        if (!dryRun && wsC != null && !clusterHeaderError)
+        {
+          var clusterDoc = RhinoDoc.ActiveDoc ?? throw new InvalidOperationException("RhinoDoc.ActiveDoc is null.");
+          clusterTable = clusterDoc.Strings ?? throw new InvalidOperationException("RhinoDoc.Strings is null.");
+        }
+
+        if (!clusterHeaderError && wsC != null)
+        {
+          for (int r = r0C + 1; r <= rNC; r++)
+          {
+            if (GhExcelClusterImport.IsBlankDataRow(wsC, r, mapC))
+            { WARN(2, $"[Cluster R{r}] empty row → skip"); clusterWarn++; clusterRows++; continue; }
+
+            if (!GhExcelClusterImport.TryBuildRowDto(wsC, r, mapC, out var rowDto, out var parseError))
+            {
+              var msg = $"[Cluster R{r}] {parseError}";
+              if (strict) { ERR(2, msg); AddErrRC(2, r, mapC.TryGetValue("ID", out var cidCol) ? cidCol : 0); clusterErr++; }
+              else { WARN(2, msg); clusterWarn++; }
+              clusterRows++;
+              continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(rowDto.ParseWarning))
+            {
+              var msg = $"[Cluster R{r}] {rowDto.ParseWarning}";
+              if (strict) { ERR(2, msg); AddErrRC(2, r, mapC.TryGetValue("VARIABLEIDS", out var vidCol) ? vidCol : 0); clusterErr++; clusterRows++; continue; }
+              else { WARN(2, msg); clusterWarn++; }
+            }
+
+            if (rowDto.VariableIds == null || rowDto.VariableIds.Length == 0)
+            {
+              WARN(2, $"[Cluster R{r}] no VariableIds → skip persist");
+              clusterWarn++;
+              clusterRows++;
+              continue;
+            }
+
+            string cName = rowDto.Name ?? "";
+            if (cName.Length > NAME_MAX || !IsPrintable(cName))
+            {
+              var msg = $"[Cluster R{r}] NAME invalid (len/charset)";
+              if (strict) { ERR(2, msg); AddErrRC(2, r, mapC.TryGetValue("NAME", out var nameCol) ? nameCol : 0); clusterErr++; clusterRows++; continue; }
+              else { WARN(2, msg); clusterWarn++; }
+            }
+
+            string cDesc = rowDto.Description ?? "";
+            if (cDesc.Length > DESC_MAX || !IsPrintable(cDesc))
+            {
+              var msg = $"[Cluster R{r}] DESCRIPTION invalid (len/charset)";
+              if (strict) { ERR(2, msg); AddErrRC(2, r, mapC.TryGetValue("DESCRIPTION", out var descCol) ? descCol : 0); clusterErr++; clusterRows++; continue; }
+              else { WARN(2, msg); clusterWarn++; }
+            }
+
+            if (!dryRun && clusterTable != null)
+            {
+              var clusterDto = new ClusterDto
+              {
+                Id = rowDto.Id,
+                Name = cName,
+                Description = cDesc,
+                VariableIds = rowDto.VariableIds,
+                Hashtag = rowDto.Hashtag
+              };
+
+              string json = JsonConvert.SerializeObject(clusterDto);
+              clusterTable.SetString("Progesi.Cluster", "cluster:" + rowDto.Id.ToString(CultureInfo.InvariantCulture), json);
+
+              int next = ReadCounter(clusterTable, "Progesi.Cluster");
+              if (rowDto.Id + 1 > next)
+                clusterTable.SetString("Progesi.Cluster", "__next__", (rowDto.Id + 1).ToString(CultureInfo.InvariantCulture));
+            }
+
+            clusterOk++;
+            clusterRows++;
+          }
+        }
       } // using wb
 
       // Aggiorna contatori solo se NON è DryRun
@@ -587,10 +691,13 @@ namespace ProgesiGrasshopperAssembly.Components
       // counts
       counts.Append(new GH_String($"Meta rows={metaRows} ok={metaOk} warn={metaWarn} err={metaErr}"), new GH_Path(0));
       counts.Append(new GH_String($"Vars rows={varRows} ok={varOk} warn={varWarn} err={varErr}"), new GH_Path(1));
+      counts.Append(new GH_String($"Clusters rows={clusterRows} ok={clusterOk} warn={clusterWarn} err={clusterErr}"), new GH_Path(2));
 
       string prefix = dryRun ? "PREVIEW " : "OK ";
       string info = $"{prefix}ImportExcel ← {p} | Meta {metaOk}/{metaRows} (warn:{metaWarn}, err:{metaErr}) | " +
-                    $"Vars {varOk}/{varRows} (warn:{varWarn}, err:{varErr}) | Log: {(string.IsNullOrWhiteSpace(logPath) ? "-" : logPath)}";
+                    $"Vars {varOk}/{varRows} (warn:{varWarn}, err:{varErr}) | " +
+                    $"Clusters {clusterOk}/{clusterRows} (warn:{clusterWarn}, err:{clusterErr}) | " +
+                    $"Log: {(string.IsNullOrWhiteSpace(logPath) ? "-" : logPath)}";
 
       return (p, logPath, warnTree, errTree, counts, errRC, info);
     }

--- a/tests/Progesi.GhExcelReadContract.Tests/GhExcelClusterImportTests.cs
+++ b/tests/Progesi.GhExcelReadContract.Tests/GhExcelClusterImportTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using ClosedXML.Excel;
+using FluentAssertions;
+using Xunit;
+
+namespace Progesi.GhExcelReadContract.Tests
+{
+  public class GhExcelClusterImportTests
+  {
+    private static (IXLWorksheet ws, Dictionary<string, int> columns, int headerRow, int lastRow) BuildSheet()
+    {
+      var wb = new XLWorkbook();
+      var ws = wb.Worksheets.Add(GhExcelSheetNames.Clusters);
+      ws.Cell(1, 1).Value = "Id";
+      ws.Cell(1, 2).Value = "Name";
+      ws.Cell(1, 3).Value = "Description";
+      ws.Cell(1, 4).Value = "Hash";
+      ws.Cell(1, 5).Value = "VariableIds";
+      ws.Cell(2, 1).Value = 7;
+      ws.Cell(2, 2).Value = "SpanSet";
+      ws.Cell(2, 3).Value = "Notes";
+      ws.Cell(2, 4).Value = "h7";
+      ws.Cell(2, 5).Value = "3,4";
+      ws.Cell(3, 1).Value = 8;
+      ws.Cell(3, 2).Value = "EmptyMembers";
+      ws.Cell(3, 5).Value = "";
+
+      var header = GhExcelHeaderMap.Build(ws, out int headerRow, out int lastRow);
+      var columns = GhExcelClusterSheet.ResolveClusterColumns(header);
+      return (ws, columns, headerRow, lastRow);
+    }
+
+    [Fact]
+    public void TryBuildRowDto_Uses_Sheet_Hash_When_Provided()
+    {
+      var (ws, columns, _, _) = BuildSheet();
+
+      var ok = GhExcelClusterImport.TryBuildRowDto(ws, 2, columns, out var dto, out var error);
+
+      ok.Should().BeTrue();
+      error.Should().BeEmpty();
+      dto.Id.Should().Be(7);
+      dto.Name.Should().Be("SpanSet");
+      dto.Description.Should().Be("Notes");
+      dto.VariableIds.Should().Equal(3, 4);
+      dto.Hashtag.Should().Be("h7");
+      dto.ParseWarning.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TryBuildRowDto_Computes_Domain_Hashtag_When_Sheet_Hash_Missing()
+    {
+      var (ws, columns, _, _) = BuildSheet();
+      ws.Cell(2, 4).Value = "";
+
+      var ok = GhExcelClusterImport.TryBuildRowDto(ws, 2, columns, out var dto, out var error);
+
+      ok.Should().BeTrue();
+      dto.Hashtag.Should().Be("7|SpanSet|3,4");
+    }
+
+    [Fact]
+    public void TryBuildRowDto_Allows_Empty_VariableIds_With_Sheet_Hash()
+    {
+      var (ws, columns, _, _) = BuildSheet();
+
+      var ok = GhExcelClusterImport.TryBuildRowDto(ws, 3, columns, out var dto, out var error);
+
+      ok.Should().BeTrue();
+      error.Should().BeEmpty();
+      dto.Id.Should().Be(8);
+      dto.VariableIds.Should().BeEmpty();
+      dto.Hashtag.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void IsBlankDataRow_Skips_Fully_Empty_Row()
+    {
+      var (ws, columns, _, _) = BuildSheet();
+      ws.Cell(4, 1).Value = "";
+      ws.Cell(4, 2).Value = "";
+      ws.Cell(4, 3).Value = "";
+      ws.Cell(4, 4).Value = "";
+      ws.Cell(4, 5).Value = "";
+
+      GhExcelClusterImport.IsBlankDataRow(ws, 4, columns).Should().BeTrue();
+      GhExcelClusterImport.IsBlankDataRow(ws, 2, columns).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReadAllRowDtos_Returns_NonBlank_Parsed_Rows()
+    {
+      var (ws, columns, headerRow, lastRow) = BuildSheet();
+
+      var rows = GhExcelClusterImport.ReadAllRowDtos(ws, columns, headerRow, lastRow);
+
+      rows.Should().HaveCount(2);
+      rows[0].Id.Should().Be(7);
+      rows[1].Id.Should().Be(8);
+    }
+
+    [Fact]
+    public void TryBuildRowDto_Fails_On_Invalid_Id()
+    {
+      var (ws, columns, _, _) = BuildSheet();
+      ws.Cell(5, 1).Value = "abc";
+      ws.Cell(5, 2).Value = "Bad";
+
+      var ok = GhExcelClusterImport.TryBuildRowDto(ws, 5, columns, out _, out var error);
+
+      ok.Should().BeFalse();
+      error.Should().Contain("invalid Id");
+    }
+  }
+}


### PR DESCRIPTION
## R2-A fix - Excel cluster-import (cross-file ClusterOut rehydration)

Adds a CLUSTERS stage to `ImportExcelValidated`: reads the `ProgesiClusters` sheet and persists clusters to the Rhino `Progesi.Cluster` StringTable (same `ClusterDto`/JSON + `__next__` block as `ImportSqlite`), so `ClusterOut` rehydrates in a NEW file after an Excel import. Root cause: the Excel importer previously imported only Metadata + Variables.

- New pure helper `GhExcelClusterImport` (+ unit tests). Reuses `ClusterImportParser` / `GhExcelClusterSheet` / `ClusterDto`.
- No changes to export / SQLite / EF / AxisVar.

### Verification
- `dotnet build -c Release`: 0 errors; `dotnet test`: >= 230/230 (this script gates on both).
- **Manual GH cross-file validation pending (acceptance test):** export a cluster in file A -> import into a new file B -> ClusterOut resolves.

Do NOT merge until the manual GH validation passes and Claude reviews.

Generated with Claude Code.