### PR TITLE
feat(r2f): Rhino geometry value codec (persistence + Excel)

### DIFF
--- a/src/Progesi.GhExcelReadContract/GhExcelObjectSheet.cs
+++ b/src/Progesi.GhExcelReadContract/GhExcelObjectSheet.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Progesi.GhExcelReadContract
+{
+  /// <summary>
+  /// Pure chunk/dechunk helpers for ProgesiVariableObjects Excel sheet payloads.
+  /// </summary>
+  public static class GhExcelObjectSheet
+  {
+    public const string SheetName = "ProgesiVariableObjects";
+    public const string SheetAlias = "VariableObjects";
+    public const string ObjectMarkerPrefix = "@OBJECT:";
+    public const int DefaultMaxChunkLength = 30000;
+
+    public sealed class ObjectChunkRow
+    {
+      public int VarId { get; set; }
+      public int ChunkIndex { get; set; }
+      public int ChunkCount { get; set; }
+      public string ObjectType { get; set; } = "";
+      public string Payload { get; set; } = "";
+    }
+
+    public static string BuildObjectMarker(string objectType)
+    {
+      var type = (objectType ?? string.Empty).Trim();
+      if (type.Length == 0)
+        throw new ArgumentException("objectType is required", nameof(objectType));
+      return ObjectMarkerPrefix + type;
+    }
+
+    public static bool TryParseObjectMarker(string? cellValue, out string objectType)
+    {
+      objectType = string.Empty;
+      if (string.IsNullOrWhiteSpace(cellValue))
+        return false;
+
+      var value = cellValue.Trim();
+      if (!value.StartsWith(ObjectMarkerPrefix, StringComparison.OrdinalIgnoreCase))
+        return false;
+
+      objectType = value.Substring(ObjectMarkerPrefix.Length).Trim();
+      return objectType.Length > 0;
+    }
+
+    public static IReadOnlyList<ObjectChunkRow> ChunkPayload(
+      int varId,
+      string objectType,
+      string payload,
+      int maxChunkLength = DefaultMaxChunkLength)
+    {
+      if (varId <= 0) throw new ArgumentOutOfRangeException(nameof(varId));
+      if (string.IsNullOrEmpty(objectType)) throw new ArgumentException("objectType is required", nameof(objectType));
+      if (payload == null) throw new ArgumentNullException(nameof(payload));
+      if (maxChunkLength <= 0) throw new ArgumentOutOfRangeException(nameof(maxChunkLength));
+
+      if (payload.Length == 0)
+      {
+        return new[]
+        {
+          new ObjectChunkRow
+          {
+            VarId = varId,
+            ChunkIndex = 0,
+            ChunkCount = 1,
+            ObjectType = objectType,
+            Payload = string.Empty
+          }
+        };
+      }
+
+      var rows = new List<ObjectChunkRow>();
+      int chunkCount = (payload.Length + maxChunkLength - 1) / maxChunkLength;
+      for (int i = 0; i < chunkCount; i++)
+      {
+        int start = i * maxChunkLength;
+        int length = Math.Min(maxChunkLength, payload.Length - start);
+        rows.Add(new ObjectChunkRow
+        {
+          VarId = varId,
+          ChunkIndex = i,
+          ChunkCount = chunkCount,
+          ObjectType = objectType,
+          Payload = payload.Substring(start, length)
+        });
+      }
+
+      return rows;
+    }
+
+    public static bool TryReassemblePayload(
+      IEnumerable<ObjectChunkRow> rows,
+      int varId,
+      out string payload,
+      out string objectType,
+      out string error)
+    {
+      payload = string.Empty;
+      objectType = string.Empty;
+      error = string.Empty;
+
+      if (rows == null)
+      {
+        error = "rows is null";
+        return false;
+      }
+
+      var chunkRows = rows
+        .Where(r => r != null && r.VarId == varId)
+        .OrderBy(r => r.ChunkIndex)
+        .ToList();
+
+      if (chunkRows.Count == 0)
+      {
+        error = $"no object chunks for VarId={varId}";
+        return false;
+      }
+
+      objectType = chunkRows[0].ObjectType ?? string.Empty;
+      if (string.IsNullOrWhiteSpace(objectType))
+      {
+        error = "missing ObjectType";
+        return false;
+      }
+
+      int expectedCount = chunkRows[0].ChunkCount;
+      if (expectedCount <= 0 || chunkRows.Count != expectedCount)
+      {
+        error = $"chunk count mismatch for VarId={varId} (expected {expectedCount}, got {chunkRows.Count})";
+        return false;
+      }
+
+      for (int i = 0; i < expectedCount; i++)
+      {
+        var row = chunkRows[i];
+        if (row.ChunkIndex != i)
+        {
+          error = $"missing chunk index {i} for VarId={varId}";
+          return false;
+        }
+
+        if (!string.Equals(row.ObjectType, objectType, StringComparison.Ordinal))
+        {
+          error = $"ObjectType mismatch at chunk {i} for VarId={varId}";
+          return false;
+        }
+
+        if (row.ChunkCount != expectedCount)
+        {
+          error = $"ChunkCount mismatch at chunk {i} for VarId={varId}";
+          return false;
+        }
+      }
+
+      payload = string.Concat(chunkRows.Select(r => r.Payload ?? string.Empty));
+      return true;
+    }
+  }
+}

