### PR TITLE
fix(dataexchange): lenient import keeps resolved metadata links (P1-1)

### DIFF
--- a/src/Progesi.LiveDataExchange/LiveExchangeExcelImporter.cs
+++ b/src/Progesi.LiveDataExchange/LiveExchangeExcelImporter.cs
@@ -204,16 +204,49 @@ namespace Progesi.LiveDataExchange
 
         if (metaIds.Length > 0)
         {
+          var resolvedMetaIds = new List<int>();
+          var droppedMetaIds = new List<int>();
+          mapV.TryGetValue("METAID", out var metaIdCol);
+
           foreach (var mid in metaIds)
           {
             if (!sink.TryGetMetadataById(mid, out var lookupInfo))
             {
               var msg = $"[Var R{r}] METAID not found: {mid}";
-              if (strict) { err(1, msg); addErrRc(1, r, mapV.TryGetValue("METAID", out var c) ? c : 0); varErr++; metaIds = Array.Empty<int>(); break; }
-              else { warn(1, msg); addErrRc(1, r, mapV.TryGetValue("METAID", out var c) ? c : 0); varWarn++; metaIds = Array.Empty<int>(); break; }
+              if (strict)
+              {
+                err(1, msg);
+                addErrRc(1, r, metaIdCol);
+                varErr++;
+                metaIds = Array.Empty<int>();
+                break;
+              }
+
+              warn(1, msg);
+              addErrRc(1, r, metaIdCol);
+              varWarn++;
+              droppedMetaIds.Add(mid);
+            }
+            else
+            {
+              resolvedMetaIds.Add(mid);
             }
           }
-          if (metaIds.Length == 0 && strict) { varRows++; continue; }
+
+          if (strict)
+          {
+            if (metaIds.Length == 0) { varRows++; continue; }
+          }
+          else
+          {
+            metaIds = resolvedMetaIds.ToArray();
+            if (droppedMetaIds.Count > 0)
+            {
+              var keptText = metaIds.Length > 0 ? string.Join(",", metaIds) : "(none)";
+              var droppedText = string.Join(",", droppedMetaIds);
+              warn(1, $"[Var R{r}] METAID partial resolve: kept [{keptText}], dropped unresolved [{droppedText}]");
+            }
+          }
         }
 
         int[] depArr = GhExcelValueParsing.ParseDepends(deps);

--- a/src/Progesi.LiveDataExchange/LiveExchangeSqliteImporter.cs
+++ b/src/Progesi.LiveDataExchange/LiveExchangeSqliteImporter.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Newtonsoft.Json;
 using Progesi.GhExcelReadContract;
 using ProgesiCore;
 
@@ -123,13 +124,18 @@ namespace Progesi.LiveDataExchange
         bool hasClusters = HasTable("Clusters") && HasTable("ClusterVariables");
         bool hasObjectTypeColumn = HasVariablesColumn(cn, "ObjectType");
         bool hasObjectPayloadColumn = HasVariablesColumn(cn, "ObjectPayloadJson");
+        bool hasMetadataIdsJsonColumn = HasVariablesColumn(cn, "MetadataIdsJson");
         bool readObjectPayloadColumns = hasObjectTypeColumn && hasObjectPayloadColumn;
 
         using (var cmd = new SQLiteCommand(cn))
         {
           cmd.CommandText = readObjectPayloadColumns
-            ? "SELECT Id, Name, Value, MetaId, Assumption, ObjectType, ObjectPayloadJson FROM Variables ORDER BY Id"
-            : "SELECT Id, Name, Value, MetaId, Assumption FROM Variables ORDER BY Id";
+            ? hasMetadataIdsJsonColumn
+              ? "SELECT Id, Name, Value, MetaId, Assumption, ObjectType, ObjectPayloadJson, MetadataIdsJson FROM Variables ORDER BY Id"
+              : "SELECT Id, Name, Value, MetaId, Assumption, ObjectType, ObjectPayloadJson FROM Variables ORDER BY Id"
+            : hasMetadataIdsJsonColumn
+              ? "SELECT Id, Name, Value, MetaId, Assumption, MetadataIdsJson FROM Variables ORDER BY Id"
+              : "SELECT Id, Name, Value, MetaId, Assumption FROM Variables ORDER BY Id";
           using (var rd = cmd.ExecuteReader())
           {
             int row = 0;
@@ -143,6 +149,12 @@ namespace Progesi.LiveDataExchange
               bool ass = !rd.IsDBNull(4) && (rd.GetInt32(4) != 0);
               string objectType = readObjectPayloadColumns && !rd.IsDBNull(5) ? rd.GetString(5) : "";
               string objectPayloadJson = readObjectPayloadColumns && !rd.IsDBNull(6) ? rd.GetString(6) : "";
+              string metadataIdsJson = "";
+              if (hasMetadataIdsJsonColumn)
+              {
+                int metadataIdsJsonColumn = readObjectPayloadColumns ? 7 : 5;
+                metadataIdsJson = rd.IsDBNull(metadataIdsJsonColumn) ? "" : rd.GetString(metadataIdsJsonColumn);
+              }
 
               if (nm.Length > NAME_MAX || !IsPrintable(nm))
               { var msg = $"[Var R{row}] NAME invalid (len/charset)"; Report(1, msg); AddErrRC(1, row, 2); if (strict) { varErr++; continue; } else { varWarn++; } }
@@ -158,11 +170,51 @@ namespace Progesi.LiveDataExchange
                 }
               }
 
