### PR TITLE
fix(r2g): ProgesiCluster referential integrity

### DIFF
--- a/src/ProgesiCore/Services/ClusterService.cs
+++ b/src/ProgesiCore/Services/ClusterService.cs
@@ -13,10 +13,14 @@ namespace ProgesiCore.Services
   public sealed class ClusterService : IClusterService
   {
     private readonly IProgesiVariableClusterRepository _clusterRepository;
+    private readonly IVariableRepository? _variableRepository;
 
-    public ClusterService(IProgesiVariableClusterRepository clusterRepository)
+    public ClusterService(
+      IProgesiVariableClusterRepository clusterRepository,
+      IVariableRepository? variableRepository = null)
     {
       _clusterRepository = clusterRepository ?? throw new ArgumentNullException(nameof(clusterRepository));
+      _variableRepository = variableRepository;
     }
 
     public async Task<ProgesiVariableCluster> CreateOrGetClusterAsync(
@@ -40,6 +44,22 @@ namespace ProgesiCore.Services
 
       if (ids.Count == 0)
         throw new ArgumentException("Cluster must contain at least one variable id.", nameof(progesiVariableIds));
+
+      // R2-G: referential integrity — reject a cluster that references non-existent ProgesiVariable(s).
+      // Only enforced when a variable repository is supplied (create path); read paths pass null.
+      if (_variableRepository != null)
+      {
+        var missing = new List<int>();
+        foreach (var vid in ids)
+        {
+          var existingVar = await _variableRepository.GetByIdAsync(vid, ct).ConfigureAwait(false);
+          if (existingVar == null) missing.Add(vid);
+        }
+        if (missing.Count > 0)
+          throw new ArgumentException(
+            $"Cluster references non-existent ProgesiVariable id(s): {string.Join(", ", missing)}.",
+            nameof(progesiVariableIds));
+      }
 
       // Candidate "logico" (Id=0) solo per confronto con i cluster esistenti
       var candidate = ProgesiVariableCluster.CreateNew(name, ids, description);
@@ -89,5 +109,40 @@ namespace ProgesiCore.Services
       IEnumerable<int> ids,
       CancellationToken ct = default)
       => _clusterRepository.DeleteManyAsync(ids, ct);
+
+    // R2-G: when a ProgesiVariable is deleted, strip it from every cluster that references it.
+    // A cluster left with no variables is deleted (cluster invariant is >= 1 variable).
+    public async Task<int> CascadeRemoveVariableFromClustersAsync(
+      int variableId,
+      CancellationToken ct = default)
+    {
+      if (variableId <= 0) return 0;
+
+      var all = await _clusterRepository.GetAllAsync(ct).ConfigureAwait(false);
+      int affected = 0;
+
+      foreach (var cluster in all)
+      {
+        if (cluster.ProgesiVariableIds == null || !cluster.ProgesiVariableIds.Contains(variableId))
+          continue;
+
+        var remaining = cluster.ProgesiVariableIds.Where(v => v != variableId).ToList();
+
+        if (remaining.Count == 0)
+        {
+          await _clusterRepository.DeleteAsync(cluster.Id, ct).ConfigureAwait(false);
+        }
+        else
+        {
+          var updated = ProgesiVariableCluster.Rehydrate(
+            cluster.Id, cluster.Name, remaining, cluster.Description, null);
+          await _clusterRepository.SaveAsync(updated, ct).ConfigureAwait(false);
+        }
+
+        affected++;
+      }
+
+      return affected;
+    }
   }
 }

--- a/src/ProgesiCore/Services/IClusterService.cs
+++ b/src/ProgesiCore/Services/IClusterService.cs
@@ -38,5 +38,14 @@ namespace ProgesiCore.Services
     Task<int> DeleteManyAsync(
       IEnumerable<int> ids,
       CancellationToken ct = default);
+
+    /// <summary>
+    /// Rimuove la ProgesiVariable indicata da tutti i cluster che la referenziano.
+    /// Se un cluster resta senza variabili viene eliminato.
+    /// Ritorna il numero di cluster modificati o eliminati.
+    /// </summary>
+    Task<int> CascadeRemoveVariableFromClustersAsync(
+      int variableId,
+      CancellationToken ct = default);
   }
 }

--- a/src/ProgesiGrasshopperAssembly/Components/ProgesiClusterDefinitionComponent.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/ProgesiClusterDefinitionComponent.cs
@@ -254,7 +254,9 @@ namespace ProgesiGrasshopperAssembly.Components
 
         // CREATE (default)
         {
-          var service = new ClusterService(clusterRepo);
+          // R2-G: pass the variable repository so creation rejects clusters that
+          // reference non-existent ProgesiVariable id(s) (surfaced via the catch below).
+          var service = new ClusterService(clusterRepo, varRepo);
           var cluster = service.CreateOrGetClusterAsync(name, ids, desc).GetAwaiter().GetResult();
 
           outId = cluster.Id;

--- a/src/ProgesiGrasshopperAssembly/Infrastructure/MetadataRepositoryCompatExtensions.cs
+++ b/src/ProgesiGrasshopperAssembly/Infrastructure/MetadataRepositoryCompatExtensions.cs
@@ -577,6 +577,20 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
           UnindexHash(table, "Progesi.VarHash", oldContent);
         }
 
