### PR TITLE
feat(r2j): deterministic hashtag identity for all core objects

### DIFF
--- a/src/Progesi.Infrastructure.EF/Repositories/EfMetadataRepository.cs
+++ b/src/Progesi.Infrastructure.EF/Repositories/EfMetadataRepository.cs
@@ -32,6 +32,23 @@ public sealed class EfMetadataRepository : IMetadataRepository
     return MetadataSerialization.FromStoredJson(entity.Json, entity.LastModified, entity.Id);
   }
 
+  public async Task<ProgesiMetadata?> GetByHashtagAsync(string hashtag, CancellationToken ct = default)
+  {
+    if (string.IsNullOrWhiteSpace(hashtag))
+      return null;
+
+    var id = await _context.Metadata
+        .AsNoTracking()
+        .Where(m => m.ContentHash == hashtag)
+        .Select(m => (int?)m.Id)
+        .FirstOrDefaultAsync(ct);
+
+    if (!id.HasValue)
+      return null;
+
+    return await GetAsync(id.Value, ct);
+  }
+
   public async Task UpsertAsync(ProgesiMetadata metadata, CancellationToken ct = default)
   {
     if (metadata is null) throw new ArgumentNullException(nameof(metadata));

--- a/src/Progesi.Infrastructure.EF/Repositories/EfVariableRepository.cs
+++ b/src/Progesi.Infrastructure.EF/Repositories/EfVariableRepository.cs
@@ -60,6 +60,23 @@ public sealed class EfVariableRepository : IVariableRepository
     return await GetByIdAsync(variable.Id, ct) ?? variable;
   }
 
