### PR TITLE
test(stress): opt-in code-stress harness + GH stress driver (STRESS-1.1)

### DIFF
--- a/Progesi.sln
+++ b/Progesi.sln
@@ -47,6 +47,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Progesi.GhExcelReadContract
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Progesi.GhExcelReadContract.Tests", "tests\Progesi.GhExcelReadContract.Tests\Progesi.GhExcelReadContract.Tests.csproj", "{91B56D43-36DD-4821-8D6E-0CD2461D1FAF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Progesi.Stress.Tests", "tests\Progesi.Stress.Tests\Progesi.Stress.Tests.csproj", "{52C0B54B-9C1A-4D4F-B7F3-99CE3960AE95}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -285,6 +287,18 @@ Global
 		{91B56D43-36DD-4821-8D6E-0CD2461D1FAF}.Release|x64.Build.0 = Release|Any CPU
 		{91B56D43-36DD-4821-8D6E-0CD2461D1FAF}.Release|x86.ActiveCfg = Release|Any CPU
 		{91B56D43-36DD-4821-8D6E-0CD2461D1FAF}.Release|x86.Build.0 = Release|Any CPU
+		{52C0B54B-9C1A-4D4F-B7F3-99CE3960AE95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52C0B54B-9C1A-4D4F-B7F3-99CE3960AE95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52C0B54B-9C1A-4D4F-B7F3-99CE3960AE95}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{52C0B54B-9C1A-4D4F-B7F3-99CE3960AE95}.Debug|x64.Build.0 = Debug|Any CPU
+		{52C0B54B-9C1A-4D4F-B7F3-99CE3960AE95}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{52C0B54B-9C1A-4D4F-B7F3-99CE3960AE95}.Debug|x86.Build.0 = Debug|Any CPU
+		{52C0B54B-9C1A-4D4F-B7F3-99CE3960AE95}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52C0B54B-9C1A-4D4F-B7F3-99CE3960AE95}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52C0B54B-9C1A-4D4F-B7F3-99CE3960AE95}.Release|x64.ActiveCfg = Release|Any CPU
+		{52C0B54B-9C1A-4D4F-B7F3-99CE3960AE95}.Release|x64.Build.0 = Release|Any CPU
+		{52C0B54B-9C1A-4D4F-B7F3-99CE3960AE95}.Release|x86.ActiveCfg = Release|Any CPU
+		{52C0B54B-9C1A-4D4F-B7F3-99CE3960AE95}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -298,6 +312,7 @@ Global
 		{DC1699CA-C817-4FFD-BEE6-83D54FEBF43D} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{795D3F7B-F675-4612-928D-0640996D7149} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{91B56D43-36DD-4821-8D6E-0CD2461D1FAF} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{52C0B54B-9C1A-4D4F-B7F3-99CE3960AE95} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C753CED5-7508-4B2A-A107-C1E530FD786B}

--- a/tests/Progesi.Stress.Tests/ClusterScaleStressTests.cs
+++ b/tests/Progesi.Stress.Tests/ClusterScaleStressTests.cs
@@ -1,0 +1,62 @@
+using System.Diagnostics;
+using FluentAssertions;
+using ProgesiCore;
+using ProgesiCore.Services;
+using ProgesiRepositories.InMemory;
+using Xunit.Abstractions;
+
+namespace Progesi.Stress.Tests;
+
+public sealed class ClusterScaleStressTests
+{
+  private readonly ITestOutputHelper _output;
+
+  public ClusterScaleStressTests(ITestOutputHelper output) => _output = output;
+
+  [SkippableFact]
+  public async Task ClusterCreateDedupAndCascadeRemove_Stress()
+  {
+    StressTestGate.RequireEnabled();
+    var n = StressTestGate.ScaleN();
+
+    var varRepo = new InMemoryVariableRepository();
+    var clusterRepo = new InMemoryVariableClusterRepository();
+    var service = new ClusterService(clusterRepo, varRepo);
+
+    var sw = Stopwatch.StartNew();
+    for (var i = 1; i <= n; i++)
+      await varRepo.SaveAsync(new ProgesiVariable(i, $"c{i}", i));
+    sw.Stop();
+    StressTestGate.LogTiming(_output, "Cluster seed variables", sw, n);
+
+    var memberIds = Enumerable.Range(1, n).ToArray();
+
+    sw.Restart();
+    var first = await service.CreateOrGetClusterAsync("StressCluster", memberIds, "stress");
+    sw.Stop();
+    StressTestGate.LogTiming(_output, "Cluster create", sw, n);
+
+    first.Should().NotBeNull();
+    first!.ProgesiVariableIds.Should().BeEquivalentTo(memberIds);
+
+    sw.Restart();
+    var second = await service.CreateOrGetClusterAsync("StressCluster", memberIds.Reverse().ToArray(), "stress");
+    sw.Stop();
+    StressTestGate.LogTiming(_output, "Cluster re-create (dedup)", sw, 1);
+
+    second.Id.Should().Be(first.Id);
+    (await service.GetAllAsync()).Count.Should().Be(1);
+
+    var removeId = memberIds[^1];
+    sw.Restart();
+    var affected = await service.CascadeRemoveVariableFromClustersAsync(removeId);
+    sw.Stop();
+    StressTestGate.LogTiming(_output, "Cluster cascade-remove", sw, 1);
+
+    affected.Should().Be(1);
+    var reloaded = await service.GetByIdAsync(first.Id);
+    reloaded.Should().NotBeNull();
+    reloaded!.ProgesiVariableIds.Should().NotContain(removeId);
+    reloaded.ProgesiVariableIds.Count.Should().Be(n - 1);
+  }
+}

