### PR TITLE
feat(cluster): SQLite persistence for ProgesiVariableCluster (Phase 2)

### DIFF
--- a/src/ProgesiRepositories.Sqlite/SqliteClusterRepository.cs
+++ b/src/ProgesiRepositories.Sqlite/SqliteClusterRepository.cs
@@ -1,0 +1,284 @@
+#nullable enable
+using Microsoft.Data.Sqlite;
+using Newtonsoft.Json;
+using ProgesiCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ProgesiRepositories.Sqlite
+{
+  public sealed class SqliteClusterRepository : SqliteRepositoryBase, IProgesiVariableClusterRepository
+  {
+    public SqliteClusterRepository(string dbPath, bool resetSchema = false)
+        : base(dbPath, resetSchema)
+    {
+      EnsureSchema();
+    }
+
+    public SqliteClusterRepository(string dbPath, bool resetSchema, IProgesiLogger logger)
+        : base(dbPath, resetSchema, logger)
+    {
+      EnsureSchema();
+    }
+
+    private void EnsureSchema()
+    {
+      using var conn = OpenConnection();
+      using (var cmd = conn.CreateCommand())
+      {
+        if (_resetSchema)
+        {
+          cmd.CommandText = @"
+DROP TABLE IF EXISTS Clusters;
+
+CREATE TABLE Clusters (
+    Id              INTEGER PRIMARY KEY,
+    Name            TEXT NOT NULL,
+    Description     TEXT NOT NULL DEFAULT '',
+    VariableIdsJson TEXT NOT NULL DEFAULT '[]',
+    ContentHash     TEXT NOT NULL,
+    Hashtag         TEXT NOT NULL DEFAULT ''
+);";
+          cmd.ExecuteNonQuery();
+          _log.Info("[SQLite] Recreated table 'Clusters' due to resetSchema=true.");
+        }
+        else
+        {
+          cmd.CommandText = @"
+CREATE TABLE IF NOT EXISTS Clusters (
+    Id              INTEGER PRIMARY KEY,
+    Name            TEXT NOT NULL,
+    Description     TEXT NOT NULL DEFAULT '',
+    VariableIdsJson TEXT NOT NULL DEFAULT '[]',
+    ContentHash     TEXT NOT NULL,
+    Hashtag         TEXT NOT NULL DEFAULT ''
+);";
+          cmd.ExecuteNonQuery();
+
+          AddColumnIfMissing(conn, "Clusters", "Description", "TEXT NOT NULL DEFAULT ''");
+          AddColumnIfMissing(conn, "Clusters", "VariableIdsJson", "TEXT NOT NULL DEFAULT '[]'");
+          AddColumnIfMissing(conn, "Clusters", "ContentHash", "TEXT NOT NULL DEFAULT ''");
+          AddColumnIfMissing(conn, "Clusters", "Hashtag", "TEXT NOT NULL DEFAULT ''");
+        }
+      }
+
+      EnsureSchemaInfoAndCleanup(conn, "Clusters");
+
+      using (var idx = conn.CreateCommand())
+      {
+        idx.CommandText = "CREATE INDEX IF NOT EXISTS IX_Clusters_Hashtag ON Clusters(Hashtag);";
+        idx.ExecuteNonQuery();
+      }
+    }
+
+    public Task<ProgesiVariableCluster> SaveAsync(ProgesiVariableCluster cluster, CancellationToken ct = default)
+        => SaveInternalAsync(cluster, ct);
+
+    private Task<ProgesiVariableCluster> SaveInternalAsync(ProgesiVariableCluster cluster, CancellationToken ct)
+    {
+      if (cluster is null) throw new ArgumentNullException(nameof(cluster));
+
+      return WithRetryAsync(async () =>
+      {
+        using var conn = OpenConnection();
+        using var tx = conn.BeginTransaction();
+
+        var hash = ProgesiHash.Compute(cluster);
+
+        int? existingId = null;
+        using (var find = conn.CreateCommand())
+        {
+          find.Transaction = tx;
+          find.CommandText = "SELECT Id FROM Clusters WHERE ContentHash=$h LIMIT 1;";
+          find.Parameters.AddWithValue("$h", hash);
+          var obj = await find.ExecuteScalarAsync(ct);
+          if (obj != null && obj != DBNull.Value)
+            existingId = Convert.ToInt32(obj);
+        }
+
+        if (existingId.HasValue && existingId.Value != cluster.Id)
+        {
+          tx.Commit();
+          _log.Debug($"[SQLite] Cluster upsert dedup: reused Id={existingId.Value} for ContentHash={hash}.");
+          return (await GetByIdAsync(existingId.Value, ct))!;
+        }
+
+        var variableIdsJson = JsonConvert.SerializeObject(cluster.ProgesiVariableIds.ToArray());
+        var hashtag = cluster.Hashtag ?? string.Empty;
+
+        using (var cmd = conn.CreateCommand())
+        {
+          cmd.Transaction = tx;
+          cmd.CommandText = @"
+INSERT INTO Clusters (Id, Name, Description, VariableIdsJson, ContentHash, Hashtag)
+VALUES ($id, $name, $desc, $vids, $h, $tag)
+ON CONFLICT(Id) DO UPDATE SET
+  Name=excluded.Name,
+  Description=excluded.Description,
+  VariableIdsJson=excluded.VariableIdsJson,
+  ContentHash=excluded.ContentHash,
+  Hashtag=excluded.Hashtag;";
+          cmd.Parameters.AddWithValue("$id", cluster.Id);
+          cmd.Parameters.AddWithValue("$name", cluster.Name ?? string.Empty);
+          cmd.Parameters.AddWithValue("$desc", cluster.Description ?? string.Empty);
+          cmd.Parameters.AddWithValue("$vids", variableIdsJson);
+          cmd.Parameters.AddWithValue("$h", hash);
+          cmd.Parameters.AddWithValue("$tag", hashtag);
+          var n = await cmd.ExecuteNonQueryAsync(ct);
+          _log.Debug($"[SQLite] Cluster upsert insert/update: Id={cluster.Id}, rows affected={n}.");
+        }
+
+        tx.Commit();
+        return (await GetByIdAsync(cluster.Id, ct))!;
+      }, ct: ct);
+    }
+
+    public async Task<ProgesiVariableCluster?> GetByIdAsync(int id, CancellationToken ct = default)
+    {
+      return await WithRetryAsync(async () =>
+      {
+        using var conn = OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+SELECT Id, Name, Description, VariableIdsJson, Hashtag
+FROM Clusters WHERE Id=$id;";
+        cmd.Parameters.AddWithValue("$id", id);
+
+        using var r = await cmd.ExecuteReaderAsync(ct);
+        if (!await r.ReadAsync(ct))
+        {
+          _log.Debug($"[SQLite] Cluster get Id={id}: not found.");
+          return null;
+        }
+
+        var clusterId = r.GetInt32(0);
+        var name = r.GetString(1);
+        var description = r.IsDBNull(2) ? string.Empty : r.GetString(2);
+        var variableIdsJson = r.IsDBNull(3) ? "[]" : r.GetString(3);
+        var hashtag = r.IsDBNull(4) ? null : r.GetString(4);
+
+        var ids = JsonConvert.DeserializeObject<int[]>(variableIdsJson) ?? Array.Empty<int>();
+        _log.Debug($"[SQLite] Cluster get Id={id}: hit.");
+        return ProgesiVariableCluster.Rehydrate(clusterId, name, ids, description, hashtag);
+      }, ct: ct);
+    }
+
+    public async Task<ProgesiVariableCluster?> GetByHashtagAsync(string hashtag, CancellationToken ct = default)
+    {
+      if (string.IsNullOrWhiteSpace(hashtag))
+        return null;
+
+      return await WithRetryAsync(async () =>
+      {
+        using var conn = OpenConnection();
+
+        int? id = null;
+        using (var cmd = conn.CreateCommand())
+        {
+          cmd.CommandText = "SELECT Id FROM Clusters WHERE Hashtag=$h LIMIT 1;";
+          cmd.Parameters.AddWithValue("$h", hashtag);
+          var scalar = await cmd.ExecuteScalarAsync(ct);
+          if (scalar != null && scalar != DBNull.Value)
+            id = Convert.ToInt32(scalar);
+        }
+
+        if (!id.HasValue)
+        {
+          using var cmd = conn.CreateCommand();
+          cmd.CommandText = "SELECT Id, Name, VariableIdsJson FROM Clusters ORDER BY Id;";
+          using var r = await cmd.ExecuteReaderAsync(ct);
+          while (await r.ReadAsync(ct))
+          {
+            var rowId = r.GetInt32(0);
+            var name = r.GetString(1);
+            var variableIdsJson = r.IsDBNull(2) ? "[]" : r.GetString(2);
+            var ids = JsonConvert.DeserializeObject<int[]>(variableIdsJson) ?? Array.Empty<int>();
+            var legacy = ProgesiVariableCluster.BuildLegacyHashtag(rowId, name, ids);
+            if (string.Equals(legacy, hashtag, StringComparison.Ordinal))
+            {
+              id = rowId;
+              break;
+            }
+          }
+        }
+
+        if (!id.HasValue)
+        {
+          _log.Debug("[SQLite] Cluster get by hashtag: miss.");
+          return null;
+        }
+
+        return await GetByIdAsync(id.Value, ct);
+      }, ct: ct);
+    }
+
+    public async Task<IReadOnlyList<ProgesiVariableCluster>> GetAllAsync(CancellationToken ct = default)
+    {
+      return await WithRetryAsync(async () =>
+      {
+        var list = new List<ProgesiVariableCluster>();
+        using var conn = OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT Id FROM Clusters ORDER BY Id;";
+
+        using var r = await cmd.ExecuteReaderAsync(ct);
+        var ids = new List<int>();
+        while (await r.ReadAsync(ct))
+          ids.Add(r.GetInt32(0));
+
+        foreach (var id in ids)
+        {
+          var cluster = await GetByIdAsync(id, ct);
+          if (cluster != null)
+            list.Add(cluster);
+        }
+
+        _log.Debug($"[SQLite] Cluster list count={list.Count}.");
+        return (IReadOnlyList<ProgesiVariableCluster>)list;
+      }, ct: ct);
+    }
+
+    public async Task<bool> DeleteAsync(int id, CancellationToken ct = default)
+    {
+      return await WithRetryAsync(async () =>
+      {
+        using var conn = OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "DELETE FROM Clusters WHERE Id=$id;";
+        cmd.Parameters.AddWithValue("$id", id);
+        var n = await cmd.ExecuteNonQueryAsync(ct);
+        var ok = n > 0;
+        _log.Debug($"[SQLite] Cluster delete Id={id}: {(ok ? "deleted" : "not found")}.");
+        return ok;
+      }, ct: ct);
+    }
+
+    public async Task<int> DeleteManyAsync(IEnumerable<int> idsToDelete, CancellationToken ct = default)
+    {
+      if (idsToDelete == null) return 0;
+      var ids = idsToDelete.ToArray();
+      if (ids.Length == 0) return 0;
+
+      return await WithRetryAsync(async () =>
+      {
+        using var conn = OpenConnection();
+        using var tx = conn.BeginTransaction();
+        int count = 0;
+        foreach (var id in ids)
+        {
+          using var cmd = conn.CreateCommand();
+          cmd.Transaction = tx;
+          cmd.CommandText = "DELETE FROM Clusters WHERE Id=$id;";
+          cmd.Parameters.AddWithValue("$id", id);
+          count += await cmd.ExecuteNonQueryAsync(ct);
+        }
+        tx.Commit();
+        _log.Debug($"[SQLite] Cluster delete-many count={count} (requested={ids.Length}).");
+        return count;
+      }, ct: ct);
+    }
+  }
+}

