### PR TITLE
fix(sqlite): align Variables.ContentHash NOT NULL + drop redundant index (P1-5 Option 1)

### DIFF
--- a/src/ProgesiRepositories.Sqlite/SqliteVariableRepository.cs
+++ b/src/ProgesiRepositories.Sqlite/SqliteVariableRepository.cs
@@ -43,7 +43,7 @@ CREATE TABLE Variables (
     MetadataId   INTEGER NULL,
     MetadataIdsJson TEXT NOT NULL DEFAULT '[]',
     DependsJson  TEXT NOT NULL,
-    ContentHash  TEXT,
+    ContentHash  TEXT NOT NULL DEFAULT '',
     ObjectType   TEXT NOT NULL DEFAULT '',
     ObjectPayloadJson TEXT NOT NULL DEFAULT ''
 );";
@@ -61,24 +61,18 @@ CREATE TABLE IF NOT EXISTS Variables (
     MetadataId   INTEGER NULL,
     MetadataIdsJson TEXT NOT NULL DEFAULT '[]',
     DependsJson  TEXT NOT NULL,
-    ContentHash  TEXT
+    ContentHash  TEXT NOT NULL DEFAULT ''
 );";
           cmd.ExecuteNonQuery();
 
           // per DB legacy che non avessero ContentHash
-          AddColumnIfMissing(conn, "Variables", "ContentHash", "TEXT");
+          AddColumnIfMissing(conn, "Variables", "ContentHash", "TEXT NOT NULL DEFAULT ''");
           AddColumnIfMissing(conn, "Variables", "MetadataIdsJson", "TEXT NOT NULL DEFAULT '[]'");
           AddColumnIfMissing(conn, "Variables", "ObjectType", "TEXT NOT NULL DEFAULT ''");
           AddColumnIfMissing(conn, "Variables", "ObjectPayloadJson", "TEXT NOT NULL DEFAULT ''");
         }
       }
       EnsureContentHash(conn, "Variables");
-
-      using (var idx = conn.CreateCommand())
-      {
-        idx.CommandText = "CREATE INDEX IF NOT EXISTS IX_Variables_ContentHash ON Variables(ContentHash);";
-        idx.ExecuteNonQuery();
-      }
     }
 
     public Task<ProgesiVariable> SaveAsync(ProgesiVariable variable, CancellationToken ct = default)