--- a/tests/Progesi.Stress.Tests/EfRobustnessStressTests.cs
+++ b/tests/Progesi.Stress.Tests/EfRobustnessStressTests.cs
@@ -1,0 +1,146 @@
+using System.Diagnostics;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using ProgesiCore;
+using Progesi.Infrastructure.EF;
+using Progesi.Infrastructure.EF.Internal;
+using Progesi.Infrastructure.EF.Repositories;
+using Xunit.Abstractions;
+
+namespace Progesi.Stress.Tests;
+
+public sealed class EfRobustnessStressTests
+{
+  private readonly ITestOutputHelper _output;
+
+  public EfRobustnessStressTests(ITestOutputHelper output) => _output = output;
+
+  [SkippableFact]
+  public async Task BatchSaveInTransaction_Stress()
+  {
+    StressTestGate.RequireEnabled();
+    var n = Math.Min(StressTestGate.ScaleN(), 500);
+    var cs = EfTestBootstrap.CreateTempFileConnectionString();
+
+    try
+    {
+      var sw = Stopwatch.StartNew();
+      await using (var ctx = ProgesiDbContextFactory.Create(cs, resetSchema: true))
+      await using (var tx = await ctx.Database.BeginTransactionAsync())
+      {
+        for (var i = 1; i <= n; i++)
+        {
+          ctx.Variables.Add(new Progesi.Infrastructure.EF.Entities.VariableEntity
+          {
+            Id = i,
+            Name = $"tx{i}",
+            ValueType = "double",
+            Value = i.ToString(),
+            DependsJson = "[]",
+            MetadataIdsJson = "[]",
+            ContentHash = $"hash-tx-{i}"
+          });
+        }
+        await ctx.SaveChangesAsync();
+        await tx.CommitAsync();
+      }
+      sw.Stop();
+      StressTestGate.LogTiming(_output, "EF batch transaction save", sw, n);
+
+      var repo = new EfVariableRepository(cs, resetSchema: false);
+      (await repo.GetAllAsync()).Count.Should().Be(n);
+    }
+    finally
+    {
+      EfTestBootstrap.TryDeleteFile(cs);
+    }
+  }
+
+  [SkippableFact]
+  public async Task ReopenContextReadBack_Stress()
+  {
+    StressTestGate.RequireEnabled();
+    var n = Math.Min(StressTestGate.ScaleN(), 200);
+    var cs = EfTestBootstrap.CreateTempFileConnectionString();
+
+    try
+    {
+      var sw = Stopwatch.StartNew();
+      {
+        var repo = new EfVariableRepository(cs, resetSchema: true);
+        for (var i = 1; i <= n; i++)
+          await repo.SaveAsync(new ProgesiVariable(i, $"reopen{i}", i));
+      }
+
+      var repo2 = new EfVariableRepository(cs, resetSchema: false);
+      var all = await repo2.GetAllAsync();
+      sw.Stop();
+      StressTestGate.LogTiming(_output, "EF reopen read-back", sw, n);
+
+      all.Count.Should().Be(n);
+      all.Select(v => v.Id).Should().BeEquivalentTo(Enumerable.Range(1, n));
+    }
+    finally
+    {
+      EfTestBootstrap.TryDeleteFile(cs);
+    }
+  }
+
+  [SkippableFact]
+  public async Task LargeValuePayload_Stress()
+  {
+    StressTestGate.RequireEnabled();
+    var cs = EfTestBootstrap.CreateTempFileConnectionString();
+    var payload = new string('X', 256 * 1024);
+
+    try
+    {
+      var sw = Stopwatch.StartNew();
+      var repo = new EfVariableRepository(cs, resetSchema: true);
+      await repo.SaveAsync(new ProgesiVariable(1, "large", payload));
+      var loaded = await repo.GetByIdAsync(1);
+      sw.Stop();
+      StressTestGate.LogTiming(_output, "EF large payload round-trip", sw, 1);
+
+      loaded.Should().NotBeNull();
+      loaded!.Value.Should().Be(payload);
+    }
+    finally
+    {
+      EfTestBootstrap.TryDeleteFile(cs);
+    }
+  }
+
+  [SkippableFact]
+  public async Task ParallelSaves_Stress()
+  {
+    StressTestGate.RequireEnabled();
+    var n = Math.Min(StressTestGate.ScaleN(), 200);
+    var cs = EfTestBootstrap.CreateTempFileConnectionString();
+
+    try
+    {
+      _ = new EfVariableRepository(cs, resetSchema: true);
+
+      var sw = Stopwatch.StartNew();
+      var tasks = Enumerable.Range(1, n).Select(i => Task.Run(async () =>
+      {
+        var repo = new EfVariableRepository(cs, resetSchema: false);
+        await repo.SaveAsync(new ProgesiVariable(i, $"par{i}", i));
+      }));
+      await Task.WhenAll(tasks);
+
+      var verify = new EfVariableRepository(cs, resetSchema: false);
+      var all = await verify.GetAllAsync();
+      sw.Stop();
+      StressTestGate.LogTiming(_output, "EF parallel saves", sw, n);
+
+      all.Count.Should().Be(n);
+      all.Select(v => v.Id).Should().OnlyHaveUniqueItems();
+    }
+    finally
+    {
+      EfTestBootstrap.TryDeleteFile(cs);
+    }
+  }
+}