+        // R2-G: cascade-remove this variable from any clusters that reference it
+        // (an emptied cluster is deleted) BEFORE deleting the variable itself.
+        try
+        {
+          var clusterRepo = new RhinoVariableClusterRepository(doc);
+          var clusterSvc = new ProgesiCore.Services.ClusterService(clusterRepo);
+          clusterSvc.CascadeRemoveVariableFromClustersAsync(id).GetAwaiter().GetResult();
+        }
+        catch (Exception cex)
+        {
+          info = "Cluster cascade cleanup failed: " + cex.Message;
+          return false;
+        }
+
         var ok = repo.DeleteAsync(id).GetAwaiter().GetResult();
         info = ok ? "OK" : "Delete non riuscita";
         return ok;

--- a/tests/ProgesiCore.Tests/ClusterServiceTests.cs
+++ b/tests/ProgesiCore.Tests/ClusterServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using ProgesiCore;
 using ProgesiCore.Services;
 using ProgesiRepositories.InMemory;
 using Xunit;
@@ -80,6 +81,71 @@ namespace Progesi.Core.Tests.Services
 
       var all = await service.GetAllAsync();
       Assert.Equal(2, all.Count);
+    }
+
+    // ---- R2-G: referential integrity ----
+
+    [Fact]
+    public async Task CreateOrGetCluster_StrictReject_When_VariableId_Missing()
+    {
+      // arrange: var 2 exists, var 9 does NOT
+      var clusterRepo = new InMemoryVariableClusterRepository();
+      var varRepo = new InMemoryVariableRepository();
+      await varRepo.SaveAsync(new ProgesiVariable(2, "v2", 1.0));
+      var service = new ClusterService(clusterRepo, varRepo);
+
+      // act + assert: creating a cluster referencing missing var 9 is rejected
+      await Assert.ThrowsAsync<System.ArgumentException>(
+        () => service.CreateOrGetClusterAsync("C", new[] { 2, 9 }, "d"));
+
+      var all = await service.GetAllAsync();
+      Assert.Empty(all);
+    }
+
+    [Fact]
+    public async Task CreateOrGetCluster_Succeeds_When_All_Variables_Exist()
+    {
+      var clusterRepo = new InMemoryVariableClusterRepository();
+      var varRepo = new InMemoryVariableRepository();
+      await varRepo.SaveAsync(new ProgesiVariable(2, "v2", 1.0));
+      await varRepo.SaveAsync(new ProgesiVariable(9, "v9", 2.0));
+      var service = new ClusterService(clusterRepo, varRepo);
+
+      var cluster = await service.CreateOrGetClusterAsync("C", new[] { 2, 9 }, "d");
+
+      Assert.NotNull(cluster);
+      Assert.True(cluster.ProgesiVariableIds.SequenceEqual(new[] { 2, 9 }));
+    }
+
+    [Fact]
+    public async Task CascadeRemove_Removes_Variable_And_Keeps_NonEmpty_Cluster()
+    {
+      var clusterRepo = new InMemoryVariableClusterRepository();
+      var service = new ClusterService(clusterRepo);
+      var c = await service.CreateOrGetClusterAsync("C", new[] { 2, 9 }, "d");
+
+      var affected = await service.CascadeRemoveVariableFromClustersAsync(9);
+
+      Assert.Equal(1, affected);
+      var reloaded = await service.GetByIdAsync(c.Id);
+      Assert.NotNull(reloaded);
+      Assert.True(reloaded!.ProgesiVariableIds.SequenceEqual(new[] { 2 }));
+    }
+
+    [Fact]
+    public async Task CascadeRemove_Deletes_Cluster_When_It_Becomes_Empty()
+    {
+      var clusterRepo = new InMemoryVariableClusterRepository();
+      var service = new ClusterService(clusterRepo);
+      var c = await service.CreateOrGetClusterAsync("C", new[] { 9 }, "d");
+
+      var affected = await service.CascadeRemoveVariableFromClustersAsync(9);
+
+      Assert.Equal(1, affected);
+      var reloaded = await service.GetByIdAsync(c.Id);
+      Assert.Null(reloaded);
+      var all = await service.GetAllAsync();
+      Assert.Empty(all);
     }
   }
 }


### PR DESCRIPTION
## R2-G - ProgesiCluster referential integrity

Prevents clusters referencing non-existent variables, and keeps cluster<->variable references consistent on delete.

- **Create (strict reject):** `ClusterService` takes an optional `IVariableRepository`; if any input variable id does not exist, creation is rejected with the missing id(s) named. `ProgesiClusterDefinitionComponent` passes the variable repo and surfaces the rejection as a component error.
- **Delete (always cascade):** `CascadeRemoveVariableFromClustersAsync(id)` removes the variable from every referencing cluster (rebuilding via `Rehydrate`) and deletes any cluster left empty; wired into `TryDeleteVariable`.
- Id-based (hashtag support deferred by decision). Core-level; no Rhino dependency in the service. +4 unit tests.

### Verification
- `dotnet build -c Release`: 0 errors. `dotnet test`: **240/240** (236 baseline + 4 new). This script gates on both.
- **Manual GH validation pending:** ClusterDef rejects a missing var id; deleting a variable used by a cluster cascades (cluster updated / emptied cluster removed).

Do NOT merge until Claude review + manual GH validation + explicit go.

Generated with Claude Code.