### PR TITLE
fix(r2h): ClusterOut IndexOutOfRange hardening

### DIFF
--- a/src/ProgesiGrasshopperAssembly/Components/ProgesiClusterOutputComponent.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/ProgesiClusterOutputComponent.cs
@@ -216,6 +216,16 @@ namespace ProgesiGrasshopperAssembly.Components
         DA.SetDataList(2, names);
         DA.SetDataList(3, values);
 
+        // Guardia difensiva: se gli output dinamici non sono (ancora) allineati al
+        // numero di valori, forziamo una ricostruzione al solve successivo invece
+        // di lanciare IndexOutOfRange (Parameter 'index').
+        if (Params.Output.Count - 4 < values.Count)
+        {
+          _lastSignature = "";
+          ExpireSolution(true);
+          return;
+        }
+
         // Ora è sicuro scrivere nei dinamici
         for (int i = 0; i < values.Count; i++)
           DA.SetData(4 + i, values[i]);
@@ -301,8 +311,12 @@ namespace ProgesiGrasshopperAssembly.Components
     // ---------------- Helpers ----------------
     private bool EnsureDynamicOutputs(string signature, List<ProgesiCore.ProgesiVariable> vars)
     {
-      // Se firma uguale, non tocchiamo nulla
-      if (string.Equals(signature, _lastSignature, StringComparison.Ordinal))
+      // Se firma uguale E il numero di output dinamici è coerente, non tocchiamo nulla.
+      // (Se la firma coincide ma i parametri sono desincronizzati — es. dopo un cambio
+      //  di membership del cluster o un reload — ricostruiamo comunque per evitare
+      //  scritture fuori range sugli output dinamici.)
+      int existingSlots = Math.Max(0, Params.Output.Count - 4);
+      if (string.Equals(signature, _lastSignature, StringComparison.Ordinal) && existingSlots == vars.Count)
         return false;
 
       _lastSignature = signature;


### PR DESCRIPTION
## R2-H - ClusterOut IndexOutOfRange hardening

Fixes a runtime "Index was out of range (Parameter 'index')" in ProgesiClusterOutputComponent when the dynamic outputs and the resolved-values list desync (surfaced by the R2-G cascade: cluster membership changes at runtime).

- `EnsureDynamicOutputs`: an unchanged signature no longer short-circuits when the dynamic output-param count is stale - it reconciles the params.
- The value-write loop bounds-checks `Params.Output` and forces a clean rebuild (`ExpireSolution`) instead of indexing past the collection.
- No behaviour change in the normal path; 1 file.

### Verification
- `dotnet build -c Release`: 0 errors. `dotnet test`: **240/240** (no regression; ClusterOut is GH-coupled, no unit test).
- **Manual GH re-test pending (acceptance):** delete a variable used by a cluster while ClusterOut is on canvas; confirm NO exception popup and the reduced set (or "Cluster non trovato" when emptied).

Do NOT merge until manual GH re-test + review + go.

Generated with Claude Code.