### PR TITLE
feat(cluster): EF persistence + SQLite<->EF parity for ProgesiVariableCluster (Phase 3)

### DIFF
--- a/src/Progesi.Infrastructure.EF/Entities/ClusterEntity.cs
+++ b/src/Progesi.Infrastructure.EF/Entities/ClusterEntity.cs
@@ -1,0 +1,11 @@
+namespace Progesi.Infrastructure.EF.Entities;
+
+public sealed class ClusterEntity
+{
+  public int Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public string Description { get; set; } = string.Empty;
+  public string VariableIdsJson { get; set; } = "[]";
+  public string ContentHash { get; set; } = string.Empty;
+  public string Hashtag { get; set; } = string.Empty;
+}

--- a/src/Progesi.Infrastructure.EF/Migrations/20260729141644_R2C3_AddClustersTable.Designer.cs
+++ b/src/Progesi.Infrastructure.EF/Migrations/20260729141644_R2C3_AddClustersTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Progesi.Infrastructure.EF;
 
@@ -10,9 +11,11 @@ using Progesi.Infrastructure.EF;
 namespace Progesi.Infrastructure.EF.Migrations
 {
     [DbContext(typeof(ProgesiDbContext))]
-    partial class ProgesiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260729141644_R2C3_AddClustersTable")]
+    partial class R2C3_AddClustersTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.11");

--- a/src/Progesi.Infrastructure.EF/Migrations/20260729141644_R2C3_AddClustersTable.cs
+++ b/src/Progesi.Infrastructure.EF/Migrations/20260729141644_R2C3_AddClustersTable.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Progesi.Infrastructure.EF.Migrations
+{
+    /// <inheritdoc />
+    public partial class R2C3_AddClustersTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Clusters",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    Description = table.Column<string>(type: "TEXT", nullable: false, defaultValue: ""),
+                    VariableIdsJson = table.Column<string>(type: "TEXT", nullable: false),
+                    ContentHash = table.Column<string>(type: "TEXT", nullable: false),
+                    Hashtag = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Clusters", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Clusters_ContentHash",
+                table: "Clusters",
+                column: "ContentHash",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Clusters_Hashtag",
+                table: "Clusters",
+                column: "Hashtag");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Clusters");
+        }
+    }
+}

--- a/src/Progesi.Infrastructure.EF/ProgesiDbContext.cs
+++ b/src/Progesi.Infrastructure.EF/ProgesiDbContext.cs
@@ -12,6 +12,7 @@ public sealed class ProgesiDbContext : DbContext
 
   public DbSet<VariableEntity> Variables => Set<VariableEntity>();
   public DbSet<MetadataEntity> Metadata => Set<MetadataEntity>();
+  public DbSet<ClusterEntity> Clusters => Set<ClusterEntity>();
 
   protected override void OnModelCreating(ModelBuilder modelBuilder)
   {
@@ -38,6 +39,19 @@ public sealed class ProgesiDbContext : DbContext
       entity.Property(e => e.LastModified).IsRequired();
       entity.Property(e => e.ContentHash).IsRequired();
       entity.HasIndex(e => e.ContentHash).IsUnique();
+    });
+
+    modelBuilder.Entity<ClusterEntity>(entity =>
+    {
+      entity.ToTable("Clusters");
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.Name).IsRequired();
+      entity.Property(e => e.Description).HasDefaultValue(string.Empty);
+      entity.Property(e => e.VariableIdsJson).IsRequired();
+      entity.Property(e => e.ContentHash).IsRequired();
+      entity.Property(e => e.Hashtag).IsRequired();
+      entity.HasIndex(e => e.ContentHash).IsUnique();
+      entity.HasIndex(e => e.Hashtag);
     });
   }
 }

