### PR TITLE
fix(r2k): enforce ProgesiVariable.Value non-null (Invariant #3)

### DIFF
--- a/src/Progesi.Infrastructure.EF/Repositories/EfVariableRepository.cs
+++ b/src/Progesi.Infrastructure.EF/Repositories/EfVariableRepository.cs
@@ -88,7 +88,7 @@ public sealed class EfVariableRepository : IVariableRepository
     var depends = JsonConvert.DeserializeObject<int[]>(entity.DependsJson) ?? Array.Empty<int>();
     var metadataIds = ReadMetadataIds(entity.MetadataIdsJson, entity.MetadataId);
     var value = ValueSerialization.ParseValue(entity.Value, entity.ValueType);
-    return new ProgesiVariable(entity.Id, entity.Name, value, depends, metadataIds);
+    return new ProgesiVariable(entity.Id, entity.Name, value ?? "", depends, metadataIds);
   }
 
   private static int[] ReadMetadataIds(string? metadataIdsJson, int? metadataId)

--- a/src/ProgesiCore/ProgesiVariable.cs
+++ b/src/ProgesiCore/ProgesiVariable.cs
@@ -9,7 +9,7 @@ namespace ProgesiCore
   {
     public int Id { get; private set; }
     public string Name { get; private set; } = string.Empty;
-    public object? Value { get; private set; }   // può essere null
+    public object Value { get; private set; }   // non-null invariant; empty string allowed
     public int[] DependsFrom { get; private set; } = Array.Empty<int>();
     public int[] MetadataIds { get; private set; } = Array.Empty<int>();
     /// <summary>First linked metadata id, or null when the list is empty (read-only compat).</summary>
@@ -27,10 +27,11 @@ namespace ProgesiCore
     {
       Guard.Against.Negative(id, nameof(id));
       Guard.Against.NullOrWhiteSpace(name, nameof(name));
+      Guard.Against.Null(value, nameof(value));
 
       Id = id;
       Name = name;
-      Value = value; // null ammesso
+      Value = value;
       DependsFrom = (dependsFrom ?? Array.Empty<int>()).ToArray();
       MetadataIds = NormalizeMetadataIds(metadataIds);
       IsAssumption = isAssumption;
@@ -73,8 +74,7 @@ namespace ProgesiCore
     {
       yield return Id;
       yield return Name;
-      // evitare null: convertiamo in string canonicale
-      yield return Value is null ? "<null>" : Value.GetType().FullName!;
+      yield return Value.GetType().FullName!;
       yield return ProgesiHash.CanonicalValue(Value);
       foreach (int d in DependsFrom.OrderBy(x => x))
       {

--- a/src/ProgesiGrasshopperAssembly/Components/ProgesiDataExchangeComponent.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/ProgesiDataExchangeComponent.cs
@@ -1510,7 +1510,7 @@ CREATE TABLE IF NOT EXISTS ClusterVariables (
         }
 
         var metadataIds = ReadVarDtoMetadataIds(dto);
-        var pv = new ProgesiVariable(id, dto.Name ?? "", typed, deps, metadataIds, ass);
+        var pv = new ProgesiVariable(id, dto.Name ?? "", typed ?? "", deps, metadataIds, ass);
         string hash = ProgesiHash.Compute(pv);
 
         list.Add(new VarRow

--- a/src/ProgesiGrasshopperAssembly/Components/RhinoBridgeBootstrap.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/RhinoBridgeBootstrap.cs
@@ -122,7 +122,7 @@ namespace Progesi.GrasshopperAssembly.Components
         }
         if (id <= 0) id = NextVariableId(repo);
 
-        var variable = new ProgesiVariable(id, d.Name ?? string.Empty, d.Value, Array.Empty<int>(), null);
+        var variable = new ProgesiVariable(id, d.Name ?? string.Empty, d.Value ?? "", Array.Empty<int>(), null);
         var _ = repo.SaveAsync(variable).GetAwaiter().GetResult();
         if (current == null) ins++; else upd++;
       }

--- a/src/ProgesiGrasshopperAssembly/Infrastructure/MetadataRepositoryCompatExtensions.cs
+++ b/src/ProgesiGrasshopperAssembly/Infrastructure/MetadataRepositoryCompatExtensions.cs
@@ -604,7 +604,7 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
 
         // dedupe sul content-hash DI DOMINIO
         var depN = (depends ?? Array.Empty<int>()).Distinct().OrderBy(x => x).ToArray();
-        var tmp = new ProgesiVariable(0, name ?? string.Empty, typedValue, depN, metadataIds, isAss);
+        var tmp = new ProgesiVariable(0, name ?? string.Empty, typedValue ?? "", depN, metadataIds, isAss);
         var contentHash = ProgesiHash.Compute(tmp);
 
         if (id <= 0 && TryResolveIdByHash(table, "Progesi.VarHash", contentHash, out var existsId))
@@ -620,7 +620,7 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
           UnindexHash(table, "Progesi.VarHash", oldContent);
         }
 
-        var variableNew = new ProgesiVariable(id, name ?? string.Empty, typedValue,
+        var variableNew = new ProgesiVariable(id, name ?? string.Empty, typedValue ?? "",
                                               dependsFrom: depN,
                                               metadataIds: metadataIds,
                                               isAssumption: isAss);

--- a/src/ProgesiRepositories.Rhino/RhinoVariableRepository.cs
+++ b/src/ProgesiRepositories.Rhino/RhinoVariableRepository.cs
@@ -67,7 +67,7 @@ namespace ProgesiRepositories.Rhino
       var metadataIds = ReadMetadataIds(dto.MetadataIds, dto.MetadataId);
       var isAss = dto.IsAssumption ?? false;
 
-      return Task.FromResult(new ProgesiVariable(dto.Id, dto.Name ?? string.Empty, value, depends, metadataIds, isAss));
+      return Task.FromResult(new ProgesiVariable(dto.Id, dto.Name ?? string.Empty, value ?? "", depends, metadataIds, isAss));
     }
 
     public async Task<ProgesiVariable?> GetByHashtagAsync(string hashtag, CancellationToken ct = default)

--- a/src/ProgesiRepositories.Sqlite/SqliteVariableRepository.cs
+++ b/src/ProgesiRepositories.Sqlite/SqliteVariableRepository.cs
@@ -204,7 +204,7 @@ ON CONFLICT(Id) DO UPDATE SET
 
         var value = ParseValue(valStr, vType);
         _log.Debug($"[SQLite] Variable get Id={id}: hit.");
-        return new ProgesiVariable(vid, name, value, depends, metadataIds);
+        return new ProgesiVariable(vid, name, value ?? "", depends, metadataIds);
       }, ct: ct);
     }
 