+  public async Task<ProgesiVariable?> GetByHashtagAsync(string hashtag, CancellationToken ct = default)
+  {
+    if (string.IsNullOrWhiteSpace(hashtag))
+      return null;
+
+    var id = await _context.Variables
+        .AsNoTracking()
+        .Where(v => v.ContentHash == hashtag)
+        .Select(v => (int?)v.Id)
+        .FirstOrDefaultAsync(ct);
+
+    if (!id.HasValue)
+      return null;
+
+    return await GetByIdAsync(id.Value, ct);
+  }
+
   public async Task<ProgesiVariable> GetByIdAsync(int id, CancellationToken ct = default)
   {
     var entity = await _context.Variables

--- a/src/ProgesiCore/IMetadataRepository.cs
+++ b/src/ProgesiCore/IMetadataRepository.cs
@@ -16,6 +16,11 @@ namespace ProgesiCore
     Task<ProgesiMetadata?> GetAsync(int id, CancellationToken ct = default);
 
     /// <summary>
+    /// Restituisce la metadata con Hashtag corrispondente, oppure null se non esiste.
+    /// </summary>
+    Task<ProgesiMetadata?> GetByHashtagAsync(string hashtag, CancellationToken ct = default);
+
+    /// <summary>
     /// Inserisce o aggiorna la metadata.
     /// </summary>
     Task UpsertAsync(ProgesiMetadata metadata, CancellationToken ct = default);

--- a/src/ProgesiCore/IVariableRepository.cs
+++ b/src/ProgesiCore/IVariableRepository.cs
@@ -8,6 +8,7 @@ namespace ProgesiCore
   {
     Task<ProgesiVariable> SaveAsync(ProgesiVariable variable, CancellationToken ct = default);  // upsert
     Task<ProgesiVariable> GetByIdAsync(int id, CancellationToken ct = default);
+    Task<ProgesiVariable?> GetByHashtagAsync(string hashtag, CancellationToken ct = default);
     Task<IReadOnlyList<ProgesiVariable>> GetAllAsync(CancellationToken ct = default);
     Task<bool> DeleteAsync(int id, CancellationToken ct = default);
     Task<int> DeleteManyAsync(IEnumerable<int> ids, CancellationToken ct = default);

--- a/src/ProgesiCore/ProgesiHash.cs
+++ b/src/ProgesiCore/ProgesiHash.cs
@@ -8,6 +8,9 @@ namespace ProgesiCore
 {
   public static class ProgesiHash
   {
+    /// <summary>Hashtag payload scheme version (v1 = current SHA-256 JSON payloads; hex is not prefixed).</summary>
+    public const int HashtagSchemeVersion = 1;
+
     private static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings
     {
       NullValueHandling = NullValueHandling.Include
@@ -145,6 +148,22 @@ namespace ProgesiCore
         AdditionalInfo = m.AdditionalInfo ?? string.Empty,
         References = refs,
         Snips = snips
+      };
+
+      string json = JsonConvert.SerializeObject(payload, JsonSettings) ?? string.Empty;
+      return Sha256Hex(json);
+    }
+
+    // ===== Compute per Snip =====
+    public static string Compute(ProgesiSnip snip)
+    {
+      if (snip == null) throw new ArgumentNullException(nameof(snip));
+
+      var payload = new
+      {
+        ContentHash = Sha256Hex(snip.Content ?? Array.Empty<byte>()),
+        MimeType = snip.MimeType ?? "image/png",
+        Source = snip.Source ?? string.Empty
       };
 
       string json = JsonConvert.SerializeObject(payload, JsonSettings) ?? string.Empty;

--- a/src/ProgesiCore/ProgesiMetadata.cs
+++ b/src/ProgesiCore/ProgesiMetadata.cs
@@ -86,6 +86,9 @@ namespace ProgesiCore
 
     public IReadOnlyList<ProgesiSnip> Snips => _snips.ToList();
 
+    /// <summary>Content-based hashtag (SHA-256 digest; derived, not part of equality).</summary>
+    public string Hashtag => ProgesiHash.Compute(this);
+
     public void UpdateAdditionalInfo(string? info)
     {
       AdditionalInfo = info ?? string.Empty;
@@ -231,6 +234,9 @@ namespace ProgesiCore
     public string MimeType { get; private set; } = "image/png";
     public string Caption { get; private set; } = string.Empty;
     public string? Source { get; private set; }
+
+    /// <summary>Content-based hashtag (SHA-256 digest; derived, not part of equality).</summary>
+    public string Hashtag => ProgesiHash.Compute(this);
 
     protected override IEnumerable<object> GetEqualityComponents()
     {

--- a/src/ProgesiCore/ProgesiVariable.cs
+++ b/src/ProgesiCore/ProgesiVariable.cs
@@ -20,6 +20,9 @@ namespace ProgesiCore
     /// </summary>
     public bool IsAssumption { get; private set; } = false;
 
+    /// <summary>Content-based hashtag (SHA-256 digest; derived, not part of equality).</summary>
+    public string Hashtag => ProgesiHash.Compute(this);
+
     public ProgesiVariable(int id, string name, object? value, IEnumerable<int>? dependsFrom = null, IEnumerable<int>? metadataIds = null, bool isAssumption = false)
     {
       Guard.Against.Negative(id, nameof(id));

--- a/src/ProgesiCore/ProgesiVariableCluster.cs
+++ b/src/ProgesiCore/ProgesiVariableCluster.cs
@@ -68,7 +68,7 @@ namespace ProgesiCore
       _progesiVariableIds.Clear();
       _progesiVariableIds.AddRange(ids);
 
-      Hashtag = BuildHashtag(Id, Name, _progesiVariableIds);
+      Hashtag = ComputeContentHashtag();
     }
 
     /// <summary>
@@ -142,18 +142,17 @@ namespace ProgesiCore
     /// </summary>
     public ProgesiVariableCluster RecalculateHashtag()
     {
-      Hashtag = BuildHashtag(Id, Name, _progesiVariableIds);
+      Hashtag = ComputeContentHashtag();
       return this;
     }
 
-    private static string BuildHashtag(int id, string name, IEnumerable<int> orderedIds)
+    private string ComputeContentHashtag() => ProgesiHash.Compute(this);
+
+    /// <summary>Pre-R2-J human-readable hashtag for same-store back-compat lookups.</summary>
+    public static string BuildLegacyHashtag(int id, string name, IEnumerable<int> orderedIds)
     {
       var idsPart = string.Join(",", orderedIds);
-      var seed = $"{id}|{name.Trim()}|{idsPart}";
-
-      // QUI puoi sostituire con la stessa logica usata per Variable/Metadata
-      // ad es. passando seed a un servizio SHA-256 comune.
-      return seed;
+      return $"{id}|{name.Trim()}|{idsPart}";
     }
 
     protected override IEnumerable<object> GetEqualityComponents()

--- a/src/ProgesiGrasshopperAssembly/Components/ProgesiMetadataOutComponent.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/ProgesiMetadataOutComponent.cs
@@ -97,15 +97,15 @@ namespace ProgesiGrasshopperAssembly.Components
           bool ok = MetadataRepositoryCompatExtensions.TryGetByHashThenId(repo, hash, id, out obj, out info);
 
           int outId = 0;
-          string sum = "", by = "-", desc = "", lm = "";
+          string digest = "", summary = "", by = "-", desc = "", lm = "";
           string[] refs = Array.Empty<string>();
           string[] snips = Array.Empty<string>();
 
           if (ok && obj != null)
           {
             ReadIf(obj, "Id", ref outId);
-            ReadIf(obj, "Hash", ref sum);
-            ReadIf(obj, "Summary", ref sum);
+            ReadIf(obj, "Hash", ref digest);
+            ReadIf(obj, "Summary", ref summary);
             ReadIf(obj, "By", ref by, "-");
             ReadIf(obj, "Description", ref desc, "");
             ReadIf(obj, "LastModified", ref lm, "");
@@ -115,7 +115,7 @@ namespace ProgesiGrasshopperAssembly.Components
 
           var path = p;
           tId.Append(new GH_Integer(outId), path);
-          tHash.Append(new GH_String(sum ?? ""), path);
+          tHash.Append(new GH_String(!string.IsNullOrWhiteSpace(digest) ? digest : (summary ?? "")), path);
           tBy.Append(new GH_String(string.IsNullOrWhiteSpace(by) ? "-" : by), path);
           tDesc.Append(new GH_String(desc ?? ""), path);
           tLM.Append(new GH_String(lm ?? ""), path);
@@ -133,7 +133,7 @@ namespace ProgesiGrasshopperAssembly.Components
             tSnip.Append(new GH_String(""), sub);
 
           var pref = ok ? "OK" : (string.IsNullOrWhiteSpace(info) ? "Errore" : info);
-          tInfo.Append(new GH_String(string.IsNullOrWhiteSpace(sum) ? pref : (pref + " | " + sum)), path);
+          tInfo.Append(new GH_String(string.IsNullOrWhiteSpace(summary) ? pref : (pref + " | " + summary)), path);
         }
       }
 

--- a/src/ProgesiGrasshopperAssembly/Components/ProgesiVariableOutComponent.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/ProgesiVariableOutComponent.cs
@@ -120,6 +120,7 @@ namespace ProgesiGrasshopperAssembly.Components
           int outId = 0, mid = 0;
           bool ass = false;
           int[] deps = Array.Empty<int>();
+          string digest = "";
           string summary = "";
 
           if (ok && obj != null)
@@ -134,6 +135,7 @@ namespace ProgesiGrasshopperAssembly.Components
             ReadIf(obj, "MetaId", ref mid);
             ass = ReadBool(obj, "IsAssumption");
             deps = ReadDepends(obj);
+            ReadIf(obj, "Hash", ref digest);
             ReadIf(obj, "Summary", ref summary);
           }
 
@@ -152,7 +154,7 @@ namespace ProgesiGrasshopperAssembly.Components
           else
             tVal.Append(new GH_String(value ?? ""), path);
           tId.Append(new GH_Integer(outId), path);
-          tHash.Append(new GH_String(summary), path);
+          tHash.Append(new GH_String(!string.IsNullOrWhiteSpace(digest) ? digest : summary), path);
           tName.Append(new GH_String(name ?? ""), path);
           tValue.Append(new GH_String(value ?? ""), path);
           tValC.Append(new GH_String(valc ?? ""), path);

--- a/src/ProgesiGrasshopperAssembly/Infrastructure/MetadataRepositoryCompatExtensions.cs
+++ b/src/ProgesiGrasshopperAssembly/Infrastructure/MetadataRepositoryCompatExtensions.cs
@@ -97,7 +97,7 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
 
     private static int[] ReadMetadataIds(object payload, StringTable table, out string error)
     {
-      error = string.Empty;
+      error = null;
       var fromPayload = ReadMetadataIdsArray(payload);
       if (fromPayload != null)
         return fromPayload;
@@ -521,7 +521,7 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
         }
 
         // resolve metadata ids from payload / mid string (numeric, comma-list, or single hash)
-        if (metaResolveError != null)
+        if (!string.IsNullOrEmpty(metaResolveError))
         {
           info = metaResolveError;
           return false;

--- a/src/ProgesiGrasshopperAssembly/Infrastructure/MetadataRepositoryCompatExtensions.cs
+++ b/src/ProgesiGrasshopperAssembly/Infrastructure/MetadataRepositoryCompatExtensions.cs
@@ -261,22 +261,29 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
       {
         var doc = rh.Doc;
         var table = doc.Strings;
+        var metaRepo = new RhinoMetadataRepository(doc);
 
-        int rid = id;
-
-        // priorità HASH: prima summary umano (ID:), poi digest content
-        if (rid <= 0) { var tryId = ExtractIdFromSummary(hash); if (tryId > 0) rid = tryId; }
-        if (rid <= 0)
+        int rid = 0;
+        ProgesiMetadata? found = null;
+        var digest = ExtractDigest(hash);
+        if (!string.IsNullOrWhiteSpace(digest))
         {
-          var digest = ExtractDigest(hash);
-          if (!string.IsNullOrWhiteSpace(digest))
+          found = metaRepo.GetByHashtagAsync(digest).GetAwaiter().GetResult();
+          if (found != null) rid = found.Id;
+        }
+
+        if (rid <= 0) { var tryId = ExtractIdFromSummary(hash); if (tryId > 0) rid = tryId; }
+        if (rid <= 0 && !string.IsNullOrWhiteSpace(digest))
+        {
+          if (!TryResolveIdByHash(table, "Progesi.MetaHashtag", digest, out rid))
             TryResolveIdByHash(table, "Progesi.MetaContentHash", digest, out rid);
         }
 
+        if (rid <= 0 && id > 0) rid = id;
+
         if (rid <= 0) { info = "Input non valido (hash/id)."; return false; }
 
-        var repo = new RhinoMetadataRepository(doc);
-        var m = repo.GetAsync(rid).GetAwaiter().GetResult();
+        var m = found ?? metaRepo.GetAsync(rid).GetAwaiter().GetResult();
         if (m == null) { info = "Non trovato (rhino)"; return false; }
 
         var by = m.CreatedBy ?? "";
@@ -289,7 +296,7 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
         metadata = new
         {
           Id = m.Id,
-          Hash = summary,                 // summary umano
+          Hash = m.Hashtag,
           Summary = summary,
           LastModified = m.LastModified.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
           By = string.IsNullOrWhiteSpace(by) ? "-" : by,
@@ -333,7 +340,7 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
 
         var repo = new RhinoMetadataRepository(doc);
 
-        // se update: togli vecchio content-hash se BY/INFO cambiano
+        // se update: togli vecchi indici se BY/INFO o contenuto cambiano
         var current = repo.GetAsync(id).GetAwaiter().GetResult();
         if (current != null)
         {
@@ -341,6 +348,7 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
           var prevHash = Sha256Hex(prevSig);
           if (!string.Equals(prevHash, contentHash, StringComparison.Ordinal))
             UnindexHash(table, "Progesi.MetaContentHash", prevHash);
+          UnindexHash(table, "Progesi.MetaHashtag", ProgesiHash.Compute(current));
         }
 
         // costruisci metadata e **salva i Ref normalizzati**
@@ -356,11 +364,12 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
         }
         repo.UpsertAsync(meta).GetAwaiter().GetResult();
 
-        // indicizza BY+INFO
+        // indicizza BY+INFO (legacy dedupe) e domain hashtag
         IndexHash(table, "Progesi.MetaContentHash", contentHash, id);
+        IndexHash(table, "Progesi.MetaHashtag", ProgesiHash.Compute(meta), id);
 
         var summary = $"ID:{id} | BY:{(string.IsNullOrEmpty(byN) ? "-" : byN)} | DESC:{descrN}";
-        persisted = new { Id = id, Hash = summary, Summary = summary };
+        persisted = new { Id = id, Hash = ProgesiHash.Compute(meta), Summary = summary };
         return true;
       }
 
@@ -384,6 +393,7 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
           var prevSig = $"BY={ToNorm(current.CreatedBy ?? "")}|INFO={(current.AdditionalInfo ?? "").Trim()}";
           var prevHash = Sha256Hex(prevSig);
           UnindexHash(table, "Progesi.MetaContentHash", prevHash);
+          UnindexHash(table, "Progesi.MetaHashtag", ProgesiHash.Compute(current));
         }
 
         var ok = repo.DeleteAsync(id).GetAwaiter().GetResult();
@@ -411,29 +421,34 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
       {
         var doc = rh.Doc;
         var table = doc.Strings;
+        var varRepo = new RhinoVariableRepository(doc);
 
-        // 1) priorità HASH (summary umano con ID:..., poi digest strict/content)
         int rid = 0;
-        var tryId = ExtractIdFromSummary(hash);
-        if (tryId > 0) rid = tryId;
+        ProgesiVariable? found = null;
+        var digest = ExtractDigest(hash);
+        if (!string.IsNullOrWhiteSpace(digest))
+        {
+          found = varRepo.GetByHashtagAsync(digest).GetAwaiter().GetResult();
+          if (found != null) rid = found.Id;
+        }
 
         if (rid <= 0)
         {
-          var digest = ExtractDigest(hash);
-          if (!string.IsNullOrWhiteSpace(digest))
-          {
-            if (!TryResolveIdByHash(table, "Progesi.VarStrictHash", digest, out rid))
-              TryResolveIdByHash(table, "Progesi.VarHash", digest, out rid);
-          }
+          var tryId = ExtractIdFromSummary(hash);
+          if (tryId > 0) rid = tryId;
         }
 
-        // 2) fallback all'Id input
+        if (rid <= 0 && !string.IsNullOrWhiteSpace(digest))
+        {
+          if (!TryResolveIdByHash(table, "Progesi.VarStrictHash", digest, out rid))
+            TryResolveIdByHash(table, "Progesi.VarHash", digest, out rid);
+        }
+
         if (rid <= 0 && id > 0) rid = id;
 
         if (rid <= 0) { info = "Input non valido (hash/id)."; return false; }
 
-        var repo = new RhinoVariableRepository(doc);
-        var v = repo.GetByIdAsync(rid).GetAwaiter().GetResult();
+        var v = found ?? varRepo.GetByIdAsync(rid).GetAwaiter().GetResult();
         if (v == null) { info = "Non trovato (rhino)"; return false; }
 
         var name = v.Name ?? "";
@@ -451,7 +466,7 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
         variable = new
         {
           Id = v.Id,
-          Hash = ProgesiHash.Compute(v),     // content-hash interno
+          Hash = v.Hashtag,
           Name = name,
           Value = value,
           TypedValue = v.Value,
@@ -633,12 +648,12 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
         persisted = new
         {
           Id = id,
-          Hash = summary,                 // per la porta Hash (umano)
+          Hash = newContent,
           MetaId = metadataIds.Length > 0 ? metadataIds[0] : 0,
           Depends = depN,
           IsAssumption = isAss,
           ValueCanonical = valc,
-          Summary = summary              // per la porta Info
+          Summary = summary
         };
         return true;
       }

--- a/src/ProgesiGrasshopperAssembly/Infrastructure/ServiceHubCore.cs
+++ b/src/ProgesiGrasshopperAssembly/Infrastructure/ServiceHubCore.cs
@@ -48,6 +48,20 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
         return Task.FromResult<ProgesiMetadata?>(null);
       }
 
+      public Task<ProgesiMetadata?> GetByHashtagAsync(string hashtag, CancellationToken ct)
+      {
+        if (string.IsNullOrWhiteSpace(hashtag))
+          return Task.FromResult<ProgesiMetadata?>(null);
+
+        for (int i = 0; i < _items.Count; i++)
+        {
+          if (string.Equals(_items[i].Hashtag, hashtag, StringComparison.Ordinal))
+            return Task.FromResult<ProgesiMetadata?>(_items[i]);
+        }
+
+        return Task.FromResult<ProgesiMetadata?>(null);
+      }
+
       public Task UpsertAsync(ProgesiMetadata m, CancellationToken ct)
       {
         if (m == null) return Task.CompletedTask;

--- a/src/ProgesiRepositories.InMemory/InMemoryVariableClusterRepository.cs
+++ b/src/ProgesiRepositories.InMemory/InMemoryVariableClusterRepository.cs
@@ -53,9 +53,22 @@ namespace ProgesiRepositories.InMemory
         return Task.FromResult<ProgesiVariableCluster?>(null);
 
       var match = _store.Values
-        .FirstOrDefault(c => string.Equals(c.Hashtag, hashtag, StringComparison.Ordinal));
+        .FirstOrDefault(c => ClusterHashtagMatches(c, hashtag));
 
       return Task.FromResult<ProgesiVariableCluster?>(match);
+    }
+
+    private static bool ClusterHashtagMatches(ProgesiVariableCluster cluster, string hashtag)
+    {
+      if (string.Equals(cluster.Hashtag, hashtag, StringComparison.Ordinal))
+        return true;
+
+      var legacy = ProgesiVariableCluster.BuildLegacyHashtag(
+        cluster.Id,
+        cluster.Name,
+        cluster.ProgesiVariableIds);
+
+      return string.Equals(legacy, hashtag, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/src/ProgesiRepositories.InMemory/InMemoryVariableRepository.cs
+++ b/src/ProgesiRepositories.InMemory/InMemoryVariableRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -21,6 +22,17 @@ namespace ProgesiRepositories.InMemory
     {
       _ = _store.TryGetValue(id, out ProgesiVariable v);
       return Task.FromResult(v);
+    }
+
+    public Task<ProgesiVariable?> GetByHashtagAsync(string hashtag, CancellationToken ct = default)
+    {
+      if (string.IsNullOrWhiteSpace(hashtag))
+        return Task.FromResult<ProgesiVariable?>(null);
+
+      var match = _store.Values.FirstOrDefault(v =>
+        string.Equals(v.Hashtag, hashtag, StringComparison.Ordinal));
+
+      return Task.FromResult<ProgesiVariable?>(match);
     }
 
     public Task<IReadOnlyList<ProgesiVariable>> GetAllAsync(CancellationToken ct = default)

--- a/src/ProgesiRepositories.Rhino/RhinoMetadataRepository.cs
+++ b/src/ProgesiRepositories.Rhino/RhinoMetadataRepository.cs
@@ -13,6 +13,9 @@ namespace ProgesiRepositories.Rhino
 {
   public sealed class RhinoMetadataRepository : IMetadataRepository
   {
+    private const string MetaSection = "Progesi.Meta";
+    private const string MetaHashtagIndexSection = "Progesi.MetaHashtag";
+
     private readonly StringTable _table;
     public RhinoMetadataRepository(RhinoDoc doc)
     {
@@ -24,7 +27,7 @@ namespace ProgesiRepositories.Rhino
     {
       var key = KeyOf(id);
       // FIX: GetValue (non GetString)
-      var json = _table.GetValue("Progesi.Meta", key);
+      var json = _table.GetValue(MetaSection, key);
       if (string.IsNullOrWhiteSpace(json))
         return Task.FromResult<ProgesiMetadata?>(null);
 
@@ -66,9 +69,26 @@ namespace ProgesiRepositories.Rhino
       return Task.FromResult<ProgesiMetadata?>(meta);
     }
 
+    public Task<ProgesiMetadata?> GetByHashtagAsync(string hashtag, CancellationToken ct = default)
+    {
+      if (string.IsNullOrWhiteSpace(hashtag))
+        return Task.FromResult<ProgesiMetadata?>(null);
+
+      var idStr = _table.GetValue(MetaHashtagIndexSection, hashtag);
+      if (!int.TryParse(idStr, out var id) || id <= 0)
+        return Task.FromResult<ProgesiMetadata?>(null);
+
+      return GetAsync(id, ct);
+    }
+
     public Task UpsertAsync(ProgesiMetadata meta, CancellationToken ct = default)
     {
+      var hashtag = ProgesiHash.Compute(meta);
       var key = KeyOf(meta.Id);
+
+      var current = GetAsync(meta.Id, ct).GetAwaiter().GetResult();
+      if (current != null)
+        UnindexHashtag(current.Hashtag);
 
       var dto = new Dto
       {
@@ -83,18 +103,24 @@ namespace ProgesiRepositories.Rhino
           Caption = s.Caption ?? string.Empty,
           Source = s.Source?.ToString(),
           Content = s.Content ?? Array.Empty<byte>()
-        })
+        }),
+        Hashtag = hashtag
       };
 
       var json = JsonConvert.SerializeObject(dto) ?? string.Empty;
-      _table.SetString("Progesi.Meta", key, json); // ? niente var = ...
+      _table.SetString(MetaSection, key, json);
+      IndexHashtag(hashtag, meta.Id);
       return Task.CompletedTask;
     }
 
     public Task<bool> DeleteAsync(int id, CancellationToken ct = default)
     {
+      var current = GetAsync(id, ct).GetAwaiter().GetResult();
+      if (current != null)
+        UnindexHashtag(current.Hashtag);
+
       var key = KeyOf(id);
-      _table.Delete("Progesi.Meta", key);
+      _table.Delete(MetaSection, key);
       return Task.FromResult(true);
     }
 
@@ -106,6 +132,18 @@ namespace ProgesiRepositories.Rhino
 
     private static string KeyOf(int id) => $"meta:{id}";
 
+    private void IndexHashtag(string hashtag, int id)
+    {
+      if (string.IsNullOrWhiteSpace(hashtag) || id <= 0) return;
+      _table.SetString(MetaHashtagIndexSection, hashtag, id.ToString(System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    private void UnindexHashtag(string hashtag)
+    {
+      if (string.IsNullOrWhiteSpace(hashtag)) return;
+      _table.Delete(MetaHashtagIndexSection, hashtag);
+    }
+
     private sealed class Dto
     {
       public int Id { get; set; }
@@ -114,6 +152,7 @@ namespace ProgesiRepositories.Rhino
       public string? AdditionalInfo { get; set; }
       public string[]? References { get; set; }
       public SnipDto[]? Snips { get; set; }
+      public string? Hashtag { get; set; }
     }
 
     private sealed class SnipDto

--- a/src/ProgesiRepositories.Rhino/RhinoVariableClusterRepository.cs
+++ b/src/ProgesiRepositories.Rhino/RhinoVariableClusterRepository.cs
@@ -88,10 +88,22 @@ namespace ProgesiRepositories.Rhino
         return null;
 
       var all = await GetAllAsync(ct).ConfigureAwait(false);
-      var match = all.FirstOrDefault(c =>
-        string.Equals(c.Hashtag, hashtag, StringComparison.Ordinal));
+      var match = all.FirstOrDefault(c => ClusterHashtagMatches(c, hashtag));
 
       return match;
+    }
+
+    private static bool ClusterHashtagMatches(ProgesiVariableCluster cluster, string hashtag)
+    {
+      if (string.Equals(cluster.Hashtag, hashtag, StringComparison.Ordinal))
+        return true;
+
+      var legacy = ProgesiVariableCluster.BuildLegacyHashtag(
+        cluster.Id,
+        cluster.Name,
+        cluster.ProgesiVariableIds);
+
+      return string.Equals(legacy, hashtag, StringComparison.Ordinal);
     }
 
     public Task<IReadOnlyList<ProgesiVariableCluster>> GetAllAsync(

--- a/src/ProgesiRepositories.Rhino/RhinoVariableRepository.cs
+++ b/src/ProgesiRepositories.Rhino/RhinoVariableRepository.cs
@@ -14,6 +14,9 @@ namespace ProgesiRepositories.Rhino
 {
   public sealed class RhinoVariableRepository : IVariableRepository
   {
+    private const string VarSection = "Progesi.Var";
+    private const string VarHashtagIndexSection = "Progesi.VarHash";
+
     private readonly StringTable _table;
 
     public RhinoVariableRepository(RhinoDoc doc)
@@ -24,7 +27,13 @@ namespace ProgesiRepositories.Rhino
 
     public Task<ProgesiVariable> SaveAsync(ProgesiVariable variable, CancellationToken ct = default)
     {
+      var hashtag = ProgesiHash.Compute(variable);
       var key = KeyOf(variable.Id);
+
+      var current = GetByIdAsync(variable.Id, ct).GetAwaiter().GetResult();
+      if (current != null)
+        UnindexHashtag(current.Hashtag);
+
       var payload = new
       {
         variable.Id,
@@ -34,10 +43,12 @@ namespace ProgesiRepositories.Rhino
         variable.MetadataId,
         MetadataIds = variable.MetadataIds ?? Array.Empty<int>(),
         Depends = variable.DependsFrom ?? Array.Empty<int>(),
-        variable.IsAssumption
+        variable.IsAssumption,
+        Hashtag = hashtag
       };
       var json = JsonConvert.SerializeObject(payload) ?? string.Empty;
-      _table.SetString("Progesi.Var", key, json);
+      _table.SetString(VarSection, key, json);
+      IndexHashtag(hashtag, variable.Id);
       return Task.FromResult(variable);
     }
 
@@ -45,7 +56,7 @@ namespace ProgesiRepositories.Rhino
     public Task<ProgesiVariable> GetByIdAsync(int id, CancellationToken ct = default)
     {
       var key = KeyOf(id);
-      var json = _table.GetValue("Progesi.Var", key);
+      var json = _table.GetValue(VarSection, key);
       if (string.IsNullOrWhiteSpace(json)) return Task.FromResult<ProgesiVariable>(null);
 
       var dto = JsonConvert.DeserializeObject<Dto>(json);
@@ -58,6 +69,18 @@ namespace ProgesiRepositories.Rhino
 
       return Task.FromResult(new ProgesiVariable(dto.Id, dto.Name ?? string.Empty, value, depends, metadataIds, isAss));
     }
+
+    public async Task<ProgesiVariable?> GetByHashtagAsync(string hashtag, CancellationToken ct = default)
+    {
+      if (string.IsNullOrWhiteSpace(hashtag))
+        return null;
+
+      var idStr = _table.GetValue(VarHashtagIndexSection, hashtag);
+      if (!int.TryParse(idStr, out var id) || id <= 0)
+        return null;
+
+      return await GetByIdAsync(id, ct);
+    }
 #nullable enable
 
     public async Task<IReadOnlyList<ProgesiVariable>> GetAllAsync(CancellationToken ct = default)
@@ -69,8 +92,12 @@ namespace ProgesiRepositories.Rhino
 
     public Task<bool> DeleteAsync(int id, CancellationToken ct = default)
     {
+      var current = GetByIdAsync(id, ct).GetAwaiter().GetResult();
+      if (current != null)
+        UnindexHashtag(current.Hashtag);
+
       var key = KeyOf(id);
-      _table.Delete("Progesi.Var", key);
+      _table.Delete(VarSection, key);
       return Task.FromResult(true);
     }
 
@@ -87,6 +114,18 @@ namespace ProgesiRepositories.Rhino
 
     private static string KeyOf(int id) => $"var:{id}";
 
+    private void IndexHashtag(string hashtag, int id)
+    {
+      if (string.IsNullOrWhiteSpace(hashtag) || id <= 0) return;
+      _table.SetString(VarHashtagIndexSection, hashtag, id.ToString(System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    private void UnindexHashtag(string hashtag)
+    {
+      if (string.IsNullOrWhiteSpace(hashtag)) return;
+      _table.Delete(VarHashtagIndexSection, hashtag);
+    }
+
     private sealed class Dto
     {
       public int Id { get; set; }
@@ -97,6 +136,7 @@ namespace ProgesiRepositories.Rhino
       public int[]? MetadataIds { get; set; }
       public int[]? Depends { get; set; }
       public bool? IsAssumption { get; set; }
+      public string? Hashtag { get; set; }
     }
 
     private static int[] ReadMetadataIds(int[]? metadataIds, int? metadataId)

--- a/src/ProgesiRepositories.Sqlite/SqliteMetadataRepository.cs
+++ b/src/ProgesiRepositories.Sqlite/SqliteMetadataRepository.cs
@@ -59,6 +59,12 @@ CREATE TABLE IF NOT EXISTS Metadata (
       }
 
       EnsureSchemaInfoAndCleanup(conn, "Metadata");
+
+      using (var idx = conn.CreateCommand())
+      {
+        idx.CommandText = "CREATE INDEX IF NOT EXISTS IX_Metadata_ContentHash ON Metadata(ContentHash);";
+        idx.ExecuteNonQuery();
+      }
     }
 
     // ========================= CRUD =========================
@@ -100,6 +106,25 @@ CREATE TABLE IF NOT EXISTS Metadata (
               );
 
         return meta;
+      }, ct: ct);
+    }
+
+    public async Task<ProgesiMetadata?> GetByHashtagAsync(string hashtag, CancellationToken ct = default)
+    {
+      if (string.IsNullOrWhiteSpace(hashtag))
+        return null;
+
+      return await WithRetryAsync(async () =>
+      {
+        using var conn = OpenConnection();
+        var id = await GetIdByHashAsync(conn, hashtag, ct);
+        if (id <= 0)
+        {
+          _log.Debug("[SQLite] Metadata get by hashtag: miss.");
+          return null;
+        }
+
+        return await GetAsync(id, ct);
       }, ct: ct);
     }
 

--- a/src/ProgesiRepositories.Sqlite/SqliteVariableRepository.cs
+++ b/src/ProgesiRepositories.Sqlite/SqliteVariableRepository.cs
@@ -69,6 +69,12 @@ CREATE TABLE IF NOT EXISTS Variables (
         }
       }
       EnsureContentHash(conn, "Variables");
+
+      using (var idx = conn.CreateCommand())
+      {
+        idx.CommandText = "CREATE INDEX IF NOT EXISTS IX_Variables_ContentHash ON Variables(ContentHash);";
+        idx.ExecuteNonQuery();
+      }
     }
 
     public Task<ProgesiVariable> SaveAsync(ProgesiVariable variable, CancellationToken ct = default)
@@ -140,6 +146,32 @@ ON CONFLICT(Id) DO UPDATE SET
         var back = await GetByIdAsync(v.Id, ct);
 #nullable enable
         return back;
+      }, ct: ct);
+    }
+
+    public async Task<ProgesiVariable?> GetByHashtagAsync(string hashtag, CancellationToken ct = default)
+    {
+      if (string.IsNullOrWhiteSpace(hashtag))
+        return null;
+
+      return await WithRetryAsync(async () =>
+      {
+        using var conn = OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT Id FROM Variables WHERE ContentHash=$h LIMIT 1;";
+        cmd.Parameters.AddWithValue("$h", hashtag);
+
+        var scalar = await cmd.ExecuteScalarAsync(ct);
+        if (scalar is null || scalar is DBNull)
+        {
+          _log.Debug($"[SQLite] Variable get by hashtag: miss.");
+          return null;
+        }
+
+        var id = Convert.ToInt32(scalar);
+#nullable disable
+        return await GetByIdAsync(id, ct);
+#nullable enable
       }, ct: ct);
     }
 

--- a/tests/Progesi.GhExcelReadContract.Tests/GhExcelClusterImportTests.cs
+++ b/tests/Progesi.GhExcelReadContract.Tests/GhExcelClusterImportTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using ClosedXML.Excel;
 using FluentAssertions;
+using ProgesiCore;
 using Xunit;
 
 namespace Progesi.GhExcelReadContract.Tests
@@ -57,7 +58,9 @@ namespace Progesi.GhExcelReadContract.Tests
       var ok = GhExcelClusterImport.TryBuildRowDto(ws, 2, columns, out var dto, out var error);
 
       ok.Should().BeTrue();
-      dto.Hashtag.Should().Be("7|SpanSet|3,4");
+      var expected = ProgesiVariableCluster.Rehydrate(7, "SpanSet", new[] { 3, 4 }, "Notes");
+      dto.Hashtag.Should().Be(expected.Hashtag);
+      dto.Hashtag.Should().Be(ProgesiHash.Compute(expected));
     }
 
     [Fact]

--- a/tests/Progesi.GhExcelReadContract.Tests/Progesi.GhExcelReadContract.Tests.csproj
+++ b/tests/Progesi.GhExcelReadContract.Tests/Progesi.GhExcelReadContract.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Progesi.GhExcelReadContract\Progesi.GhExcelReadContract.csproj" />
+    <ProjectReference Include="..\..\src\ProgesiCore\ProgesiCore.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Progesi.Infrastructure.EF.Tests/EfMetadataRepositoryTests.cs
+++ b/tests/Progesi.Infrastructure.EF.Tests/EfMetadataRepositoryTests.cs
@@ -110,6 +110,25 @@ public sealed class EfMetadataRepositoryTests : IDisposable
     (await _repo.ListAsync()).Should().HaveCount(1);
   }
 
+  [Fact]
+  public async Task GetByHashtagAsync_After_Upsert_Returns_Same_Metadata()
+  {
+    var original = ProgesiMetadata.Create("tagged", "info", id: 6);
+    await _repo.UpsertAsync(original);
+
+    var loaded = await _repo.GetByHashtagAsync(original.Hashtag);
+
+    loaded.Should().NotBeNull();
+    loaded!.Id.Should().Be(6);
+    loaded.Hashtag.Should().Be(original.Hashtag);
+  }
+
+  [Fact]
+  public async Task GetByHashtagAsync_Miss_Returns_Null()
+  {
+    (await _repo.GetByHashtagAsync("missing")).Should().BeNull();
+  }
+
   public void Dispose()
   {
     var path = _connectionString.Replace("Data Source=", string.Empty);

--- a/tests/Progesi.Infrastructure.EF.Tests/EfVariableRepositoryTests.cs
+++ b/tests/Progesi.Infrastructure.EF.Tests/EfVariableRepositoryTests.cs
@@ -187,6 +187,25 @@ public sealed class EfVariableRepositoryTests : IDisposable
     removed.Should().Be(0);
   }
 
+  [Fact]
+  public async Task GetByHashtagAsync_After_Save_Returns_Same_Variable()
+  {
+    var original = new ProgesiVariable(15, "Tagged", 99, metadataIds: new[] { 2 });
+    await _repo.SaveAsync(original);
+
+    var loaded = await _repo.GetByHashtagAsync(original.Hashtag);
+
+    loaded.Should().NotBeNull();
+    loaded!.Id.Should().Be(15);
+    loaded.Hashtag.Should().Be(original.Hashtag);
+  }
+
+  [Fact]
+  public async Task GetByHashtagAsync_Miss_Returns_Null()
+  {
+    (await _repo.GetByHashtagAsync("deadbeef")).Should().BeNull();
+  }
+
   public void Dispose()
   {
     var path = _connectionString.Replace("Data Source=", string.Empty);

--- a/tests/Progesi.Repositories.Conformance.Tests/MetadataRepositoryGetByHashtagConformanceTests.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/MetadataRepositoryGetByHashtagConformanceTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using ProgesiCore;
+using ProgesiRepositories.Sqlite;
+using Xunit;
+
+namespace Progesi.Repositories.Conformance.Tests
+{
+  public class MetadataRepositoryGetByHashtagConformanceTests
+  {
+    [Fact]
+    public async Task Sqlite_GetByHashtagAsync_After_Upsert_Returns_Same_Metadata()
+    {
+      var dbPath = Path.Combine(Path.GetTempPath(), "progesi-meta-hashtag-" + Guid.NewGuid().ToString("N") + ".db");
+      try
+      {
+        var repo = new SqliteMetadataRepository(dbPath, resetSchema: true);
+        var original = ProgesiMetadata.Create("usr", "payload", id: 4);
+
+        await repo.UpsertAsync(original);
+        var loaded = await repo.GetByHashtagAsync(original.Hashtag);
+
+        loaded.Should().NotBeNull();
+        loaded!.Id.Should().Be(4);
+        loaded.Hashtag.Should().Be(original.Hashtag);
+      }
+      finally
+      {
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(dbPath)) File.Delete(dbPath);
+      }
+    }
+
+    [Fact]
+    public async Task Sqlite_GetByHashtagAsync_Miss_Returns_Null()
+    {
+      var dbPath = Path.Combine(Path.GetTempPath(), "progesi-meta-hashtag-" + Guid.NewGuid().ToString("N") + ".db");
+      try
+      {
+        var repo = new SqliteMetadataRepository(dbPath, resetSchema: true);
+        (await repo.GetByHashtagAsync("missing")).Should().BeNull();
+      }
+      finally
+      {
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(dbPath)) File.Delete(dbPath);
+      }
+    }
+
+    private sealed class InMemoryMetadataRepository : IMetadataRepository
+    {
+      private readonly List<ProgesiMetadata> _items = new List<ProgesiMetadata>();
+
+      public Task<ProgesiMetadata?> GetAsync(int id, System.Threading.CancellationToken ct = default)
+      {
+        foreach (var item in _items)
+          if (item.Id == id) return Task.FromResult<ProgesiMetadata?>(item);
+        return Task.FromResult<ProgesiMetadata?>(null);
+      }
+
+      public Task<ProgesiMetadata?> GetByHashtagAsync(string hashtag, System.Threading.CancellationToken ct = default)
+      {
+        if (string.IsNullOrWhiteSpace(hashtag))
+          return Task.FromResult<ProgesiMetadata?>(null);
+
+        foreach (var item in _items)
+          if (string.Equals(item.Hashtag, hashtag, StringComparison.Ordinal))
+            return Task.FromResult<ProgesiMetadata?>(item);
+
+        return Task.FromResult<ProgesiMetadata?>(null);
+      }
+
+      public Task UpsertAsync(ProgesiMetadata metadata, System.Threading.CancellationToken ct = default)
+      {
+        for (int i = 0; i < _items.Count; i++)
+        {
+          if (_items[i].Id == metadata.Id)
+          {
+            _items[i] = metadata;
+            return Task.CompletedTask;
+          }
+        }
+        _items.Add(metadata);
+        return Task.CompletedTask;
+      }
+
+      public Task<bool> DeleteAsync(int id, System.Threading.CancellationToken ct = default)
+      {
+        for (int i = 0; i < _items.Count; i++)
+        {
+          if (_items[i].Id == id)
+          {
+            _items.RemoveAt(i);
+            return Task.FromResult(true);
+          }
+        }
+        return Task.FromResult(false);
+      }
+
+      public Task<IReadOnlyList<ProgesiMetadata>> ListAsync(int skip = 0, int take = 100, System.Threading.CancellationToken ct = default)
+        => Task.FromResult((IReadOnlyList<ProgesiMetadata>)_items.ToArray());
+    }
+
+    [Fact]
+    public async Task InMemory_GetByHashtagAsync_After_Upsert_Returns_Same_Metadata()
+    {
+      var repo = new InMemoryMetadataRepository();
+      var original = ProgesiMetadata.Create("me", "info", id: 2);
+
+      await repo.UpsertAsync(original);
+      var loaded = await repo.GetByHashtagAsync(original.Hashtag);
+
+      loaded.Should().NotBeNull();
+      loaded!.CreatedBy.Should().Be("me");
+    }
+  }
+}

--- a/tests/Progesi.Repositories.Conformance.Tests/VariableRepositoryConformanceTests.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/VariableRepositoryConformanceTests.cs
@@ -186,5 +186,41 @@ namespace Progesi.Repositories.Conformance.Tests
       saved.Should().NotBeNull();
       saved.Id.Should().Be(20);
     }