--- a/src/Progesi.Infrastructure.EF/Repositories/EfClusterRepository.cs
+++ b/src/Progesi.Infrastructure.EF/Repositories/EfClusterRepository.cs
@@ -1,0 +1,161 @@
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using ProgesiCore;
+using Progesi.Infrastructure.EF.Entities;
+
+namespace Progesi.Infrastructure.EF.Repositories;
+
+public sealed class EfClusterRepository : IProgesiVariableClusterRepository
+{
+  private readonly ProgesiDbContext _context;
+  private readonly bool _ownsContext;
+
+  public EfClusterRepository(ProgesiDbContext context, bool ownsContext = false)
+  {
+    _context = context ?? throw new ArgumentNullException(nameof(context));
+    _ownsContext = ownsContext;
+  }
+
+  public EfClusterRepository(string connectionString, bool resetSchema = false)
+      : this(ProgesiDbContextFactory.Create(connectionString, resetSchema), ownsContext: true)
+  {
+  }
+
+  public async Task<ProgesiVariableCluster> SaveAsync(ProgesiVariableCluster cluster, CancellationToken ct = default)
+  {
+    if (cluster is null) throw new ArgumentNullException(nameof(cluster));
+
+    var hash = ProgesiHash.Compute(cluster);
+
+    var existing = await _context.Clusters
+        .AsNoTracking()
+        .Where(c => c.ContentHash == hash)
+        .Select(c => new { c.Id })
+        .FirstOrDefaultAsync(ct);
+
+    if (existing != null && existing.Id != cluster.Id)
+    {
+      return (await GetByIdAsync(existing.Id, ct))!;
+    }
+
+    var variableIdsJson = JsonConvert.SerializeObject(cluster.ProgesiVariableIds.ToArray());
+    var hashtag = cluster.Hashtag ?? string.Empty;
+    var entity = await _context.Clusters.FindAsync(new object[] { cluster.Id }, ct);
+
+    if (entity == null)
+    {
+      entity = new ClusterEntity { Id = cluster.Id };
+      _context.Clusters.Add(entity);
+    }
+
+    entity.Name = cluster.Name ?? string.Empty;
+    entity.Description = cluster.Description ?? string.Empty;
+    entity.VariableIdsJson = variableIdsJson;
+    entity.ContentHash = hash;
+    entity.Hashtag = hashtag;
+
+    await _context.SaveChangesAsync(ct);
+
+    return (await GetByIdAsync(cluster.Id, ct))!;
+  }
+
+  public async Task<ProgesiVariableCluster?> GetByIdAsync(int id, CancellationToken ct = default)
+  {
+    var entity = await _context.Clusters
+        .AsNoTracking()
+        .FirstOrDefaultAsync(c => c.Id == id, ct);
+
+    if (entity == null) return null;
+
+    var ids = JsonConvert.DeserializeObject<int[]>(entity.VariableIdsJson) ?? Array.Empty<int>();
+    return ProgesiVariableCluster.Rehydrate(
+        entity.Id,
+        entity.Name,
+        ids,
+        entity.Description,
+        entity.Hashtag);
+  }
+
+  public async Task<ProgesiVariableCluster?> GetByHashtagAsync(string hashtag, CancellationToken ct = default)
+  {
+    if (string.IsNullOrWhiteSpace(hashtag))
+      return null;
+
+    var id = await _context.Clusters
+        .AsNoTracking()
+        .Where(c => c.Hashtag == hashtag)
+        .Select(c => (int?)c.Id)
+        .FirstOrDefaultAsync(ct);
+
+    if (!id.HasValue)
+    {
+      var clusters = await _context.Clusters
+          .AsNoTracking()
+          .OrderBy(c => c.Id)
+          .Select(c => new { c.Id, c.Name, c.VariableIdsJson })
+          .ToListAsync(ct);
+
+      foreach (var row in clusters)
+      {
+        var ids = JsonConvert.DeserializeObject<int[]>(row.VariableIdsJson) ?? Array.Empty<int>();
+        var legacy = ProgesiVariableCluster.BuildLegacyHashtag(row.Id, row.Name, ids);
+        if (string.Equals(legacy, hashtag, StringComparison.Ordinal))
+        {
+          id = row.Id;
+          break;
+        }
+      }
+    }
+
+    if (!id.HasValue)
+      return null;
+
+    return await GetByIdAsync(id.Value, ct);
+  }
+
+  public async Task<IReadOnlyList<ProgesiVariableCluster>> GetAllAsync(CancellationToken ct = default)
+  {
+    var ids = await _context.Clusters
+        .AsNoTracking()
+        .OrderBy(c => c.Id)
+        .Select(c => c.Id)
+        .ToListAsync(ct);
+
+    var list = new List<ProgesiVariableCluster>(ids.Count);
+    foreach (var id in ids)
+    {
+      var cluster = await GetByIdAsync(id, ct);
+      if (cluster != null) list.Add(cluster);
+    }
+
+    return list;
+  }
+
+  public async Task<bool> DeleteAsync(int id, CancellationToken ct = default)
+  {
+    var entity = await _context.Clusters.FindAsync(new object[] { id }, ct);
+    if (entity == null) return false;
+
+    _context.Clusters.Remove(entity);
+    await _context.SaveChangesAsync(ct);
+    return true;
+  }
+
+  public async Task<int> DeleteManyAsync(IEnumerable<int> idsToDelete, CancellationToken ct = default)
+  {
+    if (idsToDelete == null) return 0;
+
+    var ids = idsToDelete.ToArray();
+    if (ids.Length == 0) return 0;
+
+    var entities = await _context.Clusters
+        .Where(c => ids.Contains(c.Id))
+        .ToListAsync(ct);
+
+    if (entities.Count == 0) return 0;
+
+    _context.Clusters.RemoveRange(entities);
+    await _context.SaveChangesAsync(ct);
+    return entities.Count;
+  }
+}

