### PR TITLE
fix(cluster): resilient cascade-delete with partial-failure reporting (P1-2)

### DIFF
--- a/src/ProgesiCore/Services/CascadeResult.cs
+++ b/src/ProgesiCore/Services/CascadeResult.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace ProgesiCore.Services
+{
+  /// <summary>
+  /// Outcome of a cascade-remove operation across multiple clusters.
+  /// Partial failures are reported per cluster; the operation is idempotent and safe to retry.
+  /// </summary>
+  public sealed class CascadeResult
+  {
+    public CascadeResult(int applied, IReadOnlyList<int> failedClusterIds)
+    {
+      Applied = applied;
+      FailedClusterIds = failedClusterIds ?? System.Array.Empty<int>();
+    }
+
+    public int Applied { get; }
+
+    public IReadOnlyList<int> FailedClusterIds { get; }
+
+    public bool IsFullySuccessful => FailedClusterIds.Count == 0;
+  }
+}

--- a/src/ProgesiCore/Services/ClusterService.cs
+++ b/src/ProgesiCore/Services/ClusterService.cs
@@ -112,37 +112,45 @@ namespace ProgesiCore.Services
 
     // R2-G: when a ProgesiVariable is deleted, strip it from every cluster that references it.
     // A cluster left with no variables is deleted (cluster invariant is >= 1 variable).
-    public async Task<int> CascadeRemoveVariableFromClustersAsync(
+    public async Task<CascadeResult> CascadeRemoveVariableFromClustersAsync(
       int variableId,
       CancellationToken ct = default)
     {
-      if (variableId <= 0) return 0;
+      if (variableId <= 0) return new CascadeResult(0, Array.Empty<int>());
 
       var all = await _clusterRepository.GetAllAsync(ct).ConfigureAwait(false);
-      int affected = 0;
+      int applied = 0;
+      var failedClusterIds = new List<int>();
 
       foreach (var cluster in all)
       {
         if (cluster.ProgesiVariableIds == null || !cluster.ProgesiVariableIds.Contains(variableId))
           continue;
 
-        var remaining = cluster.ProgesiVariableIds.Where(v => v != variableId).ToList();
-
-        if (remaining.Count == 0)
+        try
         {
-          await _clusterRepository.DeleteAsync(cluster.Id, ct).ConfigureAwait(false);
-        }
-        else
-        {
-          var updated = ProgesiVariableCluster.Rehydrate(
-            cluster.Id, cluster.Name, remaining, cluster.Description, null);
-          await _clusterRepository.SaveAsync(updated, ct).ConfigureAwait(false);
-        }
+          var remaining = cluster.ProgesiVariableIds.Where(v => v != variableId).ToList();
 
-        affected++;
+          if (remaining.Count == 0)
+          {
+            await _clusterRepository.DeleteAsync(cluster.Id, ct).ConfigureAwait(false);
+          }
+          else
+          {
+            var updated = ProgesiVariableCluster.Rehydrate(
+              cluster.Id, cluster.Name, remaining, cluster.Description, null);
+            await _clusterRepository.SaveAsync(updated, ct).ConfigureAwait(false);
+          }
+
+          applied++;
+        }
+        catch
+        {
+          failedClusterIds.Add(cluster.Id);
+        }
       }
 
-      return affected;
+      return new CascadeResult(applied, failedClusterIds);
     }
   }
 }

--- a/src/ProgesiCore/Services/IClusterService.cs
+++ b/src/ProgesiCore/Services/IClusterService.cs
@@ -42,9 +42,9 @@ namespace ProgesiCore.Services
     /// <summary>
     /// Rimuove la ProgesiVariable indicata da tutti i cluster che la referenziano.
     /// Se un cluster resta senza variabili viene eliminato.
-    /// Ritorna il numero di cluster modificati o eliminati.
+    /// Ritorna il numero di cluster applicati con successo e gli Id dei cluster falliti.
     /// </summary>
-    Task<int> CascadeRemoveVariableFromClustersAsync(
+    Task<CascadeResult> CascadeRemoveVariableFromClustersAsync(
       int variableId,
       CancellationToken ct = default);
   }