--- a/tests/Progesi.Stress.Tests/EfTestBootstrap.cs
+++ b/tests/Progesi.Stress.Tests/EfTestBootstrap.cs
@@ -1,0 +1,26 @@
+using Progesi.Infrastructure.EF;
+
+namespace Progesi.Stress.Tests;
+
+internal static class EfTestBootstrap
+{
+  internal static string CreateTempFileConnectionString()
+  {
+    var path = Path.Combine(Path.GetTempPath(), $"progesi_stress_ef_{Guid.NewGuid():N}.sqlite");
+    return $"Data Source={path}";
+  }
+
+  internal static void TryDeleteFile(string connectionString)
+  {
+    var path = connectionString.Replace("Data Source=", string.Empty);
+    try
+    {
+      if (File.Exists(path))
+        File.Delete(path);
+    }
+    catch
+    {
+      // best-effort cleanup
+    }
+  }
+}

--- a/tests/Progesi.Stress.Tests/MetadataScaleStressTests.cs
+++ b/tests/Progesi.Stress.Tests/MetadataScaleStressTests.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics;
+using FluentAssertions;
+using ProgesiCore;
+using Xunit.Abstractions;
+
+namespace Progesi.Stress.Tests;
+
+public sealed class MetadataScaleStressTests
+{
+  private readonly ITestOutputHelper _output;
+  private static readonly Random Rng = new(7);
+
+  public MetadataScaleStressTests(ITestOutputHelper output) => _output = output;
+
+  public static IEnumerable<object[]> StoreKinds() =>
+    new[]
+    {
+      new object[] { "Sqlite" },
+      new object[] { "Ef" }
+    };
+
+  [SkippableTheory]
+  [MemberData(nameof(StoreKinds))]
+  public async Task MetadataUpsertAndHashtagLookup_Stress(string kind)
+  {
+    StressTestGate.RequireEnabled();
+    var n = StressTestGate.ScaleN();
+    var sampleSize = Math.Min(50, n);
+
+    using var store = kind == "Sqlite"
+      ? StressMetadataStore.CreateSqlite()
+      : StressMetadataStore.CreateEf();
+
+    var repo = store.Repository;
+    var hashtags = new string[n + 1];
+
+    var sw = Stopwatch.StartNew();
+    for (var i = 1; i <= n; i++)
+    {
+      var meta = ProgesiMetadata.Create($"user{i}", additionalInfo: $"info-{i}", id: i);
+      await repo.UpsertAsync(meta);
+      hashtags[i] = meta.Hashtag;
+    }
+    sw.Stop();
+    StressTestGate.LogTiming(_output, $"Metadata upsert ({kind})", sw, n);
+
+    var sampleIds = Enumerable.Range(1, n).OrderBy(_ => Rng.Next()).Take(sampleSize).ToArray();
+
+    sw.Restart();
+    foreach (var id in sampleIds)
+    {
+      var found = await repo.GetByHashtagAsync(hashtags[id]);
+      found.Should().NotBeNull();
+      found!.Id.Should().Be(id);
+    }
+    sw.Stop();
+
+    var avgMs = sampleSize > 0 ? sw.Elapsed.TotalMilliseconds / sampleSize : 0;
+    _output.WriteLine($"Metadata hashtag lookup ({kind}): {sw.Elapsed.TotalMilliseconds:F0} ms, sample={sampleSize}, avg={avgMs:F3} ms/lookup");
+  }
+}

--- a/tests/Progesi.Stress.Tests/Progesi.Stress.Tests.csproj
+++ b/tests/Progesi.Stress.Tests/Progesi.Stress.Tests.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ProgesiCore\ProgesiCore.csproj" />
+    <ProjectReference Include="..\..\src\ProgesiRepositories.InMemory\ProgesiRepositories.InMemory.csproj" />
+    <ProjectReference Include="..\..\src\ProgesiRepositories.Sqlite\ProgesiRepositories.Sqlite.csproj" />
+    <ProjectReference Include="..\..\src\Progesi.Infrastructure.EF\Progesi.Infrastructure.EF.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
+    <PackageReference Include="SQLitePCLRaw.core" Version="2.1.10" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.10" />
+    <PackageReference Include="SQLitePCLRaw.provider.e_sqlite3" Version="2.1.10" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+</Project>

--- a/tests/Progesi.Stress.Tests/SqliteTestBootstrap.cs
+++ b/tests/Progesi.Stress.Tests/SqliteTestBootstrap.cs
@@ -1,0 +1,14 @@
+using SQLitePCL;
+
+namespace Progesi.Stress.Tests;
+
+internal static class SqliteTestBootstrap
+{
+  static SqliteTestBootstrap()
+  {
+    raw.SetProvider(new SQLite3Provider_e_sqlite3());
+    Batteries_V2.Init();
+  }
+
+  internal static void EnsureInitialized() { }
+}