-              int[] metaIds = mid > 0 ? new[] { mid } : Array.Empty<int>();
-              if (mid > 0)
+              int[] metaIds = ParseVariableMetadataIds(metadataIdsJson, mid);
+              if (metaIds.Length > 0)
               {
-                if (!sink.TryGetMetadataById(mid, out _))
-                { var msg = $"[Var R{row}] METAID not found: {mid}"; Report(1, msg); AddErrRC(1, row, 4); if (strict) { varErr++; continue; } else { varWarn++; metaIds = Array.Empty<int>(); } }
+                var resolvedMetaIds = new List<int>();
+                var droppedMetaIds = new List<int>();
+
+                foreach (var metaId in metaIds)
+                {
+                  if (!sink.TryGetMetadataById(metaId, out _))
+                  {
+                    var msg = $"[Var R{row}] METAID not found: {metaId}";
+                    if (strict)
+                    {
+                      Report(1, msg);
+                      AddErrRC(1, row, 4);
+                      varErr++;
+                      metaIds = Array.Empty<int>();
+                      break;
+                    }
+
+                    Report(1, msg);
+                    AddErrRC(1, row, 4);
+                    varWarn++;
+                    droppedMetaIds.Add(metaId);
+                  }
+                  else
+                  {
+                    resolvedMetaIds.Add(metaId);
+                  }
+                }
+
+                if (strict)
+                {
+                  if (metaIds.Length == 0) { continue; }
+                }
+                else
+                {
+                  metaIds = resolvedMetaIds.ToArray();
+                  if (droppedMetaIds.Count > 0)
+                  {
+                    var keptText = metaIds.Length > 0 ? string.Join(",", metaIds) : "(none)";
+                    var droppedText = string.Join(",", droppedMetaIds);
+                    WARN(1, $"[Var R{row}] METAID partial resolve: kept [{keptText}], dropped unresolved [{droppedText}]");
+                  }
+                }
               }
 
               string geometryJson = null;
@@ -306,6 +358,25 @@ namespace Progesi.LiveDataExchange
       }
 
       return false;
+    }
+
+    private static int[] ParseVariableMetadataIds(string metadataIdsJson, int legacyMetaId)
+    {
+      if (!string.IsNullOrWhiteSpace(metadataIdsJson))
+      {
+        try
+        {
+          var parsed = JsonConvert.DeserializeObject<int[]>(metadataIdsJson);
+          if (parsed != null && parsed.Length > 0)
+            return parsed.Where(id => id > 0).Distinct().ToArray();
+        }
+        catch
+        {
+          // fall back to legacy scalar MetaId
+        }
+      }
+
+      return legacyMetaId > 0 ? new[] { legacyMetaId } : Array.Empty<int>();
     }
   }
 }

