### PR TITLE
test(r010): SQLite<->EF conformance parity (Phase 2)

### DIFF
--- a/src/ProgesiRepositories.Sqlite/SqliteRepositoryBase.cs
+++ b/src/ProgesiRepositories.Sqlite/SqliteRepositoryBase.cs
@@ -171,6 +171,31 @@ SELECT 1 WHERE NOT EXISTS(SELECT 1 FROM __SchemaInfo);";
       EnsureContentHash(conn, table);
     }
 
+    // ---------- Geometry helpers (Rhino-free; parity with EF store) ----------
+
+    protected const string ObjectMarkerPrefix = "@OBJECT:";
+
+    protected static bool IsGeometryLike(object? value)
+    {
+      var fullName = value?.GetType().FullName;
+      return fullName != null
+          && fullName.StartsWith("Rhino.Geometry.", StringComparison.Ordinal);
+    }
+
+    protected static string GeometryTypeName(object value) =>
+        value.GetType().FullName ?? string.Empty;
+
+    protected static bool IsObjectMarker(string? value) =>
+        value != null && value.StartsWith(ObjectMarkerPrefix, StringComparison.Ordinal);
+
+    protected static string BuildObjectMarker(string objectType)
+    {
+      var type = (objectType ?? string.Empty).Trim();
+      if (type.Length == 0)
+        throw new ArgumentException("objectType is required", nameof(objectType));
+      return ObjectMarkerPrefix + type;
+    }
+
     // ---------- Value helpers (null-safe) ----------
 
     protected static string TypeOf(object? obj)

--- a/src/ProgesiRepositories.Sqlite/SqliteVariableRepository.cs
+++ b/src/ProgesiRepositories.Sqlite/SqliteVariableRepository.cs
@@ -43,7 +43,9 @@ CREATE TABLE Variables (
     MetadataId   INTEGER NULL,
     MetadataIdsJson TEXT NOT NULL DEFAULT '[]',
     DependsJson  TEXT NOT NULL,
-    ContentHash  TEXT
+    ContentHash  TEXT,
+    ObjectType   TEXT NOT NULL DEFAULT '',
+    ObjectPayloadJson TEXT NOT NULL DEFAULT ''
 );";
           cmd.ExecuteNonQuery();
           _log.Info("[SQLite] Recreated table 'Variables' due to resetSchema=true.");
@@ -66,6 +68,8 @@ CREATE TABLE IF NOT EXISTS Variables (
           // per DB legacy che non avessero ContentHash
           AddColumnIfMissing(conn, "Variables", "ContentHash", "TEXT");
           AddColumnIfMissing(conn, "Variables", "MetadataIdsJson", "TEXT NOT NULL DEFAULT '[]'");
+          AddColumnIfMissing(conn, "Variables", "ObjectType", "TEXT NOT NULL DEFAULT ''");
+          AddColumnIfMissing(conn, "Variables", "ObjectPayloadJson", "TEXT NOT NULL DEFAULT ''");
         }
       }
       EnsureContentHash(conn, "Variables");