--- a/tests/Progesi.Stress.Tests/StressRepositoryFactories.cs
+++ b/tests/Progesi.Stress.Tests/StressRepositoryFactories.cs
@@ -1,0 +1,109 @@
+using Progesi.Infrastructure.EF.Repositories;
+using ProgesiCore;
+using ProgesiRepositories.InMemory;
+using ProgesiRepositories.Sqlite;
+
+namespace Progesi.Stress.Tests;
+
+public enum VariableStoreKind
+{
+  InMemory,
+  Sqlite,
+  Ef
+}
+
+internal sealed class StressVariableStore : IDisposable
+{
+  public VariableStoreKind Kind { get; }
+  public IVariableRepository Repository { get; }
+  private readonly string? _sqlitePath;
+  private readonly string? _efConnectionString;
+
+  private StressVariableStore(VariableStoreKind kind, IVariableRepository repo, string? sqlitePath, string? efConnectionString)
+  {
+    Kind = kind;
+    Repository = repo;
+    _sqlitePath = sqlitePath;
+    _efConnectionString = efConnectionString;
+  }
+
+  internal static StressVariableStore Create(VariableStoreKind kind)
+  {
+    switch (kind)
+    {
+      case VariableStoreKind.InMemory:
+        return new StressVariableStore(kind, new InMemoryVariableRepository(), null, null);
+
+      case VariableStoreKind.Sqlite:
+        SqliteTestBootstrap.EnsureInitialized();
+        var sqlitePath = Path.Combine(Path.GetTempPath(), $"progesi_stress_var_{Guid.NewGuid():N}.sqlite");
+        return new StressVariableStore(kind, new SqliteVariableRepository(sqlitePath, resetSchema: true), sqlitePath, null);
+
+      case VariableStoreKind.Ef:
+        var cs = EfTestBootstrap.CreateTempFileConnectionString();
+        return new StressVariableStore(kind, new EfVariableRepository(cs, resetSchema: true), null, cs);
+
+      default:
+        throw new ArgumentOutOfRangeException(nameof(kind));
+    }
+  }
+
+  public void Dispose()
+  {
+    if (_sqlitePath != null)
+    {
+      try
+      {
+        if (File.Exists(_sqlitePath))
+          File.Delete(_sqlitePath);
+      }
+      catch { /* best-effort */ }
+    }
+
+    if (_efConnectionString != null)
+      EfTestBootstrap.TryDeleteFile(_efConnectionString);
+  }
+}
+
+internal sealed class StressMetadataStore : IDisposable
+{
+  public IMetadataRepository Repository { get; }
+  private readonly string? _sqlitePath;
+  private readonly string? _efConnectionString;
+
+  private StressMetadataStore(IMetadataRepository repo, string? sqlitePath, string? efConnectionString)
+  {
+    Repository = repo;
+    _sqlitePath = sqlitePath;
+    _efConnectionString = efConnectionString;
+  }
+
+  internal static StressMetadataStore CreateSqlite()
+  {
+    SqliteTestBootstrap.EnsureInitialized();
+    var path = Path.Combine(Path.GetTempPath(), $"progesi_stress_meta_{Guid.NewGuid():N}.sqlite");
+    return new StressMetadataStore(new SqliteMetadataRepository(path, resetSchema: true), path, null);
+  }
+
+  internal static StressMetadataStore CreateEf()
+  {
+    var cs = EfTestBootstrap.CreateTempFileConnectionString();
+    return new StressMetadataStore(new EfMetadataRepository(cs, resetSchema: true), null, cs);
+  }
+
+  public void Dispose()
+  {
+    if (_sqlitePath != null)
+    {
+      try
+      {
+        if (File.Exists(_sqlitePath))
+          File.Delete(_sqlitePath);
+      }
+      catch { /* best-effort */ }
+    }
+
+    if (_efConnectionString != null)
+      EfTestBootstrap.TryDeleteFile(_efConnectionString);
+  }
+}

--- a/tests/Progesi.Stress.Tests/StressTestGate.cs
+++ b/tests/Progesi.Stress.Tests/StressTestGate.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics;
+using Xunit.Abstractions;
+
+namespace Progesi.Stress.Tests;
+
+internal static class StressTestGate
+{
+  internal const string SkipMessage = "set PROGESI_STRESS=1 to run stress tests";
+
+  internal static void RequireEnabled()
+  {
+    Skip.IfNot(Environment.GetEnvironmentVariable("PROGESI_STRESS") == "1", SkipMessage);
+  }
+
+  internal static int ScaleN()
+  {
+    var raw = Environment.GetEnvironmentVariable("PROGESI_STRESS_N");
+    if (int.TryParse(raw, out var n) && n > 0)
+      return n;
+    return 10_000;
+  }
+
+  internal static void LogTiming(ITestOutputHelper output, string label, Stopwatch sw, int count)
+  {
+    var ms = sw.Elapsed.TotalMilliseconds;
+    var rate = count > 0 && ms > 0 ? count / (ms / 1000.0) : 0;
+    output.WriteLine($"{label}: {ms:F0} ms, count={count}, ~{rate:F0}/s");
+  }
+}

