### PR TITLE
fix(cluster): validate variable existence on Cluster Update path (P1-3)

### DIFF
--- a/src/ProgesiCore/Services/ClusterService.cs
+++ b/src/ProgesiCore/Services/ClusterService.cs
@@ -45,21 +45,7 @@ namespace ProgesiCore.Services
       if (ids.Count == 0)
         throw new ArgumentException("Cluster must contain at least one variable id.", nameof(progesiVariableIds));
 
-      // R2-G: referential integrity — reject a cluster that references non-existent ProgesiVariable(s).
-      // Only enforced when a variable repository is supplied (create path); read paths pass null.
-      if (_variableRepository != null)
-      {
-        var missing = new List<int>();
-        foreach (var vid in ids)
-        {
-          var existingVar = await _variableRepository.GetByIdAsync(vid, ct).ConfigureAwait(false);
-          if (existingVar == null) missing.Add(vid);
-        }
-        if (missing.Count > 0)
-          throw new ArgumentException(
-            $"Cluster references non-existent ProgesiVariable id(s): {string.Join(", ", missing)}.",
-            nameof(progesiVariableIds));
-      }
+      await ValidateReferencedVariablesExistAsync(ids, nameof(progesiVariableIds), ct).ConfigureAwait(false);
 
       // Candidate "logico" (Id=0) solo per confronto con i cluster esistenti
       var candidate = ProgesiVariableCluster.CreateNew(name, ids, description);
@@ -84,6 +70,37 @@ namespace ProgesiCore.Services
       // Salviamo sul repository (che può avere ulteriore dedup via ContentHash, come in SQLite)
       var saved = await _clusterRepository.SaveAsync(newCluster, ct).ConfigureAwait(false);
       return saved;
+    }
+
+    public async Task<ProgesiVariableCluster> UpdateClusterAsync(
+      int id,
+      string name,
+      IEnumerable<int> progesiVariableIds,
+      string? description = null,
+      CancellationToken ct = default)
+    {
+      if (id <= 0)
+        throw new ArgumentException("Cluster id must be positive.", nameof(id));
+
+      if (string.IsNullOrWhiteSpace(name))
+        throw new ArgumentException("Cluster name is required.", nameof(name));
+
+      if (progesiVariableIds is null)
+        throw new ArgumentNullException(nameof(progesiVariableIds));
+
+      var ids = progesiVariableIds
+        .Where(variableId => variableId > 0)
+        .Distinct()
+        .OrderBy(variableId => variableId)
+        .ToList();
+
+      if (ids.Count == 0)
+        throw new ArgumentException("Cluster must contain at least one variable id.", nameof(progesiVariableIds));
+
+      await ValidateReferencedVariablesExistAsync(ids, nameof(progesiVariableIds), ct).ConfigureAwait(false);
+
+      var updated = ProgesiVariableCluster.Rehydrate(id, name, ids, description, null);
+      return await _clusterRepository.SaveAsync(updated, ct).ConfigureAwait(false);
     }
 
     public Task<ProgesiVariableCluster?> GetByIdAsync(
@@ -151,6 +168,26 @@ namespace ProgesiCore.Services
       }
 
       return new CascadeResult(applied, failedClusterIds);
+    }
+
+    private async Task ValidateReferencedVariablesExistAsync(
+      IReadOnlyList<int> ids,
+      string paramName,
+      CancellationToken ct)
+    {
+      if (_variableRepository == null) return;
+
+      var missing = new List<int>();
+      foreach (var vid in ids)
+      {
+        var existingVar = await _variableRepository.GetByIdAsync(vid, ct).ConfigureAwait(false);
+        if (existingVar == null) missing.Add(vid);
+      }
+
+      if (missing.Count > 0)
+        throw new ArgumentException(
+          $"Cluster references non-existent ProgesiVariable id(s): {string.Join(", ", missing)}.",
+          paramName);
     }
   }
 }

--- a/src/ProgesiCore/Services/IClusterService.cs
+++ b/src/ProgesiCore/Services/IClusterService.cs
@@ -20,6 +20,17 @@ namespace ProgesiCore.Services
       string? description = null,
       CancellationToken ct = default);
 
+    /// <summary>
+    /// Updates an existing cluster in place (same Id, no dedup).
+    /// Validates that referenced variable Ids exist when a variable repository is supplied.
+    /// </summary>
+    Task<ProgesiVariableCluster> UpdateClusterAsync(
+      int id,
+      string name,
+      IEnumerable<int> progesiVariableIds,
+      string? description = null,
+      CancellationToken ct = default);
+
     Task<ProgesiVariableCluster?> GetByIdAsync(
       int id,
       CancellationToken ct = default);

--- a/src/ProgesiGrasshopperAssembly/Components/ProgesiClusterDefinitionComponent.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/ProgesiClusterDefinitionComponent.cs
@@ -232,24 +232,29 @@ namespace ProgesiGrasshopperAssembly.Components
             return;
           }
 