--- a/tests/Progesi.Infrastructure.EF.Tests/EfClusterRepositoryTests.cs
+++ b/tests/Progesi.Infrastructure.EF.Tests/EfClusterRepositoryTests.cs
@@ -1,0 +1,140 @@
+using FluentAssertions;
+using ProgesiCore;
+using Progesi.Infrastructure.EF.Repositories;
+
+namespace Progesi.Infrastructure.EF.Tests;
+
+public sealed class EfClusterRepositoryTests : IDisposable
+{
+  private readonly string _connectionString;
+  private readonly EfClusterRepository _repo;
+
+  public EfClusterRepositoryTests()
+  {
+    _connectionString = EfTestBootstrap.CreateTempFileConnectionString();
+    _repo = new EfClusterRepository(_connectionString, resetSchema: true);
+  }
+
+  [Fact]
+  public async Task SaveAsync_Then_GetByIdAsync_RoundTrips_Cluster()
+  {
+    var cluster = ProgesiVariableCluster.Rehydrate(7, "RepoC", new[] { 2, 1 }, "desc");
+
+    await _repo.SaveAsync(cluster);
+    var loaded = await _repo.GetByIdAsync(7);
+
+    loaded.Should().NotBeNull();
+    loaded!.Id.Should().Be(7);
+    loaded.Name.Should().Be("RepoC");
+    loaded.Description.Should().Be("desc");
+    loaded.ProgesiVariableIds.Should().Equal(1, 2);
+    loaded.Hashtag.Should().Be(cluster.Hashtag);
+    ProgesiHash.Compute(loaded).Should().Be(ProgesiHash.Compute(cluster));
+  }
+
+  [Fact]
+  public async Task GetByHashtagAsync_Finds_Saved_Cluster_By_Current_Hashtag()
+  {
+    var cluster = ProgesiVariableCluster.Rehydrate(3, "HashC", new[] { 9 }, null);
+    await _repo.SaveAsync(cluster);
+
+    var loaded = await _repo.GetByHashtagAsync(cluster.Hashtag);
+
+    loaded.Should().NotBeNull();
+    loaded!.Id.Should().Be(3);
+  }
+
+  [Fact]
+  public async Task GetByHashtagAsync_Finds_Saved_Cluster_By_Legacy_Hashtag()
+  {
+    var cluster = ProgesiVariableCluster.Rehydrate(5, "LegacyC", new[] { 4, 8 }, "note");
+    await _repo.SaveAsync(cluster);
+
+    var legacy = ProgesiVariableCluster.BuildLegacyHashtag(
+        cluster.Id,
+        cluster.Name,
+        cluster.ProgesiVariableIds);
+
+    var loaded = await _repo.GetByHashtagAsync(legacy);
+
+    loaded.Should().NotBeNull();
+    loaded!.Id.Should().Be(5);
+  }
+
+  [Fact]
+  public async Task GetByHashtagAsync_Returns_Null_For_Empty_Or_Whitespace_Hashtag()
+  {
+    await _repo.SaveAsync(ProgesiVariableCluster.Rehydrate(1, "A", new[] { 1 }, null));
+
+    (await _repo.GetByHashtagAsync("")).Should().BeNull();
+    (await _repo.GetByHashtagAsync("   ")).Should().BeNull();
+  }
+
+  [Fact]
+  public async Task SaveAsync_Deduplicates_By_ContentHash()
+  {
+    var first = ProgesiVariableCluster.Rehydrate(1, "Dup", new[] { 3, 1, 2 }, "same");
+    await _repo.SaveAsync(first);
+
+    var second = ProgesiVariableCluster.Rehydrate(2, "Dup", new[] { 2, 3, 1 }, "same");
+    var returned = await _repo.SaveAsync(second);
+
+    returned.Id.Should().Be(1);
+
+    var all = await _repo.GetAllAsync();
+    all.Should().HaveCount(1);
+    all[0].Id.Should().Be(1);
+  }
+
+  [Fact]
+  public async Task GetAllAsync_Returns_Clusters_Ordered_By_Id()
+  {
+    await _repo.SaveAsync(ProgesiVariableCluster.Rehydrate(2, "B", new[] { 2 }, null));
+    await _repo.SaveAsync(ProgesiVariableCluster.Rehydrate(1, "A", new[] { 1 }, null));
+
+    var all = await _repo.GetAllAsync();
+
+    all.Should().HaveCount(2);
+    all.Select(c => c.Id).Should().Equal(1, 2);
+  }
+
+  [Fact]
+  public async Task DeleteAsync_Removes_Existing_Cluster()
+  {
+    await _repo.SaveAsync(ProgesiVariableCluster.Rehydrate(4, "Del", new[] { 1 }, null));
+
+    (await _repo.DeleteAsync(4)).Should().BeTrue();
+    (await _repo.GetByIdAsync(4)).Should().BeNull();
+  }
+
+  [Fact]
+  public async Task DeleteAsync_Returns_False_When_Not_Found()
+  {
+    (await _repo.DeleteAsync(999)).Should().BeFalse();
+  }
+
+  [Fact]
+  public async Task DeleteManyAsync_Removes_Only_Existing_Ids()
+  {
+    await _repo.SaveAsync(ProgesiVariableCluster.Rehydrate(1, "A", new[] { 1 }, null));
+    await _repo.SaveAsync(ProgesiVariableCluster.Rehydrate(2, "B", new[] { 2 }, null));
+
+    var removed = await _repo.DeleteManyAsync(new[] { 1, 99, 2 });
+
+    removed.Should().Be(2);
+    (await _repo.GetAllAsync()).Should().BeEmpty();
+  }
+
+  public void Dispose()
+  {
+    var path = _connectionString.Replace("Data Source=", string.Empty);
+    try
+    {
+      if (File.Exists(path)) File.Delete(path);
+    }
+    catch
+    {
+      // best-effort cleanup
+    }
+  }
+}