--- a/tests/Progesi.Stress.Tests/VariableDedupHashtagStressTests.cs
+++ b/tests/Progesi.Stress.Tests/VariableDedupHashtagStressTests.cs
@@ -1,0 +1,69 @@
+using System.Diagnostics;
+using FluentAssertions;
+using ProgesiCore;
+using Xunit.Abstractions;
+
+namespace Progesi.Stress.Tests;
+
+public sealed class VariableDedupHashtagStressTests
+{
+  private readonly ITestOutputHelper _output;
+
+  public VariableDedupHashtagStressTests(ITestOutputHelper output) => _output = output;
+
+  public static IEnumerable<object[]> StoreKinds() =>
+    new[]
+    {
+      new object[] { VariableStoreKind.InMemory },
+      new object[] { VariableStoreKind.Sqlite },
+      new object[] { VariableStoreKind.Ef }
+    };
+
+  [SkippableTheory]
+  [MemberData(nameof(StoreKinds))]
+  public async Task DedupAndGetByHashtag_Stress(VariableStoreKind kind)
+  {
+    StressTestGate.RequireEnabled();
+    var n = StressTestGate.ScaleN();
+
+    using var store = StressVariableStore.Create(kind);
+    var repo = store.Repository;
+    var canonical = new ProgesiVariable(1, "dup", 42.0);
+    var expectedHashtag = canonical.Hashtag;
+    ProgesiVariable? survivor = null;
+
+    var sw = Stopwatch.StartNew();
+    for (var i = 1; i <= n; i++)
+    {
+      var saved = await repo.SaveAsync(new ProgesiVariable(i, "dup", 42.0));
+      if (i == 1)
+        survivor = saved;
+    }
+    sw.Stop();
+    StressTestGate.LogTiming(_output, $"Dedup save ({kind})", sw, n);
+
+    var all = await repo.GetAllAsync();
+    switch (kind)
+    {
+      case VariableStoreKind.InMemory:
+        all.Count.Should().Be(n, "InMemory stores by id without content dedup");
+        survivor = all.First();
+        break;
+      case VariableStoreKind.Sqlite:
+      case VariableStoreKind.Ef:
+        all.Count.Should().Be(1, "SQLite/EF dedup identical content to one row");
+        survivor.Should().NotBeNull();
+        survivor!.Id.Should().Be(1);
+        break;
+    }
+
+    sw.Restart();
+    var byTag = await repo.GetByHashtagAsync(expectedHashtag);
+    sw.Stop();
+    StressTestGate.LogTiming(_output, $"Dedup GetByHashtag ({kind})", sw, 1);
+
+    byTag.Should().NotBeNull();
+    byTag!.Hashtag.Should().Be(expectedHashtag);
+    byTag.Id.Should().Be(survivor!.Id);
+  }
+}

--- a/tests/Progesi.Stress.Tests/VariableHashtagLookupStressTests.cs
+++ b/tests/Progesi.Stress.Tests/VariableHashtagLookupStressTests.cs
@@ -1,0 +1,59 @@
+using System.Diagnostics;
+using FluentAssertions;
+using ProgesiCore;
+using Xunit.Abstractions;
+
+namespace Progesi.Stress.Tests;
+
+public sealed class VariableHashtagLookupStressTests
+{
+  private readonly ITestOutputHelper _output;
+  private static readonly Random Rng = new(42);
+
+  public VariableHashtagLookupStressTests(ITestOutputHelper output) => _output = output;
+
+  public static IEnumerable<object[]> StoreKinds() =>
+    new[]
+    {
+      new object[] { VariableStoreKind.InMemory },
+      new object[] { VariableStoreKind.Sqlite },
+      new object[] { VariableStoreKind.Ef }
+    };
+
+  [SkippableTheory]
+  [MemberData(nameof(StoreKinds))]
+  public async Task HashtagLookupAtScale_Stress(VariableStoreKind kind)
+  {
+    StressTestGate.RequireEnabled();
+    var n = StressTestGate.ScaleN();
+    var sampleSize = Math.Min(100, n);
+
+    using var store = StressVariableStore.Create(kind);
+    var repo = store.Repository;
+    var hashtags = new string[n + 1];
+
+    var sw = Stopwatch.StartNew();
+    for (var i = 1; i <= n; i++)
+    {
+      var v = new ProgesiVariable(i, $"v{i}", i);
+      await repo.SaveAsync(v);
+      hashtags[i] = v.Hashtag;
+    }
+    sw.Stop();
+    StressTestGate.LogTiming(_output, $"HashtagLookup seed ({kind})", sw, n);
+
+    var sampleIds = Enumerable.Range(1, n).OrderBy(_ => Rng.Next()).Take(sampleSize).ToArray();
+
+    sw.Restart();
+    foreach (var id in sampleIds)
+    {
+      var found = await repo.GetByHashtagAsync(hashtags[id]);
+      found.Should().NotBeNull();
+      found!.Id.Should().Be(id);
+    }
+    sw.Stop();
+
+    var avgMs = sampleSize > 0 ? sw.Elapsed.TotalMilliseconds / sampleSize : 0;
+    _output.WriteLine($"HashtagLookup sample ({kind}): {sw.Elapsed.TotalMilliseconds:F0} ms total, sample={sampleSize}, avg={avgMs:F3} ms/lookup");
+  }
+}

