### PR TITLE
feat(ef): EF-canonical groundwork - disposal, Migrate, busy-retry, schema parity (Phase 4 / A1)

### DIFF
--- a/src/Progesi.Infrastructure.EF/Internal/SqliteBusyRetryExecutionStrategy.cs
+++ b/src/Progesi.Infrastructure.EF/Internal/SqliteBusyRetryExecutionStrategy.cs
@@ -1,0 +1,22 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Progesi.Infrastructure.EF.Internal;
+
+/// <summary>
+/// Retries transient SQLite busy/locked errors under WAL contention, mirroring direct SQLite repos.
+/// </summary>
+public sealed class SqliteBusyRetryExecutionStrategy : ExecutionStrategy
+{
+  public SqliteBusyRetryExecutionStrategy(ExecutionStrategyDependencies dependencies)
+      : base(dependencies, maxRetryCount: 5, maxRetryDelay: TimeSpan.FromSeconds(1))
+  {
+  }
+
+  protected override bool ShouldRetryOn(Exception exception)
+  {
+    return exception is SqliteException sqlite
+        && (sqlite.SqliteErrorCode == 5 /* SQLITE_BUSY */ || sqlite.SqliteErrorCode == 6 /* SQLITE_LOCKED */);
+  }
+}

--- a/src/Progesi.Infrastructure.EF/ProgesiDbContextFactory.cs
+++ b/src/Progesi.Infrastructure.EF/ProgesiDbContextFactory.cs
@@ -1,18 +1,41 @@
 using Microsoft.EntityFrameworkCore;
+using Progesi.Infrastructure.EF.Internal;
 
 namespace Progesi.Infrastructure.EF;
 
 public static class ProgesiDbContextFactory
 {
+  /// <summary>SQLite busy timeout (seconds) appended to connection strings when not already set.</summary>
+  public const int DefaultBusyTimeoutSeconds = 5;
+
   public static ProgesiDbContext Create(string connectionString, bool resetSchema = false)
   {
-    var options = new DbContextOptionsBuilder<ProgesiDbContext>()
-        .UseSqlite(connectionString)
-        .Options;
-
+    var options = BuildOptions(NormalizeConnectionString(connectionString));
     var context = new ProgesiDbContext(options);
     EnsureSchema(context, resetSchema);
     return context;
+  }
+
+  public static DbContextOptions<ProgesiDbContext> BuildOptions(string connectionString)
+  {
+    return new DbContextOptionsBuilder<ProgesiDbContext>()
+        .UseSqlite(
+            NormalizeConnectionString(connectionString),
+            sqlite => sqlite.ExecutionStrategy(deps => new SqliteBusyRetryExecutionStrategy(deps)))
+        .Options;
+  }
+
+  public static string NormalizeConnectionString(string connectionString)
+  {
+    if (string.IsNullOrWhiteSpace(connectionString))
+      throw new ArgumentException("Connection string is required.", nameof(connectionString));
+
+    if (connectionString.Contains("Default Timeout=", StringComparison.OrdinalIgnoreCase)
+        || connectionString.Contains("Busy Timeout=", StringComparison.OrdinalIgnoreCase))
+      return connectionString;
+
+    var separator = connectionString.TrimEnd().EndsWith(';') ? string.Empty : ";";
+    return $"{connectionString}{separator}Default Timeout={DefaultBusyTimeoutSeconds}";
   }
 
   public static void EnsureSchema(ProgesiDbContext context, bool resetSchema = false)
@@ -22,6 +45,6 @@ public static class ProgesiDbContextFactory
       context.Database.EnsureDeleted();
     }
 
-    context.Database.EnsureCreated();
+    context.Database.Migrate();
   }
 }

--- a/src/Progesi.Infrastructure.EF/README.md
+++ b/src/Progesi.Infrastructure.EF/README.md
@@ -1,0 +1,13 @@
+# Progesi.Infrastructure.EF
+
+Entity Framework persistence for the **web tier** (ASP.NET). The Rhino/Grasshopper tier uses direct SQLite repositories instead.
+
+## Lifetime and concurrency
+
+- **`ProgesiDbContext` and EF repository implementations are not thread-safe.** Register them **scoped per HTTP request / unit-of-work** in DI (one context per scope).
+- Do not share a single repository or DbContext across parallel tasks or threads.
+- Connection strings get a default `busy_timeout` (`Default Timeout=5`) and EF uses a SQLite busy/locked retry execution strategy for WAL contention — parity with the direct SQLite tier.
+
+## Schema
+
+Schema evolves through EF migrations (`Database.Migrate()`). Do not use `EnsureCreated()` for production or test bootstrap.