--- a/src/ProgesiGrasshopperAssembly/Infrastructure/MetadataRepositoryCompatExtensions.cs
+++ b/src/ProgesiGrasshopperAssembly/Infrastructure/MetadataRepositoryCompatExtensions.cs
@@ -686,7 +686,13 @@ namespace ProgesiGrasshopperAssembly.Infrastructure
         {
           var clusterRepo = new RhinoVariableClusterRepository(doc);
           var clusterSvc = new ProgesiCore.Services.ClusterService(clusterRepo);
-          clusterSvc.CascadeRemoveVariableFromClustersAsync(id).GetAwaiter().GetResult();
+          var cascade = clusterSvc.CascadeRemoveVariableFromClustersAsync(id).GetAwaiter().GetResult();
+          if (!cascade.IsFullySuccessful)
+          {
+            info = "Cluster cascade cleanup failed: could not update cluster(s) "
+                   + string.Join(", ", cascade.FailedClusterIds);
+            return false;
+          }
         }
         catch (Exception cex)
         {

--- a/tests/Progesi.Stress.Tests/ClusterScaleStressTests.cs
+++ b/tests/Progesi.Stress.Tests/ClusterScaleStressTests.cs
@@ -53,7 +53,8 @@ public sealed class ClusterScaleStressTests
     sw.Stop();
     StressTestGate.LogTiming(_output, "Cluster cascade-remove", sw, 1);
 
-    affected.Should().Be(1);
+    affected.Applied.Should().Be(1);
+    affected.IsFullySuccessful.Should().BeTrue();
     var reloaded = await service.GetByIdAsync(first.Id);
     reloaded.Should().NotBeNull();
     reloaded!.ProgesiVariableIds.Should().NotContain(removeId);

--- a/tests/ProgesiCore.Tests/ClusterServiceTests.cs
+++ b/tests/ProgesiCore.Tests/ClusterServiceTests.cs
@@ -126,7 +126,8 @@ namespace Progesi.Core.Tests.Services
 
       var affected = await service.CascadeRemoveVariableFromClustersAsync(9);
 
-      Assert.Equal(1, affected);
+      Assert.Equal(1, affected.Applied);
+      Assert.True(affected.IsFullySuccessful);
       var reloaded = await service.GetByIdAsync(c.Id);
       Assert.NotNull(reloaded);
       Assert.True(reloaded!.ProgesiVariableIds.SequenceEqual(new[] { 2 }));
@@ -141,11 +142,116 @@ namespace Progesi.Core.Tests.Services
 
       var affected = await service.CascadeRemoveVariableFromClustersAsync(9);
 
-      Assert.Equal(1, affected);
+      Assert.Equal(1, affected.Applied);
+      Assert.True(affected.IsFullySuccessful);
       var reloaded = await service.GetByIdAsync(c.Id);
       Assert.Null(reloaded);
       var all = await service.GetAllAsync();
       Assert.Empty(all);
+    }
+
+    [Fact]
+    public async Task CascadeRemove_Continues_After_Partial_Failure_And_Reports_Failed_Clusters()
+    {
+      var clusterRepo = new ThrowingOnNthCascadeMutationRepository(failOnNthMutation: 2, removedVariableId: 9);
+      var service = new ClusterService(clusterRepo);
+
+      await service.CreateOrGetClusterAsync("C1", new[] { 9, 1 }, "d");
+      var failing = await service.CreateOrGetClusterAsync("C2", new[] { 9, 2 }, "d");
+      await service.CreateOrGetClusterAsync("C3", new[] { 9, 3 }, "d");
+
+      var result = await service.CascadeRemoveVariableFromClustersAsync(9);
+
+      Assert.Equal(2, result.Applied);
+      Assert.False(result.IsFullySuccessful);
+      Assert.Equal(new[] { failing.Id }, result.FailedClusterIds);
+
+      var c1 = await service.GetByIdAsync(1);
+      var c2 = await service.GetByIdAsync(failing.Id);
+      var c3 = await service.GetByIdAsync(3);
+      Assert.NotNull(c1);
+      Assert.NotNull(c2);
+      Assert.NotNull(c3);
+      Assert.True(c1!.ProgesiVariableIds.SequenceEqual(new[] { 1 }));
+      Assert.True(c2!.ProgesiVariableIds.SequenceEqual(new[] { 2, 9 }));
+      Assert.True(c3!.ProgesiVariableIds.SequenceEqual(new[] { 3 }));
+    }
+
+    [Fact]
+    public async Task SimulatedDeleteVariable_Skips_Variable_Delete_On_Partial_Cascade_Failure()
+    {
+      var varRepo = new InMemoryVariableRepository();
+      await varRepo.SaveAsync(new ProgesiVariable(9, "v9", 2.0));
+
+      var clusterRepo = new ThrowingOnNthCascadeMutationRepository(failOnNthMutation: 2, removedVariableId: 9);
+      var clusterService = new ClusterService(clusterRepo);
+      await clusterService.CreateOrGetClusterAsync("C1", new[] { 9, 1 }, "d");
+      await clusterService.CreateOrGetClusterAsync("C2", new[] { 9, 2 }, "d");
+
+      var cascade = await clusterService.CascadeRemoveVariableFromClustersAsync(9);
+
+      var deleteVariable = cascade.IsFullySuccessful;
+      if (deleteVariable)
+        await varRepo.DeleteAsync(9);
+
+      Assert.False(deleteVariable);
+      Assert.NotNull(await varRepo.GetByIdAsync(9));
+    }
+
+    private sealed class ThrowingOnNthCascadeMutationRepository : IProgesiVariableClusterRepository
+    {
+      private readonly InMemoryVariableClusterRepository _inner = new InMemoryVariableClusterRepository();
+      private readonly int _failOnNthMutation;
+      private readonly int _removedVariableId;
+      private int _cascadeMutationCount;
+
+      public ThrowingOnNthCascadeMutationRepository(int failOnNthMutation, int removedVariableId)
+      {
+        _failOnNthMutation = failOnNthMutation;
+        _removedVariableId = removedVariableId;
+      }
+
+      public async Task<ProgesiVariableCluster> SaveAsync(ProgesiVariableCluster cluster, System.Threading.CancellationToken ct = default)
+      {
+        var existing = await _inner.GetByIdAsync(cluster.Id, ct).ConfigureAwait(false);
+        if (existing != null
+            && existing.ProgesiVariableIds.Contains(_removedVariableId)
+            && !cluster.ProgesiVariableIds.Contains(_removedVariableId))
+        {
+          _cascadeMutationCount++;
+          if (_cascadeMutationCount == _failOnNthMutation)
+            throw new System.InvalidOperationException($"Simulated cascade failure on cluster {cluster.Id}");
+        }
+
+        return await _inner.SaveAsync(cluster, ct).ConfigureAwait(false);
+      }
+
+      public Task<ProgesiVariableCluster?> GetByIdAsync(int id, System.Threading.CancellationToken ct = default)
+        => _inner.GetByIdAsync(id, ct);
+
+      public Task<ProgesiVariableCluster?> GetByHashtagAsync(string hashtag, System.Threading.CancellationToken ct = default)
+        => _inner.GetByHashtagAsync(hashtag, ct);
+
+      public Task<System.Collections.Generic.IReadOnlyList<ProgesiVariableCluster>> GetAllAsync(System.Threading.CancellationToken ct = default)
+        => _inner.GetAllAsync(ct);
+
+      public async Task<bool> DeleteAsync(int id, System.Threading.CancellationToken ct = default)
+      {
+        var existing = await _inner.GetByIdAsync(id, ct).ConfigureAwait(false);
+        if (existing != null
+            && existing.ProgesiVariableIds.Count == 1
+            && existing.ProgesiVariableIds.Contains(_removedVariableId))
+        {
+          _cascadeMutationCount++;
+          if (_cascadeMutationCount == _failOnNthMutation)
+            throw new System.InvalidOperationException($"Simulated cascade failure on cluster {id}");
+        }
+
+        return await _inner.DeleteAsync(id, ct).ConfigureAwait(false);
+      }
+
+      public Task<int> DeleteManyAsync(System.Collections.Generic.IEnumerable<int> ids, System.Threading.CancellationToken ct = default)
+        => _inner.DeleteManyAsync(ids, ct);
     }
   }
 }


### PR DESCRIPTION
## Robustness P1-2 — resilient cluster cascade-delete

**Problem:** `CascadeRemoveVariableFromClustersAsync` aborted on the first repo failure, leaving clusters half-updated.

**Fix:** per-cluster try/catch + continue; returns **`CascadeResult`** (`Applied`, `FailedClusterIds`, `IsFullySuccessful`) — idempotent/retry-safe. `TryDeleteVariable` now deletes the variable **only on full cascade success**; on partial failure it returns false listing the failed cluster Ids. A true cross-store transaction is intentionally **not** attempted (no repo/StringTable primitive) — `IProgesiVariableClusterRepository` unchanged.

**Tests:** +2 (partial-failure continuation + variable retained on partial). **340 → 342**, 19 stress skipped, 0 failed.

⚠️ **Requires tab-04 manual GH validation before merge** (variable-delete + cluster-cascade flow).