@@ -114,12 +118,28 @@ CREATE TABLE IF NOT EXISTS Variables (
         var metadataIds = v.MetadataIds ?? Array.Empty<int>();
         var payloadMetadataIds = JsonConvert.SerializeObject(metadataIds);
 
+        string valueType = TypeOf(v.Value);
+        string storedValue;
+        string objectType = string.Empty;
+        string objectPayloadJson = string.Empty;
+
+        if (IsGeometryLike(v.Value))
+        {
+          objectType = GeometryTypeName(v.Value!);
+          objectPayloadJson = Stringify(v.Value);
+          storedValue = BuildObjectMarker(objectType);
+        }
+        else
+        {
+          storedValue = Stringify(v.Value);
+        }
+
         using (var cmd = conn.CreateCommand())
         {
           cmd.Transaction = tx;
           cmd.CommandText = @"
-INSERT INTO Variables (Id, Name, ValueType, Value, MetadataId, MetadataIdsJson, DependsJson, ContentHash)
-VALUES ($id, $name, $vt, $val, $mid, $mids, $dep, $h)
+INSERT INTO Variables (Id, Name, ValueType, Value, MetadataId, MetadataIdsJson, DependsJson, ContentHash, ObjectType, ObjectPayloadJson)
+VALUES ($id, $name, $vt, $val, $mid, $mids, $dep, $h, $otype, $opayload)
 ON CONFLICT(Id) DO UPDATE SET
   Name=excluded.Name,
   ValueType=excluded.ValueType,
@@ -127,16 +147,20 @@ ON CONFLICT(Id) DO UPDATE SET
   MetadataId=excluded.MetadataId,
   MetadataIdsJson=excluded.MetadataIdsJson,
   DependsJson=excluded.DependsJson,
-  ContentHash=excluded.ContentHash;";
+  ContentHash=excluded.ContentHash,
+  ObjectType=excluded.ObjectType,
+  ObjectPayloadJson=excluded.ObjectPayloadJson;";
           cmd.Parameters.AddWithValue("$id", v.Id);
           cmd.Parameters.AddWithValue("$name", v.Name ?? string.Empty);
-          cmd.Parameters.AddWithValue("$vt", TypeOf(v.Value));
-          cmd.Parameters.AddWithValue("$val", Stringify(v.Value));
+          cmd.Parameters.AddWithValue("$vt", valueType);
+          cmd.Parameters.AddWithValue("$val", storedValue);
           if (v.MetadataId.HasValue) cmd.Parameters.AddWithValue("$mid", v.MetadataId.Value);
           else cmd.Parameters.AddWithValue("$mid", DBNull.Value);
           cmd.Parameters.AddWithValue("$mids", payloadMetadataIds);
           cmd.Parameters.AddWithValue("$dep", payloadDepends);
           cmd.Parameters.AddWithValue("$h", hash);
+          cmd.Parameters.AddWithValue("$otype", objectType);
+          cmd.Parameters.AddWithValue("$opayload", objectPayloadJson);
           var n = await cmd.ExecuteNonQueryAsync(ct);
           _log.Debug($"[SQLite] Variable upsert insert/update: Id={v.Id}, rows affected={n}.");
         }
@@ -182,7 +206,7 @@ ON CONFLICT(Id) DO UPDATE SET
       {
         using var conn = OpenConnection();
         using var cmd = conn.CreateCommand();
-        cmd.CommandText = "SELECT Id, Name, ValueType, Value, MetadataId, MetadataIdsJson, DependsJson FROM Variables WHERE Id=$id;";
+        cmd.CommandText = "SELECT Id, Name, ValueType, Value, MetadataId, MetadataIdsJson, DependsJson, ObjectType, ObjectPayloadJson FROM Variables WHERE Id=$id;";
         cmd.Parameters.AddWithValue("$id", id);
 
         using var r = await cmd.ExecuteReaderAsync(ct);
@@ -199,10 +223,16 @@ ON CONFLICT(Id) DO UPDATE SET
         int? mid = r.IsDBNull(4) ? (int?)null : r.GetInt32(4);
         var metadataIdsJson = r.IsDBNull(5) ? "[]" : r.GetString(5);
         var depJs = r.IsDBNull(6) ? "[]" : r.GetString(6);
+        _ = r.IsDBNull(7) ? string.Empty : r.GetString(7);
+        var objectPayloadJson = r.IsDBNull(8) ? string.Empty : r.GetString(8);
         var depends = JsonConvert.DeserializeObject<int[]>(depJs) ?? Array.Empty<int>();
         var metadataIds = ReadMetadataIds(metadataIdsJson, mid);
 
-        var value = ParseValue(valStr, vType);
+        object? value;
+        if (IsObjectMarker(valStr) && !string.IsNullOrEmpty(objectPayloadJson))
+          value = objectPayloadJson;
+        else
+          value = ParseValue(valStr, vType);
         _log.Debug($"[SQLite] Variable get Id={id}: hit.");
         return new ProgesiVariable(vid, name, value ?? "", depends, metadataIds);
       }, ct: ct);