--- a/src/Progesi.GhExcelReadContract/GhExcelSheetNames.cs
+++ b/src/Progesi.GhExcelReadContract/GhExcelSheetNames.cs
@@ -8,5 +8,7 @@ namespace Progesi.GhExcelReadContract
     public const string MetadataAlias = "Metadata";
     public const string Clusters = "ProgesiClusters";
     public const string ClustersAlias = "Clusters";
+    public const string VariableObjects = GhExcelObjectSheet.SheetName;
+    public const string VariableObjectsAlias = GhExcelObjectSheet.SheetAlias;
   }
 }

--- a/src/Progesi.GhExcelReadContract/GhExcelVariableValueSupport.cs
+++ b/src/Progesi.GhExcelReadContract/GhExcelVariableValueSupport.cs
@@ -8,7 +8,8 @@ namespace Progesi.GhExcelReadContract
     Primitive,
     UnsupportedMarker,
     NonPrimitiveJsonLeak,
-    ReferencedObjectDisplayString
+    ReferencedObjectDisplayString,
+    ObjectSheetReference
   }
 
   /// <summary>
@@ -122,6 +123,13 @@ namespace Progesi.GhExcelReadContract
         return false;
       }
 
+      if (GhExcelObjectSheet.TryParseObjectMarker(value, out var objectType))
+      {
+        kind = GhExcelVariableValueKind.ObjectSheetReference;
+        detail = objectType;
+        return true;
+      }
+
       var trimmed = value.TrimStart();
       if (trimmed.StartsWith("{") || trimmed.StartsWith("["))
       {
@@ -143,6 +151,8 @@ namespace Progesi.GhExcelReadContract
           return $"[Var R{row}] VALUE non-primitive JSON not supported for Excel import → skip";
         case GhExcelVariableValueKind.ReferencedObjectDisplayString:
           return $"[Var R{row}] VALUE unsupported for Excel import ({detail}) → skip";
+        case GhExcelVariableValueKind.ObjectSheetReference:
+          return $"[Var R{row}] VALUE object reference missing payload ({detail}) → skip";
         default:
           return $"[Var R{row}] VALUE unsupported for Excel import → skip";
       }

--- a/src/ProgesiGrasshopperAssembly/Components/ProgesiDataExchangeComponent.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/ProgesiDataExchangeComponent.cs
@@ -13,9 +13,11 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ProgesiCore;
 using Progesi.GhExcelReadContract;
+using ProgesiRepositories.Rhino;
 using ProgesiGrasshopperAssembly.Infrastructure; // ServiceHub, ProgesiIcons, MetadataRepositoryCompatExtensions
 using Rhino;
 using Rhino.DocObjects.Tables;
+using Rhino.Geometry;
 using System;
 using System.Collections.Generic;
 using System.Data.SQLite;
@@ -263,6 +265,13 @@ namespace ProgesiGrasshopperAssembly.Components
       var metas = ReadAllMetasFromTable(table);
       var clusters = ReadAllClustersFromTable(table);
       int unsupportedVarExports = vars.Count(v => v.IsExcelUnsupported);
+      var objectChunkRows = new List<GhExcelObjectSheet.ObjectChunkRow>();
+      foreach (var v in vars)
+      {
+        if (string.IsNullOrWhiteSpace(v.ObjectPayloadJson))
+          continue;
+        objectChunkRows.AddRange(GhExcelObjectSheet.ChunkPayload(v.Id, v.ObjectType, v.ObjectPayloadJson));
+      }
       using (var wb = new XLWorkbook())
       {
         // Variables
@@ -332,10 +341,31 @@ namespace ProgesiGrasshopperAssembly.Components
         }
         wsC.Columns().AdjustToContents();
 
+        if (objectChunkRows.Count > 0)
+        {
+          var wsO = wb.Worksheets.Add(GhExcelSheetNames.VariableObjects);
+          wsO.Cell(1, 1).Value = "VarId";
+          wsO.Cell(1, 2).Value = "ChunkIndex";
+          wsO.Cell(1, 3).Value = "ChunkCount";
+          wsO.Cell(1, 4).Value = "ObjectType";
+          wsO.Cell(1, 5).Value = "Payload";
+          int r4 = 2;
+          foreach (var chunk in objectChunkRows)
+          {
+            wsO.Cell(r4, 1).Value = chunk.VarId;
+            wsO.Cell(r4, 2).Value = chunk.ChunkIndex;
+            wsO.Cell(r4, 3).Value = chunk.ChunkCount;
+            wsO.Cell(r4, 4).Value = chunk.ObjectType ?? "";
+            wsO.Cell(r4, 5).Value = chunk.Payload ?? "";
+            r4++;
+          }
+          wsO.Columns().AdjustToContents();
+        }
+
         wb.SaveAs(p);
       }
 