--- a/tests/Progesi.Infrastructure.EF.Tests/EfVariableRepositoryTests.cs
+++ b/tests/Progesi.Infrastructure.EF.Tests/EfVariableRepositoryTests.cs
@@ -79,6 +79,29 @@ public sealed class EfVariableRepositoryTests : IDisposable
   }
 
   [Fact]
+  public async Task GetByIdAsync_Legacy_Null_ValueType_Reads_As_Empty_String()
+  {
+    using var ctx = ProgesiDbContextFactory.Create(_connectionString, resetSchema: true);
+    ctx.Variables.Add(new Progesi.Infrastructure.EF.Entities.VariableEntity
+    {
+      Id = 31,
+      Name = "LegacyNull",
+      ValueType = "null",
+      Value = "null",
+      MetadataIdsJson = "[]",
+      DependsJson = "[]",
+      ContentHash = "legacy-null-value"
+    });
+    await ctx.SaveChangesAsync();
+    ctx.Dispose();
+
+    var loaded = await _repo.GetByIdAsync(31);
+
+    loaded.Should().NotBeNull();
+    loaded!.Value.Should().Be("");
+  }
+
+  [Fact]
   public async Task SaveAsync_Empty_MetadataIds_RoundTrips_As_Empty()
   {
     var original = new ProgesiVariable(13, "NoMeta", 0);

--- a/tests/ProgesiCore.Tests/ProgesiVariableEqualityTests.cs
+++ b/tests/ProgesiCore.Tests/ProgesiVariableEqualityTests.cs
@@ -9,8 +9,8 @@ namespace ProgesiCore.Tests
     [Fact]
     public void Equality_Ignores_DependsFrom_Order()
     {
-      var v1 = new ProgesiVariable(id: 1, name: "A", value: null, dependsFrom: new[] { 3, 1, 2 }, metadataIds: new[] { 7 });
-      var v2 = new ProgesiVariable(id: 1, name: "A", value: null, dependsFrom: new[] { 2, 3, 1 }, metadataIds: new[] { 7 });
+      var v1 = new ProgesiVariable(id: 1, name: "A", value: "", dependsFrom: new[] { 3, 1, 2 }, metadataIds: new[] { 7 });
+      var v2 = new ProgesiVariable(id: 1, name: "A", value: "", dependsFrom: new[] { 2, 3, 1 }, metadataIds: new[] { 7 });
 
       _ = v1.Should().Be(v2);
 

--- a/tests/ProgesiCore.Tests/ProgesiVariableValueNonNullTests.cs
+++ b/tests/ProgesiCore.Tests/ProgesiVariableValueNonNullTests.cs
@@ -1,0 +1,50 @@
+using System;
+using FluentAssertions;
+using ProgesiCore;
+using ProgesiRepositories.InMemory;
+using Xunit;
+
+namespace ProgesiCore.Tests
+{
+  public class ProgesiVariableValueNonNullTests
+  {
+    [Fact]
+    public void Constructor_Throws_When_Value_Is_Null()
+    {
+      Action act = () => new ProgesiVariable(1, "A", null!);
+
+      act.Should().Throw<ArgumentNullException>().WithParameterName("value");
+    }
+
+    [Fact]
+    public void WithValue_Throws_When_Value_Is_Null()
+    {
+      var original = new ProgesiVariable(1, "A", 42);
+
+      Action act = () => original.WithValue(null);
+
+      act.Should().Throw<ArgumentNullException>().WithParameterName("value");
+    }
+
+    [Fact]
+    public void Empty_String_Value_Is_Allowed()
+    {
+      var v = new ProgesiVariable(1, "Blank", "");
+
+      v.Value.Should().Be("");
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Empty_String_Value_RoundTrips_InMemory()
+    {
+      var repo = new InMemoryVariableRepository();
+      var original = new ProgesiVariable(9, "Blank", "", metadataIds: new[] { 1 });
+
+      await repo.SaveAsync(original);
+      var loaded = await repo.GetByIdAsync(9);
+
+      loaded.Should().NotBeNull();
+      loaded!.Value.Should().Be("");
+    }
+  }
+}

--- a/tests/ProgesiRepositories.Sqlite.Tests/SqliteVariableRepositoryTests.cs
+++ b/tests/ProgesiRepositories.Sqlite.Tests/SqliteVariableRepositoryTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Data.Sqlite;
 using ProgesiCore;
 using ProgesiRepositories.Sqlite;
 using Xunit;
@@ -51,6 +52,25 @@ namespace ProgesiRepositories.Sqlite.Tests
 
       var all = await _repo.GetAllAsync();
       all.Select(x => x.Id).Should().Contain(1).And.NotContain(2);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_Legacy_Null_ValueType_Reads_As_Empty_String()
+    {
+      using (var conn = new SqliteConnection($"Data Source={_dbPath}"))
+      {
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+INSERT INTO Variables (Id, Name, ValueType, Value, MetadataId, MetadataIdsJson, DependsJson, ContentHash)
+VALUES (30, 'LegacyNull', 'null', 'null', NULL, '[]', '[]', 'legacy-null-value');";
+        cmd.ExecuteNonQuery();
+      }
+
+      var loaded = await _repo.GetByIdAsync(30);
+
+      loaded.Should().NotBeNull();
+      loaded!.Value.Should().Be("");
     }
 
     public void Dispose()


### PR DESCRIPTION
## R2-K - enforce ProgesiVariable.Value non-null (Invariant #3)

Human decision: a null Value is not allowed.

- **Guard:** constructor `Guard.Against.Null(value)`; `Value` property is now non-nullable (`object`). Empty string remains a valid value - VarIn (which coerces blank input to "") is unaffected. Forbids NULL only, not empty.
- **Back-compat:** all repos stored a null Value as `ValueType="null"`; read paths now coerce a parsed-null Value to "" before constructing, so pre-existing null-value data reads back as an empty-string value instead of throwing.
- **No hash-payload change:** R2-I golden hash tests and R2-J hashtag tests still pass (non-null values unaffected). **No EF migration** (no schema change).

### Verification
- `dotnet build -c Release`: 0 errors. `dotnet test`: all green (>= 279 + new: ctor/WithValue throw on null; empty allowed; SQLite/EF legacy null reads as ""). This script gates on both.
- Light manual GH smoke (advisable): VarIn with a normal value AND a blank value both Create OK.

Do NOT merge until Claude review + human go.

Generated with Claude Code.