--- a/tests/Progesi.Repositories.Conformance.Tests/SqliteEfClusterParityTests.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/SqliteEfClusterParityTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using ProgesiCore;
+using Progesi.Repositories.Conformance.Tests.Support;
+
+namespace Progesi.Repositories.Conformance.Tests;
+
+public sealed class SqliteEfClusterParityTests
+{
+  [Fact]
+  public async Task SaveAndRead_Cluster_Produces_Equivalent_Results()
+  {
+    using var stores = new SqliteEfClusterParityStores();
+    var original = ProgesiVariableCluster.Rehydrate(7, "ParityC", new[] { 2, 1 }, "desc");
+
+    await stores.Sqlite.SaveAsync(original);
+    await stores.Ef.SaveAsync(original);
+
+    var sqliteLoaded = await stores.Sqlite.GetByIdAsync(7);
+    var efLoaded = await stores.Ef.GetByIdAsync(7);
+
+    ParityAssertions.ClustersShouldMatch(sqliteLoaded!, efLoaded!, original);
+  }
+
+  [Fact]
+  public async Task Save_Deduplicates_ContentDuplicate_With_Identical_Behaviour()
+  {
+    using var stores = new SqliteEfClusterParityStores();
+    var c1 = ProgesiVariableCluster.Rehydrate(1, "Dup", new[] { 3, 1, 2 }, "same");
+    var c2 = ProgesiVariableCluster.Rehydrate(2, "Dup", new[] { 2, 3, 1 }, "same");
+
+    await stores.Sqlite.SaveAsync(c1);
+    await stores.Ef.SaveAsync(c1);
+
+    var sqliteDeduped = await stores.Sqlite.SaveAsync(c2);
+    var efDeduped = await stores.Ef.SaveAsync(c2);
+
+    sqliteDeduped.Id.Should().Be(1);
+    efDeduped.Id.Should().Be(1);
+    sqliteDeduped.Id.Should().Be(efDeduped.Id);
+    sqliteDeduped.Hashtag.Should().Be(efDeduped.Hashtag);
+
+    var sqliteByTag = await stores.Sqlite.GetByHashtagAsync(c1.Hashtag);
+    var efByTag = await stores.Ef.GetByHashtagAsync(c1.Hashtag);
+
+    ParityAssertions.ClustersShouldMatch(sqliteByTag!, efByTag!, c1);
+  }
+
+  [Fact]
+  public async Task GetByHashtagAsync_Returns_Equivalent_Cluster_On_Both_Providers()
+  {
+    using var stores = new SqliteEfClusterParityStores();
+    var original = ProgesiVariableCluster.Rehydrate(3, "Tagged", new[] { 9 }, null);
+
+    await stores.Sqlite.SaveAsync(original);
+    await stores.Ef.SaveAsync(original);
+
+    var sqliteLoaded = await stores.Sqlite.GetByHashtagAsync(original.Hashtag);
+    var efLoaded = await stores.Ef.GetByHashtagAsync(original.Hashtag);
+
+    ParityAssertions.ClustersShouldMatch(sqliteLoaded!, efLoaded!, original);
+  }
+}