--- a/tests/Progesi.Repositories.Conformance.Tests/Progesi.Repositories.Conformance.Tests.csproj
+++ b/tests/Progesi.Repositories.Conformance.Tests/Progesi.Repositories.Conformance.Tests.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
@@ -10,9 +11,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\ProgesiCore\ProgesiCore.csproj" />
     <ProjectReference Include="..\..\src\ProgesiRepositories.InMemory\ProgesiRepositories.InMemory.csproj" />
     <ProjectReference Include="..\..\src\ProgesiRepositories.Sqlite\ProgesiRepositories.Sqlite.csproj" />
+    <ProjectReference Include="..\..\src\Progesi.Infrastructure.EF\Progesi.Infrastructure.EF.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,12 +26,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SQLitePCLRaw.core" Version="2.1.10" />
     <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
     <PackageReference Include="SQLitePCLRaw.provider.e_sqlite3" Version="2.1.10" />
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
   </ItemGroup>
 </Project>

--- a/tests/Progesi.Repositories.Conformance.Tests/SqliteEfMetadataParityTests.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/SqliteEfMetadataParityTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using ProgesiCore;
+using Progesi.Repositories.Conformance.Tests.Support;
+
+namespace Progesi.Repositories.Conformance.Tests;
+
+public sealed class SqliteEfMetadataParityTests
+{
+  [Fact]
+  public async Task UpsertAndRead_BasicMetadata_Produces_Equivalent_Results()
+  {
+    using var stores = new SqliteEfMetadataParityStores();
+    var original = ProgesiMetadata.Create("author", "notes", id: 4);
+
+    await stores.Sqlite.UpsertAsync(original);
+    await stores.Ef.UpsertAsync(original);
+
+    var sqliteLoaded = await stores.Sqlite.GetAsync(4);
+    var efLoaded = await stores.Ef.GetAsync(4);
+
+    ParityAssertions.MetadataShouldMatch(sqliteLoaded, efLoaded, original);
+  }
+
+  [Fact]
+  public async Task UpsertAndRead_Metadata_With_References_And_Snips_Produces_Equivalent_Results()
+  {
+    using var stores = new SqliteEfMetadataParityStores();
+    var snip = ProgesiSnip.Create(new byte[] { 1, 2, 3 }, "image/png", "cap");
+    var original = ProgesiMetadata.Create(
+      "me",
+      "meta",
+      new[] { new Uri("https://example.com/a"), new Uri("https://example.com/b") },
+      new[] { snip },
+      id: 5);
+
+    await stores.Sqlite.UpsertAsync(original);
+    await stores.Ef.UpsertAsync(original);
+
+    var sqliteLoaded = await stores.Sqlite.GetAsync(5);
+    var efLoaded = await stores.Ef.GetAsync(5);
+
+    ParityAssertions.MetadataShouldMatch(sqliteLoaded, efLoaded, original);
+  }
+
+  [Fact]
+  public async Task Upsert_Deduplicates_By_ContentHash_With_Identical_Behaviour()
+  {
+    using var stores = new SqliteEfMetadataParityStores();
+    var m1 = ProgesiMetadata.Create("same", "payload", id: 10);
+    var m2 = ProgesiMetadata.Create("same", "payload", id: 11);
+
+    await stores.Sqlite.UpsertAsync(m1);
+    await stores.Ef.UpsertAsync(m1);
+    await stores.Sqlite.UpsertAsync(m2);
+    await stores.Ef.UpsertAsync(m2);
+
+    (await stores.Sqlite.GetAsync(10)).Should().NotBeNull();
+    (await stores.Ef.GetAsync(10)).Should().NotBeNull();
+    (await stores.Sqlite.GetAsync(11)).Should().BeNull();
+    (await stores.Ef.GetAsync(11)).Should().BeNull();
+  }
+
+  [Fact]
+  public async Task GetByHashtagAsync_Returns_Equivalent_Metadata_On_Both_Providers()
+  {
+    using var stores = new SqliteEfMetadataParityStores();
+    var original = ProgesiMetadata.Create("tagged", "info", id: 6);
+
+    await stores.Sqlite.UpsertAsync(original);
+    await stores.Ef.UpsertAsync(original);
+
+    var sqliteLoaded = await stores.Sqlite.GetByHashtagAsync(original.Hashtag);
+    var efLoaded = await stores.Ef.GetByHashtagAsync(original.Hashtag);
+
+    ParityAssertions.MetadataShouldMatch(sqliteLoaded, efLoaded, original);
+  }
+}