--- a/tests/ProgesiCore.Tests/ProgesiCore.Tests.csproj
+++ b/tests/ProgesiCore.Tests/ProgesiCore.Tests.csproj
@@ -4,14 +4,22 @@
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\ProgesiCore\ProgesiCore.csproj" />
     <ProjectReference Include="..\..\src\ProgesiRepositories.InMemory\ProgesiRepositories.InMemory.csproj" />
+    <ProjectReference Include="..\..\src\ProgesiRepositories.Sqlite\ProgesiRepositories.Sqlite.csproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" />
+    <PackageReference Include="SQLitePCLRaw.core" Version="2.1.11" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
+    <PackageReference Include="SQLitePCLRaw.provider.e_sqlite3" Version="2.1.11" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/ProgesiCore.Tests/SqliteClusterRepositoryTests.cs
+++ b/tests/ProgesiCore.Tests/SqliteClusterRepositoryTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ProgesiCore;
+using ProgesiRepositories.Sqlite;
+using SQLitePCL;
+using Xunit;
+
+namespace ProgesiCore.Tests
+{
+  public class SqliteClusterRepositoryTests : IDisposable
+  {
+    private readonly string _dbPath;
+    private readonly SqliteClusterRepository _repo;
+
+    static SqliteClusterRepositoryTests()
+    {
+      raw.SetProvider(new SQLite3Provider_e_sqlite3());
+      Batteries_V2.Init();
+    }
+
+    public SqliteClusterRepositoryTests()
+    {
+      _dbPath = Path.Combine(Path.GetTempPath(), $"progesi_cluster_{Guid.NewGuid():N}.sqlite");
+      _repo = new SqliteClusterRepository(_dbPath, resetSchema: true);
+    }
+
+    [Fact]
+    public async Task SaveAsync_Then_GetByIdAsync_RoundTrips_Cluster()
+    {
+      var cluster = ProgesiVariableCluster.Rehydrate(7, "RepoC", new[] { 2, 1 }, "desc");
+
+      await _repo.SaveAsync(cluster);
+      var loaded = await _repo.GetByIdAsync(7);
+
+      loaded.Should().NotBeNull();
+      loaded!.Id.Should().Be(7);
+      loaded.Name.Should().Be("RepoC");
+      loaded.Description.Should().Be("desc");
+      loaded.ProgesiVariableIds.Should().Equal(1, 2);
+      loaded.Hashtag.Should().Be(cluster.Hashtag);
+      ProgesiHash.Compute(loaded).Should().Be(ProgesiHash.Compute(cluster));
+    }
+
+    [Fact]
+    public async Task GetByHashtagAsync_Finds_Saved_Cluster_By_Current_Hashtag()
+    {
+      var cluster = ProgesiVariableCluster.Rehydrate(3, "HashC", new[] { 9 }, null);
+      await _repo.SaveAsync(cluster);
+
+      var loaded = await _repo.GetByHashtagAsync(cluster.Hashtag);
+
+      loaded.Should().NotBeNull();
+      loaded!.Id.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GetByHashtagAsync_Finds_Saved_Cluster_By_Legacy_Hashtag()
+    {
+      var cluster = ProgesiVariableCluster.Rehydrate(5, "LegacyC", new[] { 4, 8 }, "note");
+      await _repo.SaveAsync(cluster);
+
+      var legacy = ProgesiVariableCluster.BuildLegacyHashtag(
+        cluster.Id,
+        cluster.Name,
+        cluster.ProgesiVariableIds);
+
+      var loaded = await _repo.GetByHashtagAsync(legacy);
+
+      loaded.Should().NotBeNull();
+      loaded!.Id.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task GetByHashtagAsync_Returns_Null_For_Empty_Or_Whitespace_Hashtag()
+    {
+      await _repo.SaveAsync(ProgesiVariableCluster.Rehydrate(1, "A", new[] { 1 }, null));
+
+      (await _repo.GetByHashtagAsync("")).Should().BeNull();
+      (await _repo.GetByHashtagAsync("   ")).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SaveAsync_Deduplicates_By_ContentHash()
+    {
+      var first = ProgesiVariableCluster.Rehydrate(1, "Dup", new[] { 3, 1, 2 }, "same");
+      await _repo.SaveAsync(first);
+
+      var second = ProgesiVariableCluster.Rehydrate(2, "Dup", new[] { 2, 3, 1 }, "same");
+      var returned = await _repo.SaveAsync(second);
+
+      returned.Id.Should().Be(1);
+
+      var all = await _repo.GetAllAsync();
+      all.Should().HaveCount(1);
+      all[0].Id.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_Returns_Clusters_Ordered_By_Id()
+    {
+      await _repo.SaveAsync(ProgesiVariableCluster.Rehydrate(2, "B", new[] { 2 }, null));
+      await _repo.SaveAsync(ProgesiVariableCluster.Rehydrate(1, "A", new[] { 1 }, null));
+
+      var all = await _repo.GetAllAsync();
+
+      all.Should().HaveCount(2);
+      all.Select(c => c.Id).Should().Equal(1, 2);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Removes_Existing_Cluster()
+    {
+      await _repo.SaveAsync(ProgesiVariableCluster.Rehydrate(4, "Del", new[] { 1 }, null));
+
+      (await _repo.DeleteAsync(4)).Should().BeTrue();
+      (await _repo.GetByIdAsync(4)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Returns_False_When_Not_Found()
+    {
+      (await _repo.DeleteAsync(999)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeleteManyAsync_Removes_Only_Existing_Ids()
+    {
+      await _repo.SaveAsync(ProgesiVariableCluster.Rehydrate(1, "A", new[] { 1 }, null));
+      await _repo.SaveAsync(ProgesiVariableCluster.Rehydrate(2, "B", new[] { 2 }, null));
+
+      var removed = await _repo.DeleteManyAsync(new[] { 1, 99, 2 });
+
+      removed.Should().Be(2);
+      (await _repo.GetAllAsync()).Should().BeEmpty();
+    }
+
+    public void Dispose()
+    {
+      try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+  }
+}


### PR DESCRIPTION
## ProgesiVariableCluster Phase 2 — SQLite persistence

Implements the **existing** `IProgesiVariableClusterRepository` over SQLite, mirroring the proven `SqliteVariableRepository`/`SqliteMetadataRepository` pattern. Authorised by the 2026-07-29 block-lift (Red decision, #96).

### Added
- `src/ProgesiRepositories.Sqlite/SqliteClusterRepository.cs` — WAL/`WithRetryAsync`, ContentHash dedup (existing hash + different Id → return existing), `ON CONFLICT(Id)` upsert, `Clusters` table + `IX_Clusters_Hashtag`, current + legacy hashtag lookup.
- `tests/ProgesiCore.Tests/SqliteClusterRepositoryTests.cs` — 9 unit tests (round-trip + hash stability, current/legacy hashtag, empty-hashtag null, ContentHash dedup, ordering, delete, delete-many).

### Changed
- `tests/ProgesiCore.Tests/ProgesiCore.Tests.csproj` — project ref to the SQLite repo + patched **x64 `lib.e_sqlite3` 3.53.3** native (established PR #94 pattern; no NU1903).

### Scope / safety
- `IProgesiVariableClusterRepository` unchanged; **ProgesiCore domain/service, EF, DataExchange, AxisVar, CI all untouched.**
- Tests: **314 → 323** (+9), 19 stress skipped, 0 failed.

Phase 3 (EF + SQLite↔EF cluster parity) is sequenced to follow this merge.