+
+    [Theory]
+    [MemberData(nameof(VariableRepositoryConformanceStoreProvider.StoreFactories), MemberType = typeof(VariableRepositoryConformanceStoreProvider))]
+    public async Task GetByHashtagAsync_After_Save_Returns_Same_Variable(string storeName, System.Func<IVariableRepositoryConformanceStore> createStore)
+    {
+      using var store = createStore();
+      var original = new ProgesiVariable(15, "Tagged", 99, metadataIds: new[] { 2 });
+
+      await store.Repository.SaveAsync(original);
+      var loaded = await store.Repository.GetByHashtagAsync(original.Hashtag);
+
+      loaded.Should().NotBeNull();
+      loaded!.Id.Should().Be(15);
+      loaded.Name.Should().Be("Tagged");
+      ProgesiHash.Compute(loaded).Should().Be(original.Hashtag);
+    }
+
+    [Theory]
+    [MemberData(nameof(VariableRepositoryConformanceStoreProvider.StoreFactories), MemberType = typeof(VariableRepositoryConformanceStoreProvider))]
+    public async Task GetByHashtagAsync_Miss_Returns_Null(string storeName, System.Func<IVariableRepositoryConformanceStore> createStore)
+    {
+      using var store = createStore();
+      var loaded = await store.Repository.GetByHashtagAsync("deadbeef");
+
+      loaded.Should().BeNull();
+    }
+
+    [Theory]
+    [MemberData(nameof(VariableRepositoryConformanceStoreProvider.StoreFactories), MemberType = typeof(VariableRepositoryConformanceStoreProvider))]
+    public async Task GetByHashtagAsync_Empty_Hashtag_Returns_Null(string storeName, System.Func<IVariableRepositoryConformanceStore> createStore)
+    {
+      using var store = createStore();
+      var loaded = await store.Repository.GetByHashtagAsync("");
+
+      loaded.Should().BeNull();
+    }
   }
 }