--- a/tests/Progesi.Repositories.Conformance.Tests/Support/ParityAssertions.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/Support/ParityAssertions.cs
@@ -20,6 +20,24 @@ internal static class ParityAssertions
     sqlite.Hashtag.Should().Be(ef.Hashtag);
   }
 
+  public static void ClustersShouldMatch(
+      ProgesiVariableCluster sqlite,
+      ProgesiVariableCluster ef,
+      ProgesiVariableCluster original)
+  {
+    sqlite.Should().NotBeNull();
+    ef.Should().NotBeNull();
+
+    sqlite!.Id.Should().Be(ef!.Id);
+    sqlite.Name.Should().Be(ef.Name);
+    sqlite.Description.Should().Be(ef.Description);
+    sqlite.ProgesiVariableIds.Should().Equal(ef.ProgesiVariableIds);
+    sqlite.Hashtag.Should().Be(ef.Hashtag);
+
+    ProgesiHash.Compute(sqlite).Should().Be(ProgesiHash.Compute(ef));
+    ProgesiHash.Compute(sqlite).Should().Be(ProgesiHash.Compute(original));
+  }
+
   public static void MetadataShouldMatch(ProgesiMetadata? sqlite, ProgesiMetadata? ef, ProgesiMetadata original)
   {
     sqlite.Should().NotBeNull();

--- a/tests/Progesi.Repositories.Conformance.Tests/Support/SqliteEfParityStores.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/Support/SqliteEfParityStores.cs
@@ -77,3 +77,40 @@ internal sealed class SqliteEfMetadataParityStores : IDisposable
     }
   }
 }