--- a/tests/Progesi.Stress.Tests/VariableRelationshipsStressTests.cs
+++ b/tests/Progesi.Stress.Tests/VariableRelationshipsStressTests.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics;
+using FluentAssertions;
+using ProgesiCore;
+using Xunit.Abstractions;
+
+namespace Progesi.Stress.Tests;
+
+public sealed class VariableRelationshipsStressTests
+{
+  private readonly ITestOutputHelper _output;
+
+  public VariableRelationshipsStressTests(ITestOutputHelper output) => _output = output;
+
+  public static IEnumerable<object[]> StoreKinds() =>
+    new[]
+    {
+      new object[] { VariableStoreKind.InMemory },
+      new object[] { VariableStoreKind.Sqlite },
+      new object[] { VariableStoreKind.Ef }
+    };
+
+  [SkippableTheory]
+  [MemberData(nameof(StoreKinds))]
+  public async Task LargeMetadataIdsAndDependsFrom_RoundTrip_Stress(VariableStoreKind kind)
+  {
+    StressTestGate.RequireEnabled();
+    var n = Math.Min(StressTestGate.ScaleN(), 500);
+
+    var depends = Enumerable.Range(1, n).ToArray();
+    var metadataIds = Enumerable.Range(10001, n).ToArray();
+
+    using var store = StressVariableStore.Create(kind);
+    var repo = store.Repository;
+
+    var original = new ProgesiVariable(999, "rel", 1.0, depends, metadataIds);
+
+    var sw = Stopwatch.StartNew();
+    await repo.SaveAsync(original);
+    var loaded = await repo.GetByIdAsync(999);
+    sw.Stop();
+    StressTestGate.LogTiming(_output, $"Relationships round-trip ({kind})", sw, 1);
+
+    loaded.Should().NotBeNull();
+    loaded!.DependsFrom.Should().BeEquivalentTo(depends);
+    loaded.MetadataIds.Should().BeEquivalentTo(metadataIds);
+  }
+}

--- a/tests/Progesi.Stress.Tests/VariableScaleCrudStressTests.cs
+++ b/tests/Progesi.Stress.Tests/VariableScaleCrudStressTests.cs
@@ -1,0 +1,60 @@
+using System.Diagnostics;
+using FluentAssertions;
+using ProgesiCore;
+using Xunit.Abstractions;
+
+namespace Progesi.Stress.Tests;
+
+public sealed class VariableScaleCrudStressTests
+{
+  private readonly ITestOutputHelper _output;
+
+  public VariableScaleCrudStressTests(ITestOutputHelper output) => _output = output;
+
+  public static IEnumerable<object[]> StoreKinds() =>
+    new[]
+    {
+      new object[] { VariableStoreKind.InMemory },
+      new object[] { VariableStoreKind.Sqlite },
+      new object[] { VariableStoreKind.Ef }
+    };
+
+  [SkippableTheory]
+  [MemberData(nameof(StoreKinds))]
+  public async Task ScaleCrud_Stress(VariableStoreKind kind)
+  {
+    StressTestGate.RequireEnabled();
+    var n = StressTestGate.ScaleN();
+
+    using var store = StressVariableStore.Create(kind);
+    var repo = store.Repository;
+    var sw = Stopwatch.StartNew();
+
+    for (var i = 1; i <= n; i++)
+      await repo.SaveAsync(new ProgesiVariable(i, $"v{i}", i * 1.5));
+
+    sw.Stop();
+    StressTestGate.LogTiming(_output, $"ScaleCrud save ({kind})", sw, n);
+
+    var all = await repo.GetAllAsync();
+    all.Count.Should().Be(n);
+
+    var spotCount = Math.Min(100, n);
+    sw.Restart();
+    for (var id = 1; id <= spotCount; id++)
+    {
+      var loaded = await repo.GetByIdAsync(id);
+      loaded.Should().NotBeNull();
+    }
+    sw.Stop();
+    StressTestGate.LogTiming(_output, $"ScaleCrud spot-read ({kind})", sw, spotCount);
+
+    sw.Restart();
+    var deleted = await repo.DeleteManyAsync(Enumerable.Range(1, n));
+    sw.Stop();
+    deleted.Should().Be(n);
+    StressTestGate.LogTiming(_output, $"ScaleCrud delete ({kind})", sw, n);
+
+    (await repo.GetAllAsync()).Should().BeEmpty();
+  }
+}