--- a/tests/ProgesiRepositories.Sqlite.Tests/SqliteVariableRepositorySchemaTests.cs
+++ b/tests/ProgesiRepositories.Sqlite.Tests/SqliteVariableRepositorySchemaTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using ProgesiCore;
+using ProgesiRepositories.Sqlite;
+using Xunit;
+
+namespace ProgesiRepositories.Sqlite.Tests
+{
+  public sealed class SqliteVariableRepositorySchemaTests : IDisposable
+  {
+    private readonly string _dbPath;
+
+    public SqliteVariableRepositorySchemaTests()
+    {
+      SqliteTestBootstrap.EnsureInitialized();
+      _dbPath = Path.Combine(Path.GetTempPath(), $"progesi_var_schema_{Guid.NewGuid():N}.sqlite");
+      _ = new SqliteVariableRepository(_dbPath, resetSchema: true);
+    }
+
+    [Fact]
+    public void Fresh_variables_table_has_single_unique_content_hash_index_and_not_null_column()
+    {
+      using var conn = new SqliteConnection($"Data Source={_dbPath}");
+      conn.Open();
+
+      var contentHashIndexes = GetContentHashIndexes(conn);
+      contentHashIndexes.Should().HaveCount(1);
+      contentHashIndexes[0].Name.Should().Be("IX_Variables_ContentHash");
+      contentHashIndexes[0].IsUnique.Should().BeTrue();
+
+      using var infoCmd = conn.CreateCommand();
+      infoCmd.CommandText = "PRAGMA table_info('Variables');";
+      using var reader = infoCmd.ExecuteReader();
+      while (reader.Read())
+      {
+        var name = reader.GetString(1);
+        if (!string.Equals(name, "ContentHash", StringComparison.OrdinalIgnoreCase))
+          continue;
+
+        reader.GetInt64(3).Should().Be(1, "ContentHash should be NOT NULL on a fresh schema");
+        return;
+      }
+
+      throw new InvalidOperationException("ContentHash column not found.");
+    }
+
+    [Fact]
+    public async Task SaveAsync_deduplicates_when_second_row_shares_content_hash()
+    {
+      var repo = new SqliteVariableRepository(_dbPath, resetSchema: false);
+      var first = new ProgesiVariable(1, "A", 42, new[] { 3, 1, 2 }, metadataIds: new[] { 7 });
+      await repo.SaveAsync(first);
+
+      var second = new ProgesiVariable(2, "A", 42, new[] { 2, 3, 1 }, metadataIds: new[] { 7 });
+      var returned = await repo.SaveAsync(second);
+
+      returned.Id.Should().Be(1);
+
+      using var conn = new SqliteConnection($"Data Source={_dbPath}");
+      conn.Open();
+      using var countCmd = conn.CreateCommand();
+      countCmd.CommandText = "SELECT COUNT(*) FROM Variables WHERE ContentHash=$h;";
+      countCmd.Parameters.AddWithValue("$h", ProgesiHash.Compute(first));
+      Convert.ToInt32(countCmd.ExecuteScalar()).Should().Be(1);
+    }
+
+    [Fact]
+    public void Unique_content_hash_index_rejects_raw_duplicate_insert()
+    {
+      using var conn = new SqliteConnection($"Data Source={_dbPath}");
+      conn.Open();
+
+      using (var insert = conn.CreateCommand())
+      {
+        insert.CommandText = @"
+INSERT INTO Variables (Id, Name, ValueType, Value, MetadataIdsJson, DependsJson, ContentHash)
+VALUES (1, 'A', 'int', '1', '[]', '[]', 'dup-hash');";
+        insert.ExecuteNonQuery();
+      }
+
+      using var duplicate = conn.CreateCommand();
+      duplicate.CommandText = @"
+INSERT INTO Variables (Id, Name, ValueType, Value, MetadataIdsJson, DependsJson, ContentHash)
+VALUES (2, 'B', 'int', '2', '[]', '[]', 'dup-hash');";
+
+      Action act = () => duplicate.ExecuteNonQuery();
+      act.Should().Throw<SqliteException>();
+    }
+
+    private static IList<(string Name, bool IsUnique)> GetContentHashIndexes(SqliteConnection conn)
+    {
+      var results = new List<(string Name, bool IsUnique)>();
+
+      using var listCmd = conn.CreateCommand();
+      listCmd.CommandText = "PRAGMA index_list('Variables');";
+      using var listReader = listCmd.ExecuteReader();
+      while (listReader.Read())
+      {
+        var indexName = listReader.GetString(1);
+        var isUnique = listReader.GetInt64(2) == 1;
+
+        using var infoCmd = conn.CreateCommand();
+        infoCmd.CommandText = $"PRAGMA index_info('{indexName}');";
+        using var infoReader = infoCmd.ExecuteReader();
+        while (infoReader.Read())
+        {
+          var columnName = infoReader.GetString(2);
+          if (string.Equals(columnName, "ContentHash", StringComparison.OrdinalIgnoreCase))
+            results.Add((indexName, isUnique));
+        }
+      }
+
+      return results;
+    }
+
+    public void Dispose()
+    {
+      try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+  }
+}


### PR DESCRIPTION
## Robustness P1-5 (Option 1) — SQLite schema align

Closes the one real intra-canonical schema divergence: `SqliteVariableRepository`s `Variables.ContentHash` is now **`NOT NULL DEFAULT `** (matching the EF model, which was already NOT NULL). Also removes the **redundant non-unique** `IX_Variables_ContentHash` creation — the UNIQUE index from `EnsureContentHash` is the single, correct index.

- Existing DBs unaffected (`AddColumnIfMissing` skips when the column exists; every write sets ContentHash).
- **Untouched:** EF model (already NOT NULL, the target), the LiveExchange exporter (intentional interchange schema, not a divergence), AxisVar, cluster interface.
- **Option 2** (canonical-schema declaration + parity test) deferred to Phase 4.
- Tests: +3 (`SqliteVariableRepositorySchemaTests`). **337 → 340**, 19 stress skipped, 0 failed.