--- a/src/Progesi.Infrastructure.EF/Repositories/EfClusterRepository.cs
+++ b/src/Progesi.Infrastructure.EF/Repositories/EfClusterRepository.cs
@@ -5,7 +5,11 @@ using Progesi.Infrastructure.EF.Entities;
 
 namespace Progesi.Infrastructure.EF.Repositories;
 
-public sealed class EfClusterRepository : IProgesiVariableClusterRepository
+/// <summary>
+/// EF Core implementation of <see cref="IProgesiVariableClusterRepository"/> for the web tier.
+/// Not thread-safe — scope one instance (and its DbContext) per request/unit-of-work.
+/// </summary>
+public sealed class EfClusterRepository : IProgesiVariableClusterRepository, IDisposable, IAsyncDisposable
 {
   private readonly ProgesiDbContext _context;
   private readonly bool _ownsContext;
@@ -157,5 +161,17 @@ public sealed class EfClusterRepository : IProgesiVariableClusterRepository
     _context.Clusters.RemoveRange(entities);
     await _context.SaveChangesAsync(ct);
     return entities.Count;
+  }
+
+  public void Dispose()
+  {
+    if (_ownsContext)
+      _context.Dispose();
+  }
+
+  public async ValueTask DisposeAsync()
+  {
+    if (_ownsContext)
+      await _context.DisposeAsync().ConfigureAwait(false);
   }
 }

--- a/src/Progesi.Infrastructure.EF/Repositories/EfMetadataRepository.cs
+++ b/src/Progesi.Infrastructure.EF/Repositories/EfMetadataRepository.cs
@@ -5,7 +5,11 @@ using Progesi.Infrastructure.EF.Internal;
 
 namespace Progesi.Infrastructure.EF.Repositories;
 
-public sealed class EfMetadataRepository : IMetadataRepository
+/// <summary>
+/// EF Core implementation of <see cref="IMetadataRepository"/> for the web tier.
+/// Not thread-safe — scope one instance (and its DbContext) per request/unit-of-work.
+/// </summary>
+public sealed class EfMetadataRepository : IMetadataRepository, IDisposable, IAsyncDisposable
 {
   private readonly ProgesiDbContext _context;
   private readonly bool _ownsContext;
@@ -136,5 +140,17 @@ public sealed class EfMetadataRepository : IMetadataRepository
         .FirstOrDefaultAsync(ct);
 
     return id ?? 0;
+  }
+
+  public void Dispose()
+  {
+    if (_ownsContext)
+      _context.Dispose();
+  }
+
+  public async ValueTask DisposeAsync()
+  {
+    if (_ownsContext)
+      await _context.DisposeAsync().ConfigureAwait(false);
   }
 }

--- a/src/Progesi.Infrastructure.EF/Repositories/EfVariableRepository.cs
+++ b/src/Progesi.Infrastructure.EF/Repositories/EfVariableRepository.cs
@@ -6,7 +6,11 @@ using Progesi.Infrastructure.EF.Internal;
 
 namespace Progesi.Infrastructure.EF.Repositories;
 
-public sealed class EfVariableRepository : IVariableRepository
+/// <summary>
+/// EF Core implementation of <see cref="IVariableRepository"/> for the web tier.
+/// Not thread-safe — scope one instance (and its DbContext) per request/unit-of-work.
+/// </summary>
+public sealed class EfVariableRepository : IVariableRepository, IDisposable, IAsyncDisposable
 {
   private readonly ProgesiDbContext _context;
   private readonly bool _ownsContext;
@@ -174,5 +178,17 @@ public sealed class EfVariableRepository : IVariableRepository
     _context.Variables.RemoveRange(entities);
     await _context.SaveChangesAsync(ct);
     return entities.Count;
+  }
+
+  public void Dispose()
+  {
+    if (_ownsContext)
+      _context.Dispose();
+  }
+
+  public async ValueTask DisposeAsync()
+  {
+    if (_ownsContext)
+      await _context.DisposeAsync().ConfigureAwait(false);
   }
 }