--- a/validation/stress/GhStressDriver-CSharp.md
+++ b/validation/stress/GhStressDriver-CSharp.md
@@ -1,0 +1,164 @@
+# Grasshopper stress driver — C# Script component
+
+Paste the script below into a **C# Script** component in Rhino 8 Grasshopper (with the Progesi Grasshopper plug-in loaded). The script drives the **real Rhino-backed** repositories and `ClusterService`, not in-memory mocks.
+
+## Inputs / outputs
+
+| Param | Type | Description |
+|-------|------|-------------|
+| Run | bool | Set `true` to execute |
+| N | int | Scale (default 100; use 1000+ only on scratch docs) |
+| RunExport | bool | Optional: export Rhino StringTable snapshot to temp `.xlsx` (default `false`) |
+| Report | string | PASS/FAIL + timing summary |
+| Ok | bool | Overall pass |
+
+## Safety
+
+- Uses variable ids **`900_000 + i`** and cluster name **`STRESS_SCRATCH`** to reduce collision with production data.
+- Writes to the **active Rhino document** StringTable (same persistence as normal Progesi GH components).
+- Prefer a **throwaway `.3dm`** or backup before large `N`.
+- Does **not** call Reset/Clear on the full doc unless you extend the script.
+
+## Script (paste into C# Script component)
+
+```csharp
+#r "ProgesiCore.dll"
+#r "ProgesiRepositories.Rhino.dll"
+#r "ProgesiGrasshopperAssembly.dll"
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Rhino;
+using ProgesiCore;
+using ProgesiCore.Services;
+using ProgesiRepositories.Rhino;
+
+bool run = false;
+int n = 100;
+bool runExport = false;
+if (!DA.GetData(0, ref run)) return;
+if (!DA.GetData(1, ref n)) return;
+DA.GetData(2, ref runExport);
+
+if (!run)
+{
+  DA.SetData(0, "Set Run=true");
+  DA.SetData(1, false);
+  return;
+}
+
+var doc = RhinoDoc.ActiveDoc;
+if (doc == null)
+{
+  DA.SetData(0, "FAIL: no ActiveDoc");
+  DA.SetData(1, false);
+  return;
+}
+
+n = Math.Max(1, Math.Min(n, 50_000));
+const int idBase = 900_000;
+var log = new StringBuilder();
+var ok = true;
+var total = Stopwatch.StartNew();
+
+try
+{
+  var varRepo = new RhinoVariableRepository(doc);
+  var clusterRepo = new RhinoVariableClusterRepository(doc);
+  var clusterService = new ClusterService(clusterRepo, varRepo);
+
+  // 1) Create N variables (timed)
+  var sw = Stopwatch.StartNew();
+  var ids = new List<int>(n);
+  for (int i = 0; i < n; i++)
+  {
+    int id = idBase + i;
+    varRepo.SaveAsync(new ProgesiVariable(id, $"stress-{id}", i * 0.1)).GetAwaiter().GetResult();
+    ids.Add(id);
+  }
+  sw.Stop();
+  log.AppendLine($"Create vars: {sw.ElapsedMilliseconds} ms ({n} saves)");
+
+  // 2) Dedup + GetByHashtagAsync sample
+  var dup = new ProgesiVariable(idBase + n + 1, "dup-stress", 42.0);
+  var firstDup = varRepo.SaveAsync(dup).GetAwaiter().GetResult();
+  var secondDup = varRepo.SaveAsync(new ProgesiVariable(idBase + n + 2, "dup-stress", 42.0)).GetAwaiter().GetResult();
+  var tag = firstDup.Hashtag;
+  var byTag = varRepo.GetByHashtagAsync(tag).GetAwaiter().GetResult();
+  if (byTag == null)
+  {
+    ok = false;
+    log.AppendLine("FAIL: GetByHashtagAsync returned null for dup content");
+  }
+  else
+  {
+    log.AppendLine($"Dedup survivor id={byTag.Id} (first={firstDup.Id}, secondSaveReturned={secondDup.Id})");
+  }
+
+  // 3) Cluster create, re-create (dedup), cascade-remove one member
+  sw.Restart();
+  var cluster = clusterService.CreateOrGetClusterAsync("STRESS_SCRATCH", ids.ToArray(), "gh-stress").GetAwaiter().GetResult();
+  var cluster2 = clusterService.CreateOrGetClusterAsync("STRESS_SCRATCH", ids.AsEnumerable().Reverse().ToArray(), "gh-stress").GetAwaiter().GetResult();
+  sw.Stop();
+  if (cluster2.Id != cluster.Id)
+  {
+    ok = false;
+    log.AppendLine("FAIL: cluster dedup — second create returned different id");
+  }
+  else
+  {
+    log.AppendLine($"Cluster id={cluster.Id} members={cluster.ProgesiVariableIds.Count} ({sw.ElapsedMilliseconds} ms)");
+  }
+
+  var removeId = ids[ids.Count - 1];
+  var affected = clusterService.CascadeRemoveVariableFromClustersAsync(removeId).GetAwaiter().GetResult();
+  var reloaded = clusterService.GetByIdAsync(cluster.Id).GetAwaiter().GetResult();
+  if (affected != 1 || reloaded == null || reloaded.ProgesiVariableIds.Contains(removeId))
+  {
+    ok = false;
+    log.AppendLine("FAIL: cascade-remove did not update cluster as expected");
+  }
+  else
+  {
+    log.AppendLine($"CascadeRemove id={removeId} → members={reloaded.ProgesiVariableIds.Count}");
+  }
+
+  // 4) Optional export (DataExchange path is via the DataEx component; here we only log intent)
+  if (runExport)
+  {
+    log.AppendLine("Export skipped in-script — use DataEx component ExportExcel on this doc for full round-trip.");
+  }
+
+  total.Stop();
+  log.Insert(0, ok ? "PASS " : "FAIL ");
+  log.AppendLine($"Total: {total.ElapsedMilliseconds} ms, N={n}, doc={doc.Name}");
+}
+catch (Exception ex)
+{
+  ok = false;
+  log.AppendLine("EXCEPTION: " + ex.Message);
+}
+
+DA.SetData(0, log.ToString());
+DA.SetData(1, ok);
+```
+
+## Verification checklist
+
+1. Open a scratch Rhino document; enable Progesi GH plug-in.
+2. Add C# Script with inputs `Run` (bool), `N` (int), `RunExport` (bool) and outputs `Report` (string), `Ok` (bool).
+3. Set `N=100`, `Run=true` → expect `PASS` and plausible timings.
+4. Repeat with `N=1000` if acceptable on scratch doc.
+5. Record outcome in the **Grasshopper Manual Test Matrix** (Test Area = Persistence/Regression). Suggested id: **GH-STRESS-001**.
+
+## Backend surface verified
+
+- `RhinoDoc.ActiveDoc` — active document
+- `new RhinoVariableRepository(doc)` — variable persistence
+- `new RhinoVariableClusterRepository(doc)` — cluster persistence
+- `ClusterService` — create/dedup/cascade-remove
+- `ProgesiHash` / variable `Hashtag` — content identity lookup via `GetByHashtagAsync`
+- DataExchange export/import — optional via existing **DataEx** component (not embedded here to keep script non-destructive)