-      string info = $"OK ExportExcel → {p} (Vars:{vars.Length}, Meta:{metas.Length}, Clusters:{clusters.Length})";
+      string info = $"OK ExportExcel → {p} (Vars:{vars.Length}, Meta:{metas.Length}, Clusters:{clusters.Length}, ObjectChunks:{objectChunkRows.Count})";
       if (unsupportedVarExports > 0)
         info += $" | UnsupportedVarValues:{unsupportedVarExports}";
       return (p, info);
@@ -505,6 +535,8 @@ namespace ProgesiGrasshopperAssembly.Components
 
         if (!varHeaderError && wsV != null)
         {
+          var objectChunkRows = ReadObjectChunkRows(wb);
+
           for (int r = r0V + 1; r <= rNV; r++)
           {
             string name = GhExcelCellReader.ReadCell(wsV, r, mapV, "NAME");
@@ -534,7 +566,30 @@ namespace ProgesiGrasshopperAssembly.Components
             int[] depArr = GhExcelValueParsing.ParseDepends(deps);
             bool ass = GhExcelValueParsing.ToBool(asS);
 
-            if (!GhExcelVariableValueSupport.IsImportSupported(value, out var unsupportedKind, out var unsupportedDetail))
+            string geometryJson = null;
+            if (GhExcelObjectSheet.TryParseObjectMarker(value, out _))
+            {
+              if (!GhExcelObjectSheet.TryReassemblePayload(objectChunkRows, id, out var payload, out var objectType, out var objErr))
+              {
+                var msg = $"[Var R{r}] object payload missing/invalid: {objErr}";
+                if (strict) { ERR(1, msg); AddErrRC(1, r, mapV.TryGetValue("VALUE", out var c) ? c : 0); varErr++; }
+                else { WARN(1, msg); AddErrRC(1, r, mapV.TryGetValue("VALUE", out var c) ? c : 0); varWarn++; }
+                varRows++;
+                continue;
+              }
+
+              if (!ProgesiGeometryValueCodec.TryDecode(payload, out var geometry) || geometry == null)
+              {
+                var msg = $"[Var R{r}] object decode failed ({objectType})";
+                if (strict) { ERR(1, msg); AddErrRC(1, r, mapV.TryGetValue("VALUE", out var c) ? c : 0); varErr++; }
+                else { WARN(1, msg); AddErrRC(1, r, mapV.TryGetValue("VALUE", out var c) ? c : 0); varWarn++; }
+                varRows++;
+                continue;
+              }
+
+              geometryJson = payload;
+            }
+            else if (!GhExcelVariableValueSupport.IsImportSupported(value, out var unsupportedKind, out var unsupportedDetail))
             {
               var msg = GhExcelVariableValueSupport.BuildImportSkipMessage(r, unsupportedKind, unsupportedDetail);
               if (strict) { ERR(1, msg); AddErrRC(1, r, mapV.TryGetValue("VALUE", out var c) ? c : 0); varErr++; }
@@ -549,7 +604,8 @@ namespace ProgesiGrasshopperAssembly.Components
               {
                 id = id,
                 name = name ?? "",
-                value = value ?? "",
+                value = geometryJson ?? (value ?? ""),
+                geometryJson = geometryJson ?? "",
                 unit = "",
                 by = "",
                 isAssumption = ass,
@@ -1333,6 +1389,8 @@ CREATE TABLE IF NOT EXISTS ClusterVariables (
       public int[] Depends;
       public bool Assumption;
       public bool IsExcelUnsupported;
+      public string ObjectType = "";
+      public string ObjectPayloadJson = "";
     }
 
     private sealed class MetaRow
@@ -1421,8 +1479,23 @@ CREATE TABLE IF NOT EXISTS ClusterVariables (
         int[] deps = dto.Depends ?? Array.Empty<int>();
         bool ass = dto.IsAssumption ?? false;
         string valueType = dto.ValueType ?? "string";
-        string excelValue = GhExcelVariableValueSupport.FormatExportValue(valueType, dto.Value ?? "", valc);
-        bool isExcelUnsupported = GhExcelVariableValueSupport.RequiresUnsupportedExportHandling(valueType, dto.Value ?? "");
+        string excelValue;
+        string objectType = "";
+        string objectPayloadJson = "";
+        bool isExcelUnsupported;
+
+        if (typed is GeometryBase geometry)
+        {
+          objectType = ProgesiGeometryValueCodec.GetShortTypeName(geometry);
+          objectPayloadJson = ProgesiGeometryValueCodec.Encode(geometry);
+          excelValue = GhExcelObjectSheet.BuildObjectMarker(objectType);
+          isExcelUnsupported = false;
+        }
+        else
+        {
+          excelValue = GhExcelVariableValueSupport.FormatExportValue(valueType, dto.Value ?? "", valc);
+          isExcelUnsupported = GhExcelVariableValueSupport.RequiresUnsupportedExportHandling(valueType, dto.Value ?? "");
+        }
 
         var pv = new ProgesiVariable(id, dto.Name ?? "", typed, deps, dto.MetadataId, ass);
         string hash = ProgesiHash.Compute(pv);
@@ -1437,7 +1510,9 @@ CREATE TABLE IF NOT EXISTS ClusterVariables (
           MetaId = dto.MetadataId ?? 0,
           Depends = deps,
           Assumption = ass,
-          IsExcelUnsupported = isExcelUnsupported
+          IsExcelUnsupported = isExcelUnsupported,
+          ObjectType = objectType,
+          ObjectPayloadJson = objectPayloadJson
         });
       }
       return list.ToArray();
@@ -1494,13 +1569,60 @@ CREATE TABLE IF NOT EXISTS ClusterVariables (
       return ids.Distinct().ToArray();
     }
 
+    private static List<GhExcelObjectSheet.ObjectChunkRow> ReadObjectChunkRows(XLWorkbook workbook)
+    {
+      var rows = new List<GhExcelObjectSheet.ObjectChunkRow>();
+      var wsO = GhExcelWorksheetLocator.TryGetWorksheet(
+        workbook,
+        GhExcelSheetNames.VariableObjects,
+        GhExcelSheetNames.VariableObjectsAlias);
+      if (wsO == null)
+        return rows;
+
+      var header = GhExcelHeaderMap.Build(wsO, out int headerRow, out int lastRow);
+      if (!header.TryGetValue("VARID", out int colVarId)
+          || !header.TryGetValue("CHUNKINDEX", out int colChunkIndex)
+          || !header.TryGetValue("CHUNKCOUNT", out int colChunkCount)
+          || !header.TryGetValue("OBJECTTYPE", out int colObjectType)
+          || !header.TryGetValue("PAYLOAD", out int colPayload))
+      {
+        return rows;
+      }
+
+      for (int r = headerRow + 1; r <= lastRow; r++)
+      {
+        int varId = GhExcelValueParsing.ToInt(wsO.Cell(r, colVarId).GetString());
+        if (varId <= 0)
+          continue;
+
+        rows.Add(new GhExcelObjectSheet.ObjectChunkRow
+        {
+          VarId = varId,
+          ChunkIndex = GhExcelValueParsing.ToInt(wsO.Cell(r, colChunkIndex).GetString()),
+          ChunkCount = GhExcelValueParsing.ToInt(wsO.Cell(r, colChunkCount).GetString()),
+          ObjectType = wsO.Cell(r, colObjectType).GetString() ?? "",
+          Payload = wsO.Cell(r, colPayload).GetString() ?? ""
+        });
+      }
+
+      return rows;
+    }
+
     private static object ParseValue(string value, string valueType)
     {
-      string vt = (valueType ?? "string").Trim().ToLowerInvariant();
-      if (string.Equals(value, "null", StringComparison.OrdinalIgnoreCase) || vt == "null") return null;
+      string vt = (valueType ?? "string").Trim();
+      if (string.Equals(value, "null", StringComparison.OrdinalIgnoreCase)
+          || string.Equals(vt, "null", StringComparison.OrdinalIgnoreCase))
+        return null;
+
+      if (ProgesiGeometryValueCodec.IsGeometryValueType(vt)
+          && ProgesiGeometryValueCodec.TryDecode(value, out var geometry)
+          && geometry != null)
+        return geometry;
+
       try
       {
-        switch (vt)
+        switch (vt.ToLowerInvariant())
         {
           case "string": return value ?? "";
           case "int": return int.Parse(value ?? "0", CultureInfo.InvariantCulture);

--- a/src/ProgesiGrasshopperAssembly/Components/ProgesiVariableInComponent.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/ProgesiVariableInComponent.cs
@@ -6,8 +6,11 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Reflection;
 using Grasshopper.Kernel;
+using Grasshopper.Kernel.Types;
 using ProgesiGrasshopperAssembly.Infrastructure;
 using ProgesiCore;
+using ProgesiRepositories.Rhino;
+using Rhino.Geometry;
 
 namespace ProgesiGrasshopperAssembly.Components
 {
@@ -29,7 +32,8 @@ namespace ProgesiGrasshopperAssembly.Components
       p.AddTextParameter("Act", "Act", "Create | Update | Delete", GH_ParamAccess.item, "Create");
       p.AddIntegerParameter("Id", "Id", "Id per Update/Delete.", GH_ParamAccess.item, 0);
       p.AddTextParameter("Name", "Name", "Nome variabile (es. LEN).", GH_ParamAccess.item, "");
-      p.AddTextParameter("Value", "Value", "Valore (string/number).", GH_ParamAccess.item, "");
+      p.AddGenericParameter("Value", "Value", "Valore (string/number/GeometryBase).", GH_ParamAccess.item);
+      Params.Input[Params.Input.Count - 1].Optional = true;
       p.AddTextParameter("Unit", "Unit", "Fattore numerico (double) applicato a Value se ENTRAMBI numerici; altrimenti ignorato.", GH_ParamAccess.item, "");
       p.AddTextParameter("By", "By", "Autore (es. GM).", GH_ParamAccess.item, "");
 
@@ -59,12 +63,14 @@ namespace ProgesiGrasshopperAssembly.Components
 
     protected override void SolveInstance(IGH_DataAccess DA)
     {
-      bool run = false; string act = "Create"; int id = 0; string name = ""; string val = ""; string unit = ""; string by = "";
+      bool run = false; string act = "Create"; int id = 0; string name = ""; string val = ""; string geometryJson = ""; string unit = ""; string by = "";
       bool isAss = false; string mid = "";
       var depends = new List<int>();
+      object valueInput = null;
 
       DA.GetData(0, ref run); DA.GetData(1, ref act); DA.GetData(2, ref id);
-      DA.GetData(3, ref name); DA.GetData(4, ref val); DA.GetData(5, ref unit); DA.GetData(6, ref by);
+      DA.GetData(3, ref name); DA.GetData(4, ref valueInput); DA.GetData(5, ref unit); DA.GetData(6, ref by);
+      CoerceValueInput(valueInput, out val, out geometryJson);
       DA.GetData(7, ref isAss); DA.GetData(8, ref mid);
       if (!DA.GetDataList(9, depends)) depends.Clear();
 
@@ -86,10 +92,11 @@ namespace ProgesiGrasshopperAssembly.Components
         return;
       }
 
-      // Unit come fattore numerico opzionale: Value × Unit se ENTRAMBI numerici
+      // Unit come fattore numerico opzionale: Value × Unit se ENTRAMBI numerici (non per geometry)
       var inv = CultureInfo.InvariantCulture;
-      if (double.TryParse(val, NumberStyles.Any, inv, out var vFix) &&
-          double.TryParse(unit, NumberStyles.Any, inv, out var uFix))
+      if (string.IsNullOrWhiteSpace(geometryJson)
+          && double.TryParse(val, NumberStyles.Any, inv, out var vFix)
+          && double.TryParse(unit, NumberStyles.Any, inv, out var uFix))
       {
         var combined = vFix * uFix;
         val = combined.ToString(inv);
@@ -116,6 +123,7 @@ namespace ProgesiGrasshopperAssembly.Components
           allowIdReassign = isCreate && IsTreeOrBatchInput(),
           name = name ?? "",
           value = val ?? "",
+          geometryJson = geometryJson ?? "",
           unit = unit ?? "",
           by = by ?? "",
           isAssumption = isAss,
@@ -135,8 +143,10 @@ namespace ProgesiGrasshopperAssembly.Components
         var prefix = string.IsNullOrWhiteSpace(upInfo) ? (upOk ? "OK" : "Operazione non riuscita") : upInfo;
         outInfo = string.IsNullOrWhiteSpace(summary) ? prefix : $"{prefix} | {summary}";
 
-        if (!upOk) { Fail(DA, val, outId, outHash, outInfo, name); return; }
-        Emit(DA, val, outId, outHash, outInfo, name);
+        string emitVal = val;
+        ReadIf(saved, "ValueCanonical", ref emitVal);
+        if (!upOk) { Fail(DA, emitVal, outId, outHash, outInfo, name); return; }
+        Emit(DA, emitVal, outId, outHash, outInfo, name);
       }
       catch (Exception ex) { Fail(DA, val, outId, outHash, "Errore: " + ex.Message, name); }
     }
@@ -159,6 +169,7 @@ namespace ProgesiGrasshopperAssembly.Components
       public bool allowIdReassign { get; set; }
       public string name { get; set; }
       public string value { get; set; }
+      public string geometryJson { get; set; }
       public string unit { get; set; }
       public string by { get; set; }
       public bool isAssumption { get; set; }
@@ -182,6 +193,81 @@ namespace ProgesiGrasshopperAssembly.Components
       if (pi == null) return;
       var v = pi.GetValue(obj, null);
       target = v == null ? "" : v.ToString();
+    }
+
+    private static void CoerceValueInput(object input, out string val, out string geometryJson)
+    {
+      val = "";
+      geometryJson = "";
+
+      if (input == null)
+        return;
+
+      if (input is IGH_Goo goo)
+      {
+        if (goo is GH_ObjectWrapper ow && ow.Value != null)
+          input = ow.Value;
+        else if (TryCastGeometry(goo, out var geomFromGoo))
+        {
+          geometryJson = ProgesiGeometryValueCodec.Encode(geomFromGoo);
+          val = geometryJson;
+          return;
+        }
+        else
+        {
+          string s;
+          if (goo.CastTo(out s))
+          {
+            val = s ?? "";
+            return;
+          }
+
+          int i;
+          if (goo.CastTo(out i))
+          {
+            val = i.ToString(CultureInfo.InvariantCulture);
+            return;
+          }
+
+          double d;
+          if (goo.CastTo(out d))
+          {
+            val = d.ToString(CultureInfo.InvariantCulture);
+            return;
+          }
+
+          bool b;
+          if (goo.CastTo(out b))
+          {
+            val = b ? "true" : "false";
+            return;
+          }
+        }
+      }
+
+      if (input is GeometryBase geometry)
+      {
+        geometryJson = ProgesiGeometryValueCodec.Encode(geometry);
+        val = geometryJson;
+        return;
+      }
+
+      val = input.ToString() ?? "";
+    }
+
+    private static bool TryCastGeometry(IGH_Goo goo, out GeometryBase geometry)
+    {
+      geometry = null;
+      if (goo == null)
+        return false;
+
+      if (goo is GH_ObjectWrapper ow && ow.Value is GeometryBase wrapped)
+      {
+        geometry = wrapped;
+        return true;
+      }
+
+      return goo.CastTo(out geometry) && geometry != null;
     }
 
     // Esito bloccante: errore rosso sul componente + Info testuale, senza overwrite silenzioso.

--- a/src/ProgesiGrasshopperAssembly/Components/ProgesiVariableOutComponent.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/ProgesiVariableOutComponent.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
+using Grasshopper.Kernel.Parameters;
 using Grasshopper.Kernel.Types;
 using ProgesiGrasshopperAssembly.Infrastructure;
 
@@ -38,7 +39,14 @@ namespace ProgesiGrasshopperAssembly.Components
 
     protected override void RegisterOutputParams(GH_OutputParamManager p)
     {
-      p.AddTextParameter("Val", "Val", "Dynamic: Value con NickName uguale al Name (se singolo elemento).", GH_ParamAccess.tree);
+      var valOut = new Param_GenericObject
+      {
+        Name = "Val",
+        NickName = "Val",
+        Description = "Dynamic: Value con NickName uguale al Name (GenericObject).",
+        Access = GH_ParamAccess.tree
+      };
+      p.AddParameter(valOut);
       p.AddIntegerParameter("Id", "Id", "Id.", GH_ParamAccess.tree);
       p.AddTextParameter("Hash", "Hash", "Riepilogo umano: ID/NAME/VALC/BY/MID/DEP/ASS.", GH_ParamAccess.tree);
       p.AddTextParameter("Name", "Name", "Nome.", GH_ParamAccess.tree);
@@ -72,7 +80,7 @@ namespace ProgesiGrasshopperAssembly.Components
       foreach (var p in idIn.Paths) allPaths.Add(p);
       if (allPaths.Count == 0) allPaths.Add(new GH_Path(0));
 
-      var tVal = new GH_Structure<GH_String>();
+      var tVal = new GH_Structure<IGH_Goo>();
       var tId = new GH_Structure<GH_Integer>();
       var tHash = new GH_Structure<GH_String>();
       var tName = new GH_Structure<GH_String>();
@@ -107,6 +115,7 @@ namespace ProgesiGrasshopperAssembly.Components
           object obj;
           bool ok = MetadataRepositoryCompatExtensions.TryGetVariableByHashThenId(repo, hash, id, out obj, out info);
 
+          object typedValue = null;
           string name = "", value = "", valc = "", by = "-", lm = "";
           int outId = 0, mid = 0;
           bool ass = false;
@@ -119,6 +128,7 @@ namespace ProgesiGrasshopperAssembly.Components
             ReadIf(obj, "Name", ref name);
             ReadIf(obj, "Value", ref value);
             ReadIf(obj, "ValueCanonical", ref valc);
+            typedValue = ReadObject(obj, "TypedValue");
             ReadIf(obj, "By", ref by, "-");
             ReadIf(obj, "LastModified", ref lm);
             ReadIf(obj, "MetaId", ref mid);
@@ -137,7 +147,10 @@ namespace ProgesiGrasshopperAssembly.Components
           }
 
           var path = p;
-          tVal.Append(new GH_String(value ?? ""), path);
+          if (typedValue != null)
+            tVal.Append(new GH_ObjectWrapper(typedValue), path);
+          else
+            tVal.Append(new GH_String(value ?? ""), path);
           tId.Append(new GH_Integer(outId), path);
           tHash.Append(new GH_String(summary), path);
           tName.Append(new GH_String(name ?? ""), path);
@@ -230,6 +243,14 @@ namespace ProgesiGrasshopperAssembly.Components
         if (goo.CastTo(out s) && int.TryParse(s, out n)) return n;
       }
       return 0;
+    }
+
+    private static object ReadObject(object obj, string prop)
+    {
+      if (obj == null) return null;
+      var pi = obj.GetType().GetProperty(prop, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+      if (pi == null) return null;
+      return pi.GetValue(obj, null);
     }
 
     // -------- reflection helpers --------

--- a/src/ProgesiGrasshopperAssembly/Infrastructure/MetadataRepositoryCompatExtensions.cs
+++ b/src/ProgesiGrasshopperAssembly/Infrastructure/MetadataRepositoryCompatExtensions.cs
@@ -372,6 +372,7 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
           Hash = ProgesiHash.Compute(v),     // content-hash interno
           Name = name,
           Value = value,
+          TypedValue = v.Value,
           ValueCanonical = valc,
           By = by,
           LastModified = IsoNowUtc(),
@@ -435,9 +436,16 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
           }
         }
 
-        // cast a tipo semplice
+        // cast a tipo semplice (geometry codec overrides string parsing)
         object typedValue = value;
-        if (int.TryParse(value, NumberStyles.Integer, inv, out var asInt)) typedValue = asInt;
+        var geometryJson = ReadString(payload, "geometryJson");
+        if (!string.IsNullOrWhiteSpace(geometryJson)
+            && ProgesiGeometryValueCodec.TryDecode(geometryJson, out var geometryValue)
+            && geometryValue != null)
+        {
+          typedValue = geometryValue;
+        }
+        else if (int.TryParse(value, NumberStyles.Integer, inv, out var asInt)) typedValue = asInt;
         else if (double.TryParse(value, NumberStyles.Float, inv, out var asDbl)) typedValue = asDbl;
         else if (string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)) typedValue = true;
         else if (string.Equals(value, "false", StringComparison.OrdinalIgnoreCase)) typedValue = false;

--- a/src/ProgesiRepositories.Rhino/ProgesiGeometryValueCodec.cs
+++ b/src/ProgesiRepositories.Rhino/ProgesiGeometryValueCodec.cs
@@ -1,0 +1,66 @@
+using Rhino.FileIO;
+using Rhino.Geometry;
+using System;
+
+#nullable enable
+namespace ProgesiRepositories.Rhino
+{
+  /// <summary>
+  /// RhinoCommon geometry persistence codec (ToJSON / FromJSON).
+  /// Lives in ProgesiRepositories.Rhino to keep GhExcelReadContract Rhino-free.
+  /// </summary>
+  public static class ProgesiGeometryValueCodec
+  {
+    public const string StorageValueTypePrefix = "Progesi.Geometry:";
+
+    public static bool IsGeometry(object? obj) => obj is GeometryBase;
+
+    public static bool IsGeometryValueType(string? valueType)
+    {
+      if (string.IsNullOrWhiteSpace(valueType))
+        return false;
+
+      if (valueType.StartsWith(StorageValueTypePrefix, StringComparison.OrdinalIgnoreCase))
+        return true;
+
+      var type = Type.GetType(valueType, throwOnError: false);
+      return type != null && typeof(GeometryBase).IsAssignableFrom(type);
+    }
+
+    public static string GetStorageValueType(GeometryBase geometry)
+    {
+      if (geometry == null) throw new ArgumentNullException(nameof(geometry));
+      return StorageValueTypePrefix + geometry.GetType().FullName;
+    }
+
+    public static string GetShortTypeName(GeometryBase geometry)
+    {
+      if (geometry == null) throw new ArgumentNullException(nameof(geometry));
+      return geometry.GetType().FullName ?? "Rhino.Geometry.GeometryBase";
+    }
+
+    public static string Encode(GeometryBase geometry)
+    {
+      if (geometry == null) throw new ArgumentNullException(nameof(geometry));
+      return geometry.ToJSON(new SerializationOptions());
+    }
+
+    public static bool TryDecode(string? json, out GeometryBase? geometry)
+    {
+      geometry = null;
+      if (string.IsNullOrWhiteSpace(json))
+        return false;
+
+      try
+      {
+        var obj = GeometryBase.FromJSON(json);
+        geometry = obj as GeometryBase;
+        return geometry != null;
+      }
+      catch
+      {
+        return false;
+      }
+    }
+  }
+}

--- a/src/ProgesiRepositories.Rhino/RhinoVariableRepository.cs
+++ b/src/ProgesiRepositories.Rhino/RhinoVariableRepository.cs
@@ -2,6 +2,7 @@
 using ProgesiCore;
 using Rhino;
 using Rhino.DocObjects.Tables;
+using Rhino.Geometry;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -99,6 +100,9 @@ namespace ProgesiRepositories.Rhino
     private static string TypeOf(object? obj)
     {
       if (obj == null) return "null";
+      if (obj is GeometryBase geom)
+        return ProgesiGeometryValueCodec.GetStorageValueType(geom);
+
       return obj switch
       {
         string _ => "string",
@@ -115,6 +119,9 @@ namespace ProgesiRepositories.Rhino
     private static string Stringify(object? obj)
     {
       if (obj == null) return "null";
+      if (obj is GeometryBase geom)
+        return ProgesiGeometryValueCodec.Encode(geom);
+
       return obj switch
       {
         string s => s,
@@ -131,6 +138,14 @@ namespace ProgesiRepositories.Rhino
     private static object? ParseValue(string value, string valueType)
     {
       if (valueType == "null") return null;
+
+      if (ProgesiGeometryValueCodec.IsGeometryValueType(valueType))
+      {
+        if (ProgesiGeometryValueCodec.TryDecode(value, out var geometry))
+          return geometry;
+        return value;
+      }
+
       return valueType switch
       {
         "string" => value,

--- a/tests/Progesi.GhExcelReadContract.Tests/GhExcelObjectSheetTests.cs
+++ b/tests/Progesi.GhExcelReadContract.Tests/GhExcelObjectSheetTests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using Progesi.GhExcelReadContract;
+using System.Linq;
+using Xunit;
+
+namespace Progesi.GhExcelReadContract.Tests
+{
+  public class GhExcelObjectSheetTests
+  {
+    [Fact]
+    public void BuildObjectMarker_And_TryParseObjectMarker_RoundTrip()
+    {
+      var marker = GhExcelObjectSheet.BuildObjectMarker("Rhino.Geometry.LineCurve");
+
+      GhExcelObjectSheet.TryParseObjectMarker(marker, out var type).Should().BeTrue();
+      type.Should().Be("Rhino.Geometry.LineCurve");
+    }
+
+    [Fact]
+    public void ChunkPayload_SingleChunk_When_Payload_Fits()
+    {
+      var rows = GhExcelObjectSheet.ChunkPayload(5, "Rhino.Geometry.Point3d", "{\"x\":1}");
+
+      rows.Should().HaveCount(1);
+      rows[0].VarId.Should().Be(5);
+      rows[0].ChunkIndex.Should().Be(0);
+      rows[0].ChunkCount.Should().Be(1);
+      rows[0].ObjectType.Should().Be("Rhino.Geometry.Point3d");
+      rows[0].Payload.Should().Be("{\"x\":1}");
+    }
+
+    [Fact]
+    public void ChunkPayload_And_TryReassemblePayload_RoundTrip_MultiChunk()
+    {
+      var payload = new string('A', GhExcelObjectSheet.DefaultMaxChunkLength + 123);
+      var rows = GhExcelObjectSheet.ChunkPayload(9, "Rhino.Geometry.PolylineCurve", payload);
+
+      rows.Should().HaveCount(2);
+      rows[0].ChunkCount.Should().Be(2);
+      rows[1].ChunkIndex.Should().Be(1);
+
+      GhExcelObjectSheet.TryReassemblePayload(rows, 9, out var rebuilt, out var type, out var error)
+        .Should().BeTrue(error);
+
+      rebuilt.Should().Be(payload);
+      type.Should().Be("Rhino.Geometry.PolylineCurve");
+    }
+
+    [Fact]
+    public void TryReassemblePayload_Fails_When_Chunk_Missing()
+    {
+      var payload = new string('B', GhExcelObjectSheet.DefaultMaxChunkLength + 50);
+      var rows = GhExcelObjectSheet.ChunkPayload(3, "Rhino.Geometry.Curve", payload).ToList();
+      rows.RemoveAt(1);
+
+      GhExcelObjectSheet.TryReassemblePayload(rows, 3, out _, out _, out var error)
+        .Should().BeFalse();
+
+      error.Should().Contain("chunk count mismatch");
+    }
+
+    [Fact]
+    public void TryReassemblePayload_Fails_When_VarId_Not_Found()
+    {
+      var rows = GhExcelObjectSheet.ChunkPayload(4, "Rhino.Geometry.Curve", "abc");
+
+      GhExcelObjectSheet.TryReassemblePayload(rows, 99, out _, out _, out var error)
+        .Should().BeFalse();
+
+      error.Should().Contain("no object chunks");
+    }
+  }
+}


### PR DESCRIPTION
## R2-F - Rhino geometry value serialization (codec: persistence + Excel)

One RhinoCommon geometry codec (`ToJSON`/`FromJSON`, spike-proven: faithful + doc-independent) used in:
- `RhinoVariableRepository` Save/Get for geometry `Value`s (faithful .3dm persistence; backward-compatible for other types).
- DataExchange Excel export/import via a chunked `ProgesiVariableObjects` sheet (box ~23k chars -> chunking at ~30k/cell).

Geometry-valued ProgesiVariables now round-trip same-file and cross-file. Non-geometry/primitive values unchanged. Core stays Rhino-free.

### Verification
- `dotnet build -c Release`: 0 errors. `dotnet test`: >= 240 + new sheet unit tests. This script gates on both.
- **Manual GH pending (acceptance):** VarIn a Brep -> VarOut same file shows geometry; ExportExcel -> new file -> ImportExcel -> geometry Value reconstructed (no @UNSUPPORTED for geometry).

Do NOT merge until manual GH + Claude review + go.

Generated with Claude Code.