--- a/tests/Progesi.Infrastructure.EF.Tests/EfClusterRepositoryTests.cs
+++ b/tests/Progesi.Infrastructure.EF.Tests/EfClusterRepositoryTests.cs
@@ -127,6 +127,7 @@ public sealed class EfClusterRepositoryTests : IDisposable
 
   public void Dispose()
   {
+    _repo.Dispose();
     var path = _connectionString.Replace("Data Source=", string.Empty);
     try
     {

--- a/tests/Progesi.Infrastructure.EF.Tests/EfMetadataRepositoryTests.cs
+++ b/tests/Progesi.Infrastructure.EF.Tests/EfMetadataRepositoryTests.cs
@@ -131,6 +131,7 @@ public sealed class EfMetadataRepositoryTests : IDisposable
 
   public void Dispose()
   {
+    _repo.Dispose();
     var path = _connectionString.Replace("Data Source=", string.Empty);
     try
     {

--- a/tests/Progesi.Infrastructure.EF.Tests/EfRepositoryDisposalTests.cs
+++ b/tests/Progesi.Infrastructure.EF.Tests/EfRepositoryDisposalTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Progesi.Infrastructure.EF.Repositories;
+
+namespace Progesi.Infrastructure.EF.Tests;
+
+public sealed class EfRepositoryDisposalTests
+{
+  [Fact]
+  public void ConnectionStringCtor_Disposes_Owned_DbContext()
+  {
+    var connectionString = EfTestBootstrap.CreateTempFileConnectionString();
+    var repo = new EfVariableRepository(connectionString, resetSchema: true);
+
+    repo.Dispose();
+
+    var act = () => repo.GetAllAsync().GetAwaiter().GetResult();
+    act.Should().Throw<ObjectDisposedException>();
+  }
+
+  [Fact]
+  public async Task ConnectionStringCtor_DisposeAsync_Disposes_Owned_DbContext()
+  {
+    var connectionString = EfTestBootstrap.CreateTempFileConnectionString();
+    var repo = new EfMetadataRepository(connectionString, resetSchema: true);
+
+    await repo.DisposeAsync();
+
+    var act = async () => await repo.ListAsync();
+    await act.Should().ThrowAsync<ObjectDisposedException>();
+  }
+
+  [Fact]
+  public void InjectedContextCtor_Does_Not_Dispose_External_Context()
+  {
+    var (context, connection) = EfTestBootstrap.CreateIsolatedContext();
+    try
+    {
+      var repo = new EfClusterRepository(context, ownsContext: false);
+      repo.Dispose();
+
+      context.Database.CanConnect().Should().BeTrue(
+        because: "repos with ownsContext=false must not dispose an injected DbContext");
+    }
+    finally
+    {
+      context.Dispose();
+      connection.Dispose();
+    }
+  }
+}

--- a/tests/Progesi.Infrastructure.EF.Tests/EfVariableRepositoryGeometryTests.cs
+++ b/tests/Progesi.Infrastructure.EF.Tests/EfVariableRepositoryGeometryTests.cs
@@ -95,6 +95,7 @@ public sealed class EfVariableRepositoryGeometryTests : IDisposable
 
   public void Dispose()
   {
+    _repo.Dispose();
     var path = _connectionString.Replace("Data Source=", string.Empty);
     try
     {

--- a/tests/Progesi.Infrastructure.EF.Tests/EfVariableRepositoryTests.cs
+++ b/tests/Progesi.Infrastructure.EF.Tests/EfVariableRepositoryTests.cs
@@ -231,6 +231,7 @@ public sealed class EfVariableRepositoryTests : IDisposable
 
   public void Dispose()
   {
+    _repo.Dispose();
     var path = _connectionString.Replace("Data Source=", string.Empty);
     try
     {

--- a/tests/Progesi.Infrastructure.EF.Tests/ProgesiDbContextTests.cs
+++ b/tests/Progesi.Infrastructure.EF.Tests/ProgesiDbContextTests.cs
@@ -14,14 +14,16 @@ public sealed class ProgesiDbContextTests : IDisposable
   }
 
   [Fact]
-  public void EnsureCreated_Creates_Variable_And_Metadata_Tables()
+  public void Migrate_Creates_Core_Tables()
   {
     _context.Variables.Should().NotBeNull();
     _context.Metadata.Should().NotBeNull();
+    _context.Clusters.Should().NotBeNull();
 
     _context.Database.CanConnect().Should().BeTrue();
     _context.Variables.Count().Should().Be(0);
     _context.Metadata.Count().Should().Be(0);
+    _context.Clusters.Count().Should().Be(0);
   }
 
   public void Dispose()

--- a/tests/Progesi.Repositories.Conformance.Tests/SqliteEfSchemaParityTests.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/SqliteEfSchemaParityTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Progesi.Infrastructure.EF;
+using Progesi.Repositories.Conformance.Tests.Support;
+using ProgesiRepositories.Sqlite;
+
+namespace Progesi.Repositories.Conformance.Tests;
+
+/// <summary>
+/// Pins the canonical relational schema: direct SQLite (GH tier) and EF Migrate (web tier) must agree
+/// on column sets, ContentHash NOT NULL, and UNIQUE(ContentHash) per core table.
+/// </summary>
+public sealed class SqliteEfSchemaParityTests : IDisposable
+{
+  private readonly string _sqlitePath;
+  private readonly string _efPath;
+
+  public SqliteEfSchemaParityTests()
+  {
+    _sqlitePath = Path.Combine(Path.GetTempPath(), $"progesi_schema_sqlite_{Guid.NewGuid():N}.sqlite");
+    _efPath = Path.Combine(Path.GetTempPath(), $"progesi_schema_ef_{Guid.NewGuid():N}.sqlite");
+
+    _ = new SqliteVariableRepository(_sqlitePath, resetSchema: true);
+    _ = new SqliteMetadataRepository(_sqlitePath, resetSchema: false);
+    _ = new SqliteClusterRepository(_sqlitePath, resetSchema: false);
+
+    using var efContext = ProgesiDbContextFactory.Create($"Data Source={_efPath}", resetSchema: true);
+  }
+
+  [Theory]
+  [InlineData("Variables")]
+  [InlineData("Metadata")]
+  [InlineData("Clusters")]
+  public void Sqlite_And_Ef_Schemas_Agree_On_Columns_ContentHash_NotNull_And_Unique_Index(string table)
+  {
+    var sqliteColumns = ReadColumns(_sqlitePath, table);
+    var efColumns = ReadColumns(_efPath, table);
+
+    sqliteColumns.Select(c => c.Name).Should().BeEquivalentTo(efColumns.Select(c => c.Name),
+      because: $"{table} column sets must match between SQLite and EF");
+
+    sqliteColumns.Single(c => c.Name == "ContentHash").NotNull.Should().BeTrue(
+      because: $"SQLite {table}.ContentHash must be NOT NULL");
+    efColumns.Single(c => c.Name == "ContentHash").NotNull.Should().BeTrue(
+      because: $"EF {table}.ContentHash must be NOT NULL");
+
+    var sqliteIndex = ReadUniqueContentHashIndex(_sqlitePath, table);
+    var efIndex = ReadUniqueContentHashIndex(_efPath, table);
+
+    sqliteIndex.Should().NotBeNull(because: $"SQLite {table} must have a UNIQUE index on ContentHash");
+    efIndex.Should().NotBeNull(because: $"EF {table} must have a UNIQUE index on ContentHash");
+    sqliteIndex!.Columns.Should().Equal("ContentHash");
+    efIndex!.Columns.Should().Equal("ContentHash");
+  }
+
+  private static IReadOnlyList<ColumnInfo> ReadColumns(string dbPath, string table)
+  {
+    using var conn = OpenReadOnly(dbPath);
+    return SchemaIntrospection.GetColumns(conn, table);
+  }
+
+  private static IndexInfo? ReadUniqueContentHashIndex(string dbPath, string table)
+  {
+    using var conn = OpenReadOnly(dbPath);
+    return SchemaIntrospection.FindUniqueContentHashIndex(conn, table);
+  }
+
+  private static SqliteConnection OpenReadOnly(string dbPath)
+  {
+    var conn = new SqliteConnection($"Data Source={dbPath};Mode=ReadOnly");
+    conn.Open();
+    return conn;
+  }
+
+  public void Dispose()
+  {
+    TryDelete(_sqlitePath);
+    TryDelete(_efPath);
+  }
+
+  private static void TryDelete(string path)
+  {
+    try
+    {
+      if (File.Exists(path)) File.Delete(path);
+    }
+    catch
+    {
+      // best-effort cleanup
+    }
+  }
+}

--- a/tests/Progesi.Repositories.Conformance.Tests/Support/SchemaIntrospection.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/Support/SchemaIntrospection.cs
@@ -1,0 +1,57 @@
+using Microsoft.Data.Sqlite;
+
+namespace Progesi.Repositories.Conformance.Tests.Support;
+
+internal sealed record ColumnInfo(string Name, bool NotNull);
+
+internal sealed record IndexInfo(string Name, bool IsUnique, IReadOnlyList<string> Columns);
+
+internal static class SchemaIntrospection
+{
+  public static IReadOnlyList<ColumnInfo> GetColumns(SqliteConnection conn, string table)
+  {
+    using var cmd = conn.CreateCommand();
+    cmd.CommandText = $"PRAGMA table_info({table});";
+
+    var columns = new List<ColumnInfo>();
+    using var reader = cmd.ExecuteReader();
+    while (reader.Read())
+    {
+      var name = reader.GetString(1);
+      var notNull = reader.GetInt32(3) == 1;
+      columns.Add(new ColumnInfo(name, notNull));
+    }
+
+    return columns;
+  }
+
+  public static IndexInfo? FindUniqueContentHashIndex(SqliteConnection conn, string table)
+  {
+    using var listCmd = conn.CreateCommand();
+    listCmd.CommandText = $"PRAGMA index_list({table});";
+
+    using var listReader = listCmd.ExecuteReader();
+    while (listReader.Read())
+    {
+      var indexName = listReader.GetString(1);
+      var isUnique = listReader.GetInt32(2) == 1;
+      if (!isUnique)
+        continue;
+
+      using var infoCmd = conn.CreateCommand();
+      infoCmd.CommandText = $"PRAGMA index_info({indexName});";
+
+      var columns = new List<string>();
+      using var infoReader = infoCmd.ExecuteReader();
+      while (infoReader.Read())
+      {
+        columns.Add(infoReader.GetString(2));
+      }
+
+      if (columns.Any(c => string.Equals(c, "ContentHash", StringComparison.OrdinalIgnoreCase)))
+        return new IndexInfo(indexName, true, columns);
+    }
+
+    return null;
+  }
+}


### PR DESCRIPTION
## Phase 4 / A1 — EF-canonical groundwork

Hardens `Progesi.Infrastructure.EF` as the canonical web-tier persistence + pins the canonical schema. Delivers the deferred **P2** (EF lifetime/resilience) + **P1-5 Option 2** (schema parity).

- **DbContext disposal** — Ef{Variable,Metadata,Cluster}Repository now `IDisposable`+`IAsyncDisposable`; dispose the owned context only when `_ownsContext` (fixes the leak; the field is no longer dead).
- **`EnsureCreated()` → `Migrate()`** — `ProgesiDbContextFactory` (reset = `EnsureDeleted()`+`Migrate()`); fixes silent schema drift, enables migration-based evolution. All 3 migrations apply cleanly.
- **Resilience** — `SqliteBusyRetryExecutionStrategy` (SQLITE_BUSY/LOCKED, 5 attempts) + `Default Timeout=5`; README/XML docs: EF repos not thread-safe → scope per request.
- **Schema parity (P1-5 Opt 2)** — `SqliteEfSchemaParityTests` asserts SQLite-tier and EF-Migrate agree on column set + `ContentHash` NOT NULL + UNIQUE(ContentHash) for Variables/Metadata/Clusters.

**Out of scope:** the `IVariableRepository` nullable-contract change (broad ripple — separate task); the ASP.NET/web project (A2/A3). **Tests: 344 → 350** (+3 disposal, +3 parity), 19 stress skipped, 0 failed. CI-validated (EF is web-tier only; no manual GH).