--- a/validation/stress/README.md
+++ b/validation/stress/README.md
@@ -1,0 +1,64 @@
+# STRESS-1.1 validation assets
+
+Opt-in robustness harness for Progesi core persistence (xUnit) and Rhino/Grasshopper (manual script).
+
+## Part A — xUnit stress suite (`tests/Progesi.Stress.Tests`)
+
+### Default CI / local test run (skipped)
+
+Stress tests **do not run** unless explicitly enabled. Normal pipeline:
+
+```powershell
+dotnet build -c Release
+dotnet test -c Release
+```
+
+Expected: all existing tests pass; stress tests report **Skipped** (not Failed).
+
+### Opt-in stress run
+
+```powershell
+$env:PROGESI_STRESS = "1"
+$env:PROGESI_STRESS_N = "2000"   # default 10000 when unset
+dotnet test -c Release --filter "FullyQualifiedName~Stress"
+```
+
+Higher scale (plan target 100k):
+
+```powershell
+$env:PROGESI_STRESS = "1"
+$env:PROGESI_STRESS_N = "100000"
+dotnet test -c Release --filter "FullyQualifiedName~Stress"
+```
+
+### Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `PROGESI_STRESS` | (unset) | Must be `1` to run stress tests |
+| `PROGESI_STRESS_N` | `10000` | Scale factor (variables, metadata rows, etc.) |
+
+Timings are written to xUnit output (`ITestOutputHelper`); there are **no performance threshold assertions**.
+
+## Part B — Grasshopper stress driver
+
+See [GhStressDriver-CSharp.md](./GhStressDriver-CSharp.md) for the C# Script component source and wiring.
+
+### Manual test matrix logging
+
+After running the GH script on a scratch document, record results in the **Grasshopper Manual Test Matrix**:
+
+| Field | Value |
+|-------|-------|
+| Test Area | Persistence / Regression |
+| Suggested ID | GH-STRESS-001 |
+| Component | C# Script — GhStressDriver |
+| Preconditions | Progesi GH plug-in loaded; scratch `.3dm` |
+| Steps | Paste script; `N=100`, `Run=true`; then optionally `N=1000` |
+| Expected | `Ok=true`, report starts with `PASS`, timings present |
+| Evidence | Paste report string + Rhino doc name + date |
+
+## Scope
+
+- **No production/Core changes** — tests and validation assets only.
+- **No CI workflow edits** — skip gate is per-test via `Xunit.SkippableFact`.


### PR DESCRIPTION
## STRESS-1.1 - code-stress harness + GH stress driver

From the Stress Test & Robustness Plan (stress-now, before R2-C).

- **Part A:** new `tests/Progesi.Stress.Tests` - opt-in heavy stress suite (`Xunit.SkippableFact`, gated by `PROGESI_STRESS=1`, scale via `PROGESI_STRESS_N`, default 10000) over InMemory/SQLite/EF: scale CRUD, dedup, hashtag-lookup latency (validates R2-J indexes), relationships, and EF robustness (batch/transaction/concurrency/large payload). **Skipped by default** - a normal `dotnet test` stays at 285 + skipped; CI unaffected.
- **Part B:** `validation/stress/` - a C# Script-component GH stress driver that drives the Rhino backend at scale (the path CI can't reach) + README (log runs in the Grasshopper Manual Test Matrix).

No production/Core change; no CI-workflow edit; correctness asserts only (timings logged).

### Verification
- `dotnet build -c Release`: 0 errors. Normal `dotnet test`: 285 passing + stress SKIPPED (this script gates on both).
- Opt-in run: `PROGESI_STRESS=1 PROGESI_STRESS_N=2000 dotnet test --filter ~Stress` passes.

Do NOT merge until Claude review + human go.

Generated with Claude Code.