+
+internal sealed class SqliteEfClusterParityStores : IDisposable
+{
+  private readonly string _sqlitePath;
+  private readonly string _efConnectionString;
+
+  public IProgesiVariableClusterRepository Sqlite { get; }
+  public IProgesiVariableClusterRepository Ef { get; }
+
+  public SqliteEfClusterParityStores()
+  {
+    SqliteTestBootstrap.EnsureInitialized();
+    _sqlitePath = Path.Combine(Path.GetTempPath(), $"progesi_parity_cluster_sqlite_{Guid.NewGuid():N}.sqlite");
+    _efConnectionString = $"Data Source={Path.Combine(Path.GetTempPath(), $"progesi_parity_cluster_ef_{Guid.NewGuid():N}.sqlite")}";
+
+    Sqlite = new SqliteClusterRepository(_sqlitePath, resetSchema: true);
+    Ef = new EfClusterRepository(_efConnectionString, resetSchema: true);
+  }
+
+  public void Dispose()
+  {
+    TryDelete(_sqlitePath);
+    TryDelete(_efConnectionString.Replace("Data Source=", string.Empty));
+  }
+
+  private static void TryDelete(string path)
+  {
+    try
+    {
+      if (File.Exists(path)) File.Delete(path);
+    }
+    catch
+    {
+      // best-effort cleanup
+    }
+  }
+}


### PR DESCRIPTION
## ProgesiVariableCluster Phase 3 — EF persistence + SQLite<->EF parity

Completes cluster persistence: EF Core implementation of the **existing** `IProgesiVariableClusterRepository`, plus a cross-provider parity suite proving SQLite (Phase 2) and EF produce representationally identical, hash-stable clusters. Authorised under the 2026-07-29 block-lift (#96); sequencing gate cleared by the #97 (Phase 2) merge.

### Added
- `src/Progesi.Infrastructure.EF/Entities/ClusterEntity.cs`
- `src/Progesi.Infrastructure.EF/Repositories/EfClusterRepository.cs` — mirrors `EfVariableRepository`; ContentHash dedup; `GetByHashtag` uses **cluster** semantics (Hashtag + legacy fallback).
- `src/Progesi.Infrastructure.EF/Migrations/*_R2C3_AddClustersTable.cs` (+ Designer + snapshot) — `Clusters` table, unique `IX_Clusters_ContentHash`, non-unique `IX_Clusters_Hashtag`.
- `tests/Progesi.Repositories.Conformance.Tests/SqliteEfClusterParityTests.cs` (round-trip, content-dedup, GetByHashtag) + `Support/SqliteEfClusterParityStores` + `ParityAssertions.ClustersShouldMatch`.
- `tests/Progesi.Infrastructure.EF.Tests/EfClusterRepositoryTests.cs` — 9 EF unit tests.

### Changed
- `ProgesiDbContext.cs` — `DbSet<ClusterEntity>` + `OnModelCreating` config.

### Scope / safety
- `IProgesiVariableClusterRepository` unchanged; **ProgesiCore, ProgesiRepositories.Sqlite (Phase 2), DataExchange, AxisVar all untouched.** Existing migrations not edited (new migration only).
- Tests: **323 → 335** (+12: 9 EF unit + 3 parity), 19 stress skipped, 0 failed.

Closes the Cluster SQLite/EF persistence line (Phases 2 + 3).