-          // Manteniamo lo stesso Id: UPDATE vero (non dedup tramite service!)
-          var updated = ProgesiVariableCluster.Rehydrate(
-            existing.Id,
-            name,
-            ids,
-            desc,
-            null);
+          var service = new ClusterService(clusterRepo, varRepo);
+          try
+          {
+            var saved = service.UpdateClusterAsync(existing.Id, name, ids, desc).GetAwaiter().GetResult();
 
-          var saved = clusterRepo.SaveAsync(updated, default).GetAwaiter().GetResult();
+            outId = saved.Id;
+            outHash = saved.Hashtag ?? string.Empty;
+            outInfo = $"OK (Updated Cluster Id={saved.Id}, Vars={saved.ProgesiVariableIds.Count})";
 
-          outId = saved.Id;
-          outHash = saved.Hashtag ?? string.Empty;
-          outInfo = $"OK (Updated Cluster Id={saved.Id}, Vars={saved.ProgesiVariableIds.Count})";
-
-          DA.SetData(0, outId);
-          DA.SetData(1, outHash);
-          DA.SetData(2, outInfo);
-          return;
+            DA.SetData(0, outId);
+            DA.SetData(1, outHash);
+            DA.SetData(2, outInfo);
+            return;
+          }
+          catch (ArgumentException ex)
+          {
+            AddRuntimeMessage(GH_RuntimeMessageLevel.Error, ex.Message);
+            outInfo = "Errore: " + ex.Message;
+            DA.SetData(0, 0);
+            DA.SetData(1, "");
+            DA.SetData(2, outInfo);
+            return;
+          }
         }
 
         // CREATE (default)

--- a/tests/ProgesiCore.Tests/ClusterServiceTests.cs
+++ b/tests/ProgesiCore.Tests/ClusterServiceTests.cs
@@ -118,6 +118,43 @@ namespace Progesi.Core.Tests.Services
     }
 
     [Fact]
+    public async Task UpdateCluster_StrictReject_When_VariableId_Missing()
+    {
+      var clusterRepo = new InMemoryVariableClusterRepository();
+      var varRepo = new InMemoryVariableRepository();
+      await varRepo.SaveAsync(new ProgesiVariable(2, "v2", 1.0));
+      var service = new ClusterService(clusterRepo, varRepo);
+
+      var created = await service.CreateOrGetClusterAsync("C", new[] { 2 }, "d");
+
+      await Assert.ThrowsAsync<System.ArgumentException>(
+        () => service.UpdateClusterAsync(created.Id, "C", new[] { 2, 9 }, "d"));
+
+      var reloaded = await service.GetByIdAsync(created.Id);
+      Assert.NotNull(reloaded);
+      Assert.True(reloaded!.ProgesiVariableIds.SequenceEqual(new[] { 2 }));
+    }
+
+    [Fact]
+    public async Task UpdateCluster_Succeeds_When_All_Variables_Exist()
+    {
+      var clusterRepo = new InMemoryVariableClusterRepository();
+      var varRepo = new InMemoryVariableRepository();
+      await varRepo.SaveAsync(new ProgesiVariable(2, "v2", 1.0));
+      await varRepo.SaveAsync(new ProgesiVariable(9, "v9", 2.0));
+      var service = new ClusterService(clusterRepo, varRepo);
+
+      var created = await service.CreateOrGetClusterAsync("C", new[] { 2 }, "d");
+
+      var updated = await service.UpdateClusterAsync(created.Id, "C2", new[] { 2, 9 }, "d2");
+
+      Assert.Equal(created.Id, updated.Id);
+      Assert.Equal("C2", updated.Name);
+      Assert.True(updated.ProgesiVariableIds.SequenceEqual(new[] { 2, 9 }));
+      Assert.Equal("d2", updated.Description);
+    }
+
+    [Fact]
     public async Task CascadeRemove_Removes_Variable_And_Keeps_NonEmpty_Cluster()
     {
       var clusterRepo = new InMemoryVariableClusterRepository();


### PR DESCRIPTION
## Robustness P1-3 — Cluster Update validates variable existence

**Problem:** the ClusterDef **Update** path wrote straight to the repo via `Rehydrate`, bypassing the variable-existence validation that **Create** enforces — so the UI could introduce **dangling variable references**.

**Fix:** adds `ClusterService.UpdateClusterAsync` (validates referenced variable Ids exist via a shared `ValidateReferencedVariablesExistAsync` helper — also DRYs up Create — then a true in-place update, no dedup) + `IClusterService` signature. The component Update branch now routes through it and surfaces validation failures as a **red `AddRuntimeMessage(Error)`** (also improves GH error surfacing).

**Integration note:** P1-3 was reapplied cleanly on top of the merged P1-2 (#102) — both `CascadeResult` and `UpdateClusterAsync` coexist; auto-merge verified by build+test.

**Tests:** +Update-path tests (missing-id rejection + in-place update). Reports the exact delta on build.

⚠️ **Requires tab-04 manual GH validation before merge** (ClusterDef Update with valid + invalid member Ids).