### PR TITLE
fix(sec): patched e_sqlite3 3.53.3 in x64 plugin (GHSA-2m69-gcr7-jv3q) - Rhino smoke gated

### DIFF
--- a/Deploy-Progesi-GHA.ps1
+++ b/Deploy-Progesi-GHA.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = "Stop"
 
 # 1) percorsi di origine
 $RepoRoot    = Split-Path -Parent $MyInvocation.MyCommand.Path
-$AsmDir      = Join-Path $RepoRoot "src\ProgesiGrasshopperAssembly\bin\$Config\$Tf"
+$AsmDir      = Join-Path $RepoRoot "src\ProgesiGrasshopperAssembly\bin\$Config\$Tf\win-x64"
 
 if (-not (Test-Path $AsmDir)) {
   throw "Cartella di build non trovata: $AsmDir (hai fatto 'dotnet build -c $Config'?)"

--- a/src/ProgesiGrasshopperAssembly/ProgesiGrasshopperAssembly.csproj
+++ b/src/ProgesiGrasshopperAssembly/ProgesiGrasshopperAssembly.csproj
@@ -5,6 +5,9 @@
     <LangVersion>8.0</LangVersion>
     <Nullable>disable</Nullable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PlatformTarget>x64</PlatformTarget>
+    <Prefer32Bit>false</Prefer32Bit>
     <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3277</MSBuildWarningsAsMessages>
   </PropertyGroup>
 
@@ -23,6 +26,10 @@
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="ClosedXML" Version="0.104.0" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
+    <PackageReference Include="SQLitePCLRaw.core" Version="3.0.5" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
+    <PackageReference Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.5" />
   </ItemGroup>
 
   <!-- Librerie Progesi usate dal plugin -->
@@ -49,6 +56,23 @@
       <BuiltDll Include="$(OutDir)$(AssemblyName).dll" />
     </ItemGroup>
     <Copy SourceFiles="@(BuiltDll)" DestinationFiles="$(OutDir)$(AssemblyName).gha" SkipUnchangedFiles="true" />
+  </Target>
+
+  <!-- Ensure patched x64 e_sqlite3 (3.53.3) wins over transitive 2.1.11 from ProgesiRepositories.Sqlite -->
+  <Target Name="CopyPatchedESqlite3Native" AfterTargets="Build">
+    <PropertyGroup>
+      <PatchedESqlite3Source>$(NuGetPackageRoot)sqlitepclraw.lib.e_sqlite3\3.53.3\runtimes\win-x64\native\e_sqlite3.dll</PatchedESqlite3Source>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(PatchedESqlite3Source)')"
+           Text="Patched e_sqlite3 native not found at $(PatchedESqlite3Source)" />
+    <MakeDir Directories="$(OutDir)runtimes\win-x64\native" />
+    <Copy SourceFiles="$(PatchedESqlite3Source)"
+          DestinationFiles="$(OutDir)runtimes\win-x64\native\e_sqlite3.dll"
+          SkipUnchangedFiles="false" />
+    <RemoveDir Directories="$(OutDir)runtimes\win-arm;$(OutDir)runtimes\win-x86" Condition="Exists('$(OutDir)runtimes\win-arm')" />
+    <Copy SourceFiles="$(PatchedESqlite3Source)"
+          DestinationFiles="$(OutDir)e_sqlite3.dll"
+          SkipUnchangedFiles="false" />
   </Target>
 
 </Project>

--- a/src/ProgesiRepositories.Sqlite/ProgesiRepositories.Sqlite.csproj
+++ b/src/ProgesiRepositories.Sqlite/ProgesiRepositories.Sqlite.csproj
@@ -17,6 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PlatformTarget>x64</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>


### PR DESCRIPTION
Full plugin remediation of GHSA-2m69-gcr7-jv3q (path (a), x64-only). The deployed .gha now ships the patched native e_sqlite3 3.53.3 (confirmed in output; hash matches). Build 0 errors, no NU1903, 314 pass + 19 stress skipped. DEVIATION (per constraints): the Sqlite repo stays at SQLitePCLRaw 2.1.11 (bumping it broke Any-CPU Browsers + NU1605 vs tests) - the patched native is forced via the GH assembly explicit 3.0.5 packages + a copy target. RUNTIME CAVEAT: the plugin mixes Microsoft.Data.Sqlite 7.0.20 with SQLitePCLRaw 3.0.5 managed + 3.53.3 native, a combo CI does NOT cover. MANDATORY Rhino GH smoke before merge (plugin loads x64 + DataEx SQLite round-trip incl. geometry; no e_sqlite3/BadImageFormat/DllNotFound). Do NOT merge on CI alone.