--- a/tests/Progesi.Repositories.Conformance.Tests/SqliteEfVariableParityTests.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/SqliteEfVariableParityTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using Newtonsoft.Json;
+using ProgesiCore;
+using Progesi.Repositories.Conformance.Tests.Support;
+using Rhino.Geometry;
+
+namespace Progesi.Repositories.Conformance.Tests;
+
+public sealed class SqliteEfVariableParityTests
+{
+  [Theory]
+  [InlineData("text-value")]
+  [InlineData(42)]
+  [InlineData(3.14)]
+  [InlineData(true)]
+  public async Task SaveAndRead_NonGeometryValue_Produces_Equivalent_Results(object value)
+  {
+    using var stores = new SqliteEfVariableParityStores();
+    var original = new ProgesiVariable(1, "Field", value, new[] { 2, 1 }, metadataIds: new[] { 5, 9 });
+
+    await stores.Sqlite.SaveAsync(original);
+    await stores.Ef.SaveAsync(original);
+
+    var sqliteLoaded = await stores.Sqlite.GetByIdAsync(1);
+    var efLoaded = await stores.Ef.GetByIdAsync(1);
+
+    ParityAssertions.VariablesShouldMatch(sqliteLoaded!, efLoaded!, original);
+  }
+
+  [Fact]
+  public async Task SaveAndRead_GeometryLikeValue_Produces_Equivalent_Payload_And_Hash()
+  {
+    using var stores = new SqliteEfVariableParityStores();
+    var geometry = new FakeCurve();
+    var original = new ProgesiVariable(2, "Curve", geometry, new[] { 4 }, metadataIds: new[] { 7 });
+
+    await stores.Sqlite.SaveAsync(original);
+    await stores.Ef.SaveAsync(original);
+
+    var sqliteLoaded = await stores.Sqlite.GetByIdAsync(2);
+    var efLoaded = await stores.Ef.GetByIdAsync(2);
+
+    ParityAssertions.VariablesShouldMatch(sqliteLoaded!, efLoaded!, original);
+    sqliteLoaded!.Value.Should().Be(JsonConvert.SerializeObject(geometry));
+    efLoaded!.Value.Should().Be(sqliteLoaded.Value);
+  }
+
+  [Fact]
+  public async Task Save_Deduplicates_ContentDuplicate_With_Identical_Behaviour()
+  {
+    using var stores = new SqliteEfVariableParityStores();
+    var v1 = new ProgesiVariable(1, "A", 42, new[] { 3, 1, 2 }, metadataIds: new[] { 7 });
+    var v2 = new ProgesiVariable(2, "A", 42, new[] { 2, 3, 1 }, metadataIds: new[] { 7 });
+
+    await stores.Sqlite.SaveAsync(v1);
+    await stores.Ef.SaveAsync(v1);
+
+    var sqliteDeduped = await stores.Sqlite.SaveAsync(v2);
+    var efDeduped = await stores.Ef.SaveAsync(v2);
+
+    sqliteDeduped.Id.Should().Be(1);
+    efDeduped.Id.Should().Be(1);
+    sqliteDeduped.Id.Should().Be(efDeduped.Id);
+    sqliteDeduped.Hashtag.Should().Be(efDeduped.Hashtag);
+
+    var sqliteByTag = await stores.Sqlite.GetByHashtagAsync(v1.Hashtag);
+    var efByTag = await stores.Ef.GetByHashtagAsync(v1.Hashtag);
+
+    ParityAssertions.VariablesShouldMatch(sqliteByTag!, efByTag!, v1);
+  }
+
+  [Fact]
+  public async Task GetByHashtagAsync_Returns_Equivalent_Variable_On_Both_Providers()
+  {
+    using var stores = new SqliteEfVariableParityStores();
+    var original = new ProgesiVariable(3, "Tagged", "payload", metadataIds: new[] { 2 });
+
+    await stores.Sqlite.SaveAsync(original);
+    await stores.Ef.SaveAsync(original);
+
+    var sqliteLoaded = await stores.Sqlite.GetByHashtagAsync(original.Hashtag);
+    var efLoaded = await stores.Ef.GetByHashtagAsync(original.Hashtag);
+
+    ParityAssertions.VariablesShouldMatch(sqliteLoaded!, efLoaded!, original);
+  }
+}

--- a/tests/Progesi.Repositories.Conformance.Tests/Support/FakeRhinoGeometryTypes.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/Support/FakeRhinoGeometryTypes.cs
@@ -1,0 +1,6 @@
+namespace Rhino.Geometry;
+
+public sealed class FakeCurve
+{
+  public double[] Pts { get; set; } = new[] { 0.0, 1.0 };
+}

--- a/tests/Progesi.Repositories.Conformance.Tests/Support/ParityAssertions.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/Support/ParityAssertions.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using ProgesiCore;
+
+namespace Progesi.Repositories.Conformance.Tests.Support;
+
+internal static class ParityAssertions
+{
+  public static void VariablesShouldMatch(ProgesiVariable sqlite, ProgesiVariable ef, ProgesiVariable original)
+  {
+    sqlite.Should().NotBeNull();
+    ef.Should().NotBeNull();
+
+    sqlite!.Name.Should().Be(ef!.Name);
+    sqlite.Value.Should().Be(ef.Value);
+    sqlite.DependsFrom.Should().BeEquivalentTo(ef.DependsFrom);
+    sqlite.MetadataIds.Should().Equal(ef.MetadataIds);
+
+    ProgesiHash.Compute(sqlite).Should().Be(ProgesiHash.Compute(ef));
+    ProgesiHash.Compute(sqlite).Should().Be(ProgesiHash.Compute(original));
+    sqlite.Hashtag.Should().Be(ef.Hashtag);
+  }
+
+  public static void MetadataShouldMatch(ProgesiMetadata? sqlite, ProgesiMetadata? ef, ProgesiMetadata original)
+  {
+    sqlite.Should().NotBeNull();
+    ef.Should().NotBeNull();
+
+    sqlite!.CreatedBy.Should().Be(ef!.CreatedBy);
+    sqlite.AdditionalInfo.Should().Be(ef.AdditionalInfo);
+    sqlite.Hashtag.Should().Be(ef.Hashtag);
+    sqlite.Hashtag.Should().Be(original.Hashtag);
+
+    var sqliteRefs = (sqlite.References ?? Array.Empty<Uri>()).Select(u => u.ToString()).OrderBy(s => s).ToArray();
+    var efRefs = (ef.References ?? Array.Empty<Uri>()).Select(u => u.ToString()).OrderBy(s => s).ToArray();
+    sqliteRefs.Should().Equal(efRefs);
+
+    sqlite.Snips.Should().HaveCount(ef.Snips?.Count ?? 0);
+    if (sqlite.Snips != null && ef.Snips != null)
+    {
+      for (int i = 0; i < sqlite.Snips.Count; i++)
+      {
+        sqlite.Snips[i].MimeType.Should().Be(ef.Snips[i].MimeType);
+        sqlite.Snips[i].Caption.Should().Be(ef.Snips[i].Caption);
+        sqlite.Snips[i].Content.Should().Equal(ef.Snips[i].Content);
+      }
+    }
+  }
+}