--- a/tests/Progesi.LiveDataExchange.Tests/LiveExchangeLenientMetadataImportTests.cs
+++ b/tests/Progesi.LiveDataExchange.Tests/LiveExchangeLenientMetadataImportTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Data.SQLite;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Progesi.LiveDataExchange;
+using Progesi.LiveDataExchange.Tests.Support;
+using Xunit;
+
+namespace Progesi.LiveDataExchange.Tests
+{
+  public sealed class LiveExchangeLenientMetadataImportTests
+  {
+    [Fact]
+    public void Excel_lenient_import_keeps_resolved_metadata_and_warns_on_dropped_ids()
+    {
+      var snapshot = new LiveExchangeSnapshot
+      {
+        Metadata = new[]
+        {
+          new MetadataExportRow { Id = 1, Hash = "meta-1", By = "eng", Description = "Known metadata", LM = "2026-07-29T10:00:00Z" }
+        },
+        Variables = new[]
+        {
+          new VariableExportRow
+          {
+            Id = 10,
+            Hash = "var-10",
+            Name = "LinkedVar",
+            Value = "42",
+            ValC = "42",
+            MetadataIds = new[] { 1, 999 }
+          }
+        }
+      };
+
+      var codec = new FakeGeometryCodec();
+      var sink = new InMemoryImportSink();
+      string path = Path.Combine(Path.GetTempPath(), "progesi-lenient-meta-excel-" + Path.GetRandomFileName() + ".xlsx");
+
+      try
+      {
+        LiveExchangeExcelExporter.Export(snapshot, path, overwrite: true);
+
+        var result = LiveExchangeExcelImporter.ImportValidated(
+          path, strict: false, failOnError: false, maxErrors: 1000, mapJson: "", dryRun: false, sink, codec);
+
+        result.Errors.Should().BeEmpty();
+        sink.Variables.Should().ContainSingle();
+        sink.Variables[0].MetadataIds.Should().Equal(1);
+        result.Warnings.Should().Contain(w => w.Text.Contains("METAID not found: 999"));
+        result.Warnings.Should().Contain(w => w.Text.Contains("partial resolve") && w.Text.Contains("kept [1]") && w.Text.Contains("999"));
+      }
+      finally
+      {
+        if (File.Exists(path)) File.Delete(path);
+        var log = path + ".import.log.txt";
+        if (File.Exists(log)) File.Delete(log);
+      }
+    }
+
+    [Fact]
+    public void Sqlite_lenient_import_keeps_resolved_metadata_and_warns_on_dropped_ids()
+    {
+      var codec = new FakeGeometryCodec();
+      var sink = new InMemoryImportSink();
+      string path = Path.Combine(Path.GetTempPath(), "progesi-lenient-meta-sqlite-" + Path.GetRandomFileName() + ".db");
+
+      try
+      {
+        CreatePartialMetadataDb(path);
+
+        var result = LiveExchangeSqliteImporter.ImportValidated(path, strict: false, dryRun: false, sink, codec);
+
+        result.Errors.Should().BeEmpty();
+        sink.Variables.Should().ContainSingle();
+        sink.Variables[0].MetadataIds.Should().Equal(1);
+        result.Warnings.Should().Contain(w => w.Text.Contains("METAID not found: 999"));
+        result.Warnings.Should().Contain(w => w.Text.Contains("partial resolve") && w.Text.Contains("kept [1]") && w.Text.Contains("999"));
+      }
+      finally
+      {
+        if (File.Exists(path)) File.Delete(path);
+        var log = path + ".import.log.txt";
+        if (File.Exists(log)) File.Delete(log);
+      }
+    }
+
+    private static void CreatePartialMetadataDb(string path)
+    {
+      if (File.Exists(path))
+        File.Delete(path);
+
+      using (var cn = new SQLiteConnection($@"Data Source={path};Version=3;"))
+      {
+        cn.Open();
+        using (var cmd = new SQLiteCommand(cn))
+        {
+          cmd.CommandText = @"
+CREATE TABLE Metadata (
+  Id INTEGER PRIMARY KEY,
+  Hash TEXT NOT NULL,
+  By TEXT,
+  Description TEXT,
+  LM TEXT
+);
+CREATE TABLE Variables (
+  Id INTEGER PRIMARY KEY,
+  Hash TEXT NOT NULL,
+  Name TEXT NOT NULL,
+  Value TEXT,
+  ValC TEXT,
+  MetaId INTEGER NULL,
+  Assumption INTEGER NOT NULL DEFAULT 0,
+  MetadataIdsJson TEXT
+);
+CREATE TABLE VariableDepends (
+  VarId INTEGER NOT NULL,
+  DepId INTEGER NOT NULL,
+  PRIMARY KEY (VarId, DepId)
+);
+CREATE TABLE Refs (
+  MetaId INTEGER NOT NULL,
+  Ref TEXT NOT NULL,
+  PRIMARY KEY (MetaId, Ref)
+);";
+          cmd.ExecuteNonQuery();
+
+          cmd.CommandText = "INSERT INTO Metadata (Id,Hash,By,Description,LM) VALUES (1,'meta-1','eng','Known metadata','2026-07-29T10:00:00Z')";
+          cmd.ExecuteNonQuery();
+
+          cmd.CommandText = "INSERT INTO Variables (Id,Hash,Name,Value,ValC,MetaId,Assumption,MetadataIdsJson) VALUES (10,'var-10','LinkedVar','42','42',NULL,0,'[1,999]')";
+          cmd.ExecuteNonQuery();
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Robustness P1-1 — lenient import no longer drops resolved metadata links

**Problem:** in lenient import mode a single unresolved `METAID` cleared **all** metadata links on the row (silent data-integrity loss). `LiveExchangeExcelImporter.cs` / `LiveExchangeSqliteImporter.cs`.

**Fix:** lenient mode now filters per-id — drops only the unresolved id(s), **keeps the resolved ones**, and emits a prominent per-id warning plus a `partial resolve: kept [...], dropped [...]` summary. **Strict mode unchanged** (still skips the row).

**Scope note:** the SQLite importer gains a **guarded optional `MetadataIdsJson` read** (only when the column exists; falls back to scalar `MetaId` — the canonical exporter shape) to enable the symmetric multi-id test. No change to `LiveExchangeImportResult`, Core, legacy `ProgesiDataExchange`, or AxisVar.

**Tests:** +2 (Excel + SQLite lenient partial-resolve). **335 → 337**, 19 stress skipped, 0 failed.