--- a/tests/ProgesiCore.Tests/ProgesiHashtagIdentityTests.cs
+++ b/tests/ProgesiCore.Tests/ProgesiHashtagIdentityTests.cs
@@ -1,0 +1,71 @@
+using System;
+using FluentAssertions;
+using ProgesiCore;
+using ProgesiRepositories.InMemory;
+using Xunit;
+
+namespace ProgesiCore.Tests
+{
+  public class ProgesiHashtagIdentityTests
+  {
+    [Fact]
+    public void Variable_Hashtag_Equals_ProgesiHash_Compute()
+    {
+      var v = new ProgesiVariable(1, "Load", 42, new[] { 3, 1, 2 }, metadataIds: new[] { 4 });
+      v.Hashtag.Should().Be(ProgesiHash.Compute(v));
+    }
+
+    [Fact]
+    public void Variable_Hashtag_Matches_R2I_Golden_Hashes()
+    {
+      var noMeta = new ProgesiVariable(11, "Load", 42, new[] { 3, 1, 2 });
+      var singleMeta = new ProgesiVariable(11, "Load", 42, new[] { 3, 1, 2 }, metadataIds: new[] { 4 });
+
+      noMeta.Hashtag.Should().Be("1ebd9965c6a742c6077d8ad6767a77f51eb1cf21d6f91ac2915904a758fc6aa7");
+      singleMeta.Hashtag.Should().Be("f0f23acbfe86bd3ae84018d5a4e540045d87b7b6be5b657fdab575e658109fa1");
+    }
+
+    [Fact]
+    public void Metadata_Hashtag_Equals_ProgesiHash_Compute()
+    {
+      var m = ProgesiMetadata.Create("author", "notes", id: 3);
+      m.Hashtag.Should().Be(ProgesiHash.Compute(m));
+    }
+
+    [Fact]
+    public void Snip_Hashtag_Equals_ProgesiHash_Compute()
+    {
+      var snip = ProgesiSnip.Create(new byte[] { 1, 2, 3 }, "image/png", "cap", new Uri("https://example.com/x"));
+      snip.Hashtag.Should().Be(ProgesiHash.Compute(snip));
+    }
+
+    [Fact]
+    public void Cluster_Hashtag_Equals_ProgesiHash_Compute_Not_Legacy_Format()
+    {
+      var cluster = ProgesiVariableCluster.Rehydrate(3, "HashC", new[] { 9 }, null);
+
+      cluster.Hashtag.Should().Be(ProgesiHash.Compute(cluster));
+      cluster.Hashtag.Should().NotBe("3|HashC|9");
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Cluster_GetByHashtagAsync_Resolves_Legacy_Format()
+    {
+      var repo = new InMemoryVariableClusterRepository();
+      var cluster = ProgesiVariableCluster.Rehydrate(3, "HashC", new[] { 9 }, null);
+      await repo.SaveAsync(cluster);
+
+      var legacy = "3|HashC|9";
+      var loaded = await repo.GetByHashtagAsync(legacy);
+
+      loaded.Should().NotBeNull();
+      loaded!.Id.Should().Be(3);
+    }
+
+    [Fact]
+    public void HashtagSchemeVersion_Is_One()
+    {
+      ProgesiHash.HashtagSchemeVersion.Should().Be(1);
+    }
+  }
+}


### PR DESCRIPTION
## R2-J - Deterministic hashtag identity for all core objects

Per ADR-017 (Accepted). One shared, versioned, content-based SHA-256 hashtag across ProgesiVariable / ProgesiMetadata / ProgesiSnip / ProgesiVariableCluster, with hashtag-first (Id-fallback) lookups.

- **Variable/Metadata:** expose the existing content-based SHA-256 (ProgesiHash.Compute) as a `Hashtag` property - **hash values unchanged; R2-I golden hash tests still pass.**
- **Snip:** new content-based Hashtag (no repo; looked up within its parent Metadata).
- **Cluster:** migrated from human-readable `id|name|ids` to `ProgesiHash.Compute(cluster)` (content-only, Id-independent); GetByHashtagAsync keeps a back-compat match for the legacy format.
- **Repositories:** `GetByHashtagAsync` added to IVariableRepository + IMetadataRepository, implemented in InMemory / SQLite / Rhino / EF; SQLite gains ContentHash indexes; EF already had the unique index.
- **Versioning:** `ProgesiHash.HashtagSchemeVersion = 1`.

ProgesiCore stays Rhino-/EF-/Excel-free. AxisVar untouched.

### Verification
- `dotnet build -c Release`: 0 errors. `dotnet test`: all green (>= 259 + new hashtag + GetByHashtagAsync conformance tests), **including the unchanged R2-I golden hash tests**. This script gates on both.
- Post-merge (advisable, non-blocking): GH smoke - VarIn/VarOut/ClusterDef resolve by hashtag.

Backing ADR-017. Do NOT merge until Claude review + human go.

Generated with Claude Code.