--- a/tests/Progesi.Repositories.Conformance.Tests/Support/SqliteEfParityStores.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/Support/SqliteEfParityStores.cs
@@ -1,0 +1,79 @@
+using ProgesiCore;
+using Progesi.Infrastructure.EF.Repositories;
+using ProgesiRepositories.Sqlite;
+
+namespace Progesi.Repositories.Conformance.Tests.Support;
+
+internal sealed class SqliteEfVariableParityStores : IDisposable
+{
+  private readonly string _sqlitePath;
+  private readonly string _efConnectionString;
+
+  public IVariableRepository Sqlite { get; }
+  public IVariableRepository Ef { get; }
+
+  public SqliteEfVariableParityStores()
+  {
+    SqliteTestBootstrap.EnsureInitialized();
+    _sqlitePath = Path.Combine(Path.GetTempPath(), $"progesi_parity_sqlite_{Guid.NewGuid():N}.sqlite");
+    _efConnectionString = $"Data Source={Path.Combine(Path.GetTempPath(), $"progesi_parity_ef_{Guid.NewGuid():N}.sqlite")}";
+
+    Sqlite = new SqliteVariableRepository(_sqlitePath, resetSchema: true);
+    Ef = new EfVariableRepository(_efConnectionString, resetSchema: true);
+  }
+
+  public void Dispose()
+  {
+    TryDelete(_sqlitePath);
+    TryDelete(_efConnectionString.Replace("Data Source=", string.Empty));
+  }
+
+  private static void TryDelete(string path)
+  {
+    try
+    {
+      if (File.Exists(path)) File.Delete(path);
+    }
+    catch
+    {
+      // best-effort cleanup
+    }
+  }
+}
+
+internal sealed class SqliteEfMetadataParityStores : IDisposable
+{
+  private readonly string _sqlitePath;
+  private readonly string _efConnectionString;
+
+  public IMetadataRepository Sqlite { get; }
+  public IMetadataRepository Ef { get; }
+
+  public SqliteEfMetadataParityStores()
+  {
+    SqliteTestBootstrap.EnsureInitialized();
+    _sqlitePath = Path.Combine(Path.GetTempPath(), $"progesi_parity_meta_sqlite_{Guid.NewGuid():N}.db");
+    _efConnectionString = $"Data Source={Path.Combine(Path.GetTempPath(), $"progesi_parity_meta_ef_{Guid.NewGuid():N}.sqlite")}";
+
+    Sqlite = new SqliteMetadataRepository(_sqlitePath, resetSchema: true);
+    Ef = new EfMetadataRepository(_efConnectionString, resetSchema: true);
+  }
+
+  public void Dispose()
+  {
+    TryDelete(_sqlitePath);
+    TryDelete(_efConnectionString.Replace("Data Source=", string.Empty));
+  }
+
+  private static void TryDelete(string path)
+  {
+    try
+    {
+      if (File.Exists(path)) File.Delete(path);
+    }
+    catch
+    {
+      // best-effort cleanup
+    }
+  }
+}


### PR DESCRIPTION
Phase 2 per the Accepted Persistence Architecture ADR (Option C). Cross-provider conformance suite proving SQLite<->EF representational parity (variables incl. geometry, metadata, dedup, GetByHashtag; +11 tests). Real divergence fixed: direct-SQLite now matches EF geometry storage (ObjectType/ObjectPayloadJson + @OBJECT marker; back-compat). Conformance project retargeted net48->net8.0 + EF ref. By-design: no SQLite/EF cluster repo -> cluster parity N/A. CI-coverable (Rhino-free); no manual GH. Build 0 errors; 314 passed, 19 skipped. Do NOT merge until Claude review + human go.