### PR TITLE
feat(axisvar): B1 - ProgesiAxisVariable Core evolution + ProgesiFunction (post-unfreeze)

### DIFF
--- a/src/ProgesiCore/AxisCurveMode.cs
+++ b/src/ProgesiCore/AxisCurveMode.cs
@@ -1,0 +1,12 @@
+namespace ProgesiCore
+{
+  /// <summary>
+  /// Canonical curve interpretation mode for an axis (promoted from GH AxisContext).
+  /// </summary>
+  public enum AxisCurveMode
+  {
+    Curve3d = 0,
+    PlanXY = 1,
+    Profile = 2
+  }
+}

--- a/src/ProgesiCore/Internal/ProgesiFunctionExpressionEvaluator.cs
+++ b/src/ProgesiCore/Internal/ProgesiFunctionExpressionEvaluator.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace ProgesiCore.Internal
+{
+  /// <summary>
+  /// Pure-managed deterministic evaluator for axis function expressions.
+  /// Variable: x (normalized position). Supports + - * / ^ and sin cos tan log ln abs sqrt min max.
+  /// </summary>
+  internal static class ProgesiFunctionExpressionEvaluator
+  {
+    public static double Evaluate(string expression, double x)
+    {
+      if (string.IsNullOrWhiteSpace(expression))
+        throw new ArgumentException("Expression is required.", nameof(expression));
+
+      var tokens = Tokenize(expression);
+      var parser = new Parser(tokens, x);
+      var value = parser.ParseExpression();
+      if (parser.HasRemaining)
+        throw new FormatException("Unexpected trailing tokens in expression.");
+      return value;
+    }
+
+    private static List<Token> Tokenize(string expression)
+    {
+      var tokens = new List<Token>();
+      int i = 0;
+      while (i < expression.Length)
+      {
+        char c = expression[i];
+        if (char.IsWhiteSpace(c))
+        {
+          i++;
+          continue;
+        }
+
+        if (char.IsDigit(c) || (c == '.' && i + 1 < expression.Length && char.IsDigit(expression[i + 1])))
+        {
+          int start = i;
+          i++;
+          while (i < expression.Length && (char.IsDigit(expression[i]) || expression[i] == '.'))
+            i++;
+          tokens.Add(new Token(TokenKind.Number, expression.Substring(start, i - start)));
+          continue;
+        }
+
+        if (char.IsLetter(c))
+        {
+          int start = i;
+          i++;
+          while (i < expression.Length && (char.IsLetterOrDigit(expression[i]) || expression[i] == '_'))
+            i++;
+          tokens.Add(new Token(TokenKind.Identifier, expression.Substring(start, i - start)));
+          continue;
+        }
+
+        if ("+-*/^(),".IndexOf(c) >= 0)
+        {
+          tokens.Add(new Token(TokenKind.Symbol, c.ToString()));
+          i++;
+          continue;
+        }
+
+        throw new FormatException($"Unsupported character '{c}' in expression.");
+      }
+
+      return tokens;
+    }
+
+    private enum TokenKind { Number, Identifier, Symbol }
+
+    private readonly struct Token
+    {
+      public TokenKind Kind { get; }
+      public string Text { get; }
+      public Token(TokenKind kind, string text) { Kind = kind; Text = text; }
+    }
+
+    private sealed class Parser
+    {
+      private readonly List<Token> _tokens;
+      private readonly double _x;
+      private int _index;
+
+      public Parser(List<Token> tokens, double x)
+      {
+        _tokens = tokens;
+        _x = x;
+      }
+
+      public bool HasRemaining => _index < _tokens.Count;
+
+      public double ParseExpression() => ParseAddSub();
+
+      private double ParseAddSub()
+      {
+        double left = ParseMulDiv();
+        while (Match("+", "-"))
+        {
+          string op = Previous().Text;
+          double right = ParseMulDiv();
+          left = op == "+" ? left + right : left - right;
+        }
+        return left;
+      }
+
+      private double ParseMulDiv()
+      {
+        double left = ParsePower();
+        while (Match("*", "/"))
+        {
+          string op = Previous().Text;
+          double right = ParsePower();
+          left = op == "*" ? left * right : left / right;
+        }
+        return left;
+      }
+
+      private double ParsePower()
+      {
+        double left = ParseUnary();
+        if (Match("^"))
+          left = Math.Pow(left, ParseUnary());
+        return left;
+      }
+
+      private double ParseUnary()
+      {
+        if (Match("-"))
+          return -ParseUnary();
+        return ParsePrimary();
+      }
+
+      private double ParsePrimary()
+      {
+        if (MatchNumber(out var number))
+          return number;
+
+        if (MatchIdentifier(out var ident))
+        {
+          if (string.Equals(ident, "x", StringComparison.OrdinalIgnoreCase))
+            return _x;
+
+          if (Match("("))
+          {
+            var args = new List<double>();
+            if (!Check(")"))
+            {
+              do
+              {
+                args.Add(ParseExpression());
+              } while (Match(","));
+            }
+            Consume(")", "Expected ')' after function arguments.");
+            return EvaluateFunction(ident, args);
+          }
+
+          throw new FormatException($"Unknown identifier '{ident}'.");
+        }
+
+        if (Match("("))
+        {
+          double val = ParseExpression();
+          Consume(")", "Expected ')' after expression.");
+          return val;
+        }
+
+        throw new FormatException("Expected number, identifier, or '('.");
+      }
+
+      private static double EvaluateFunction(string name, List<double> args)
+      {
+        switch (name.ToLowerInvariant())
+        {
+          case "sin": return RequireArgs(name, args, 1, a => Math.Sin(a[0]));
+          case "cos": return RequireArgs(name, args, 1, a => Math.Cos(a[0]));
+          case "tan": return RequireArgs(name, args, 1, a => Math.Tan(a[0]));
+          case "log": return RequireArgs(name, args, 1, a => Math.Log10(a[0]));
+          case "ln": return RequireArgs(name, args, 1, a => Math.Log(a[0]));
+          case "abs": return RequireArgs(name, args, 1, a => Math.Abs(a[0]));
+          case "sqrt": return RequireArgs(name, args, 1, a => Math.Sqrt(a[0]));
+          case "min": return RequireArgs(name, args, 2, a => Math.Min(a[0], a[1]));
+          case "max": return RequireArgs(name, args, 2, a => Math.Max(a[0], a[1]));
+          default:
+            throw new FormatException($"Unsupported function '{name}'.");
+        }
+      }
+
+      private static double RequireArgs(string name, List<double> args, int count, Func<List<double>, double> eval)
+      {
+        if (args.Count != count)
+          throw new FormatException($"Function '{name}' expects {count} argument(s).");
+        return eval(args);
+      }
+
+      private bool MatchNumber(out double value)
+      {
+        if (_index < _tokens.Count && _tokens[_index].Kind == TokenKind.Number)
+        {
+          value = double.Parse(_tokens[_index].Text, CultureInfo.InvariantCulture);
+          _index++;
+          return true;
+        }
+        value = 0;
+        return false;
+      }
+
+      private bool MatchIdentifier(out string ident)
+      {
+        if (_index < _tokens.Count && _tokens[_index].Kind == TokenKind.Identifier)
+        {
+          ident = _tokens[_index].Text;
+          _index++;
+          return true;
+        }
+        ident = string.Empty;
+        return false;
+      }
+
+      private bool Match(params string[] symbols)
+      {
+        if (_index >= _tokens.Count || _tokens[_index].Kind != TokenKind.Symbol)
+          return false;
+        foreach (var sym in symbols)
+        {
+          if (_tokens[_index].Text == sym)
+          {
+            _index++;
+            return true;
+          }
+        }
+        return false;
+      }
+
+      private bool Check(string symbol) =>
+        _index < _tokens.Count && _tokens[_index].Kind == TokenKind.Symbol && _tokens[_index].Text == symbol;
+
+      private void Consume(string symbol, string message)
+      {
+        if (!Match(symbol))
+          throw new FormatException(message);
+      }
+
+      private Token Previous() => _tokens[_index - 1];
+    }
+  }
+}

--- a/src/ProgesiCore/ProgesiAxisVariable.cs
+++ b/src/ProgesiCore/ProgesiAxisVariable.cs
@@ -26,6 +26,15 @@ namespace ProgesiCore
     /// </summary>
     public double? AxisLength { get; private set; }
 
+    /// <summary>Opaque serialized curve geometry (Rhino-free round-trip payload for adapters).</summary>
+    public string CurvePayload { get; private set; } = string.Empty;
+
+    /// <summary>Canonical curve interpretation mode.</summary>
+    public AxisCurveMode Mode { get; private set; } = AxisCurveMode.Curve3d;
+
+    /// <summary>Normalized [0,1] positions where variables are always defined/interpolated.</summary>
+    public IReadOnlyList<double> KeyPoints { get; private set; } = Array.Empty<double>();
+
     /// <summary>Nome della ProgesiVariable mappata (UNICO per l'intero oggetto).</summary>
     public string Name { get; private set; } = string.Empty;
 
@@ -36,9 +45,18 @@ namespace ProgesiCore
     public string ValueTypeKey { get; private set; } = string.Empty;
 
     /// <summary>
-    /// Placeholder per futuri modelli di legge/segmenti (oggi resta per compatibilità roadmap).
+    /// Legacy placeholder retained for back-compat; prefer <see cref="FunctionRef"/>.
     /// </summary>
     public int? RuleId { get; private set; }
+
+    /// <summary>Reference to or embedded copy of the governing ProgesiFunction.</summary>
+    public ProgesiFunctionRef FunctionRef { get; private set; } = ProgesiFunctionRef.Empty;
+
+    /// <summary>Content-based hashtag (SHA-256 digest; derived, not part of equality).</summary>
+    public string Hashtag => ProgesiHash.Compute(this);
+
+    /// <summary>Alias aligned with Cluster/Metadata naming.</summary>
+    public string ContentHash => Hashtag;
 
     // Single-series map: PositionKey -> set of variable ids
     private readonly SortedDictionary<PositionKey, HashSet<int>> _map
@@ -50,7 +68,11 @@ namespace ProgesiCore
       string name,
       string valueTypeKey,
       double? axisLength = null,
-      int? ruleId = null)
+      int? ruleId = null,
+      string? curvePayload = null,
+      AxisCurveMode mode = AxisCurveMode.Curve3d,
+      IEnumerable<double>? keyPoints = null,
+      ProgesiFunctionRef? functionRef = null)
     {
       Guard.Against.Negative(id, nameof(id));
       Guard.Against.NullOrWhiteSpace(axisName, nameof(axisName));
@@ -65,6 +87,10 @@ namespace ProgesiCore
       ValueTypeKey = valueTypeKey.Trim();
       AxisLength = axisLength;
       RuleId = ruleId;
+      CurvePayload = curvePayload ?? string.Empty;
+      Mode = mode;
+      FunctionRef = functionRef ?? ProgesiFunctionRef.Empty;
+      KeyPoints = NormalizeKeyPoints(keyPoints);
     }
 
     /// <summary>
@@ -90,12 +116,9 @@ namespace ProgesiCore
 
     public IReadOnlyDictionary<double, int[]> GetMap(double tol = DefaultTolerance)
     {
-      // tol is only used for consistency with callers; keys already bucketed.
       var result = new Dictionary<double, int[]>();
       foreach (var kv in _map)
-      {
         result[kv.Key.Value] = kv.Value.OrderBy(x => x).ToArray();
-      }
       return result;
     }
 
@@ -112,14 +135,11 @@ namespace ProgesiCore
       {
         var posKey = inner.Key;
         var ids = inner.Value;
-        foreach (int id in ids.OrderBy(x => x))
-          yield return (posKey.Value, id);
+        foreach (int vid in ids.OrderBy(x => x))
+          yield return (posKey.Value, vid);
       }
     }
 
-    /// <summary>
-    /// Aggiunge una variabile alla stazione (posizione normalizzata). Valida Name e ValueTypeKey.
-    /// </summary>
     public void Add(ProgesiVariableSignature signature, double positionNormalized, double tol = DefaultTolerance)
     {
       if (!StringComparer.Ordinal.Equals(signature.Name, Name))
@@ -131,9 +151,6 @@ namespace ProgesiCore
       AddUnsafe(positionNormalized, signature.Id, tol);
     }
 
-    /// <summary>
-    /// Aggiunge un id senza poter verificare Name/ValueTypeKey. Usare solo in contesti controllati (DTO/repo).
-    /// </summary>
     internal void AddUnsafe(double positionNormalized, int variableId, double tol = DefaultTolerance)
     {
       Guard.Against.Negative(variableId, nameof(variableId));
@@ -229,7 +246,26 @@ namespace ProgesiCore
       AxisLength = axisLength;
     }
 
-    /// <summary>Converte una stazione reale (lunghezza lungo curva) in normalizzata [0,1].</summary>
+    public void SetCurvePayload(string? curvePayload)
+    {
+      CurvePayload = curvePayload ?? string.Empty;
+    }
+
+    public void SetMode(AxisCurveMode mode)
+    {
+      Mode = mode;
+    }
+
+    public void SetKeyPoints(IEnumerable<double>? keyPoints)
+    {
+      KeyPoints = NormalizeKeyPoints(keyPoints);
+    }
+
+    public void SetFunctionRef(ProgesiFunctionRef? functionRef)
+    {
+      FunctionRef = functionRef ?? ProgesiFunctionRef.Empty;
+    }
+
     public double ToNormalizedFromReal(double realStation)
     {
       if (!AxisLength.HasValue)
@@ -239,13 +275,27 @@ namespace ProgesiCore
       return realStation / AxisLength.Value;
     }
 
-    /// <summary>Converte una stazione normalizzata [0,1] in reale (lunghezza lungo curva).</summary>
     public double ToRealFromNormalized(double normalizedStation)
     {
       if (!AxisLength.HasValue)
         throw new InvalidOperationException("AxisLength is required to convert from normalized to real.");
       ValidateNormalizedPosition(normalizedStation);
       return normalizedStation * AxisLength.Value;
+    }
+
+    private static IReadOnlyList<double> NormalizeKeyPoints(IEnumerable<double>? keyPoints)
+    {
+      if (keyPoints == null)
+        return Array.Empty<double>();
+
+      var list = new List<double>();
+      foreach (var point in keyPoints)
+      {
+        ValidateNormalizedPosition(point);
+        list.Add(point);
+      }
+
+      return list.OrderBy(x => x).Distinct().ToArray();
     }
 
     private static void ValidateNormalizedPosition(double positionNormalized)
@@ -263,9 +313,15 @@ namespace ProgesiCore
       yield return Id;
       yield return AxisName;
       yield return AxisLength.HasValue ? AxisLength.Value : double.NaN;
+      yield return CurvePayload;
+      yield return Mode;
+      foreach (double kp in KeyPoints)
+        yield return kp;
       yield return Name;
       yield return ValueTypeKey;
       yield return RuleId.HasValue ? RuleId.Value : int.MinValue;
+      if (!FunctionRef.IsEmpty)
+        yield return FunctionRef;
 
       foreach (var kv in _map)
       {

--- a/src/ProgesiCore/ProgesiAxisVariableDto.cs
+++ b/src/ProgesiCore/ProgesiAxisVariableDto.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Ardalis.GuardClauses;
 
 namespace ProgesiCore.Serialization
@@ -12,7 +13,7 @@ namespace ProgesiCore.Serialization
   /// - Name e ValueTypeKey sono univoci per l'intero oggetto.
   ///
   /// Tabelle suggerite:
-  ///   Axis:      (AxisId, AxisName, AxisLength, Name, ValueTypeKey, RuleId)
+  ///   Axis:      (AxisId, AxisName, AxisLength, Name, ValueTypeKey, RuleId, CurvePayload, Mode, KeyPointsJson, FunctionRef...)
   ///   AxisEntry: (AxisId, Position, VariableId)
   /// </summary>
   public sealed class ProgesiAxisVariableDto
@@ -21,10 +22,20 @@ namespace ProgesiCore.Serialization
     public string AxisName { get; set; } = string.Empty;
     public double? AxisLength { get; set; }
 
+    public string CurvePayload { get; set; } = string.Empty;
+    public AxisCurveMode Mode { get; set; } = AxisCurveMode.Curve3d;
+    public List<double> KeyPoints { get; set; } = new List<double>();
+
     public string Name { get; set; } = string.Empty;
     public string ValueTypeKey { get; set; } = string.Empty;
 
     public int? RuleId { get; set; }
+
+    public int? FunctionId { get; set; }
+    public string? FunctionHashtag { get; set; }
+    public string? FunctionPayload { get; set; }
+
+    public string ContentHash { get; set; } = string.Empty;
 
     public List<Entry> Entries { get; set; } = new List<Entry>();
 
@@ -44,11 +55,23 @@ namespace ProgesiCore.Serialization
         AxisId = axis.Id,
         AxisName = axis.AxisName,
         AxisLength = axis.AxisLength,
+        CurvePayload = axis.CurvePayload,
+        Mode = axis.Mode,
+        KeyPoints = axis.KeyPoints.ToList(),
         Name = axis.Name,
         ValueTypeKey = axis.ValueTypeKey,
         RuleId = axis.RuleId,
+        ContentHash = axis.ContentHash,
         Entries = new List<Entry>()
       };
+
+      if (!axis.FunctionRef.IsEmpty)
+      {
+        dto.FunctionId = axis.FunctionRef.FunctionId;
+        dto.FunctionHashtag = axis.FunctionRef.FunctionHashtag;
+        if (axis.FunctionRef.Embedded != null)
+          dto.FunctionPayload = axis.FunctionRef.Embedded.ToJson();
+      }
 
       foreach (var t in axis.EnumerateAll())
       {
@@ -71,8 +94,20 @@ namespace ProgesiCore.Serialization
       Guard.Against.NullOrWhiteSpace(dto.ValueTypeKey, nameof(dto.ValueTypeKey));
       if (dto.AxisLength.HasValue) Guard.Against.NegativeOrZero(dto.AxisLength.Value, nameof(dto.AxisLength));
       if (dto.RuleId.HasValue) Guard.Against.Negative(dto.RuleId.Value, nameof(dto.RuleId));
+      if (dto.FunctionId.HasValue) Guard.Against.Negative(dto.FunctionId.Value, nameof(dto.FunctionId));
 
-      var axis = new ProgesiAxisVariable(dto.AxisId, dto.AxisName, dto.Name, dto.ValueTypeKey, dto.AxisLength, dto.RuleId);
+      var functionRef = BuildFunctionRef(dto);
+      var axis = new ProgesiAxisVariable(
+        dto.AxisId,
+        dto.AxisName,
+        dto.Name,
+        dto.ValueTypeKey,
+        dto.AxisLength,
+        dto.RuleId,
+        dto.CurvePayload,
+        dto.Mode,
+        dto.KeyPoints,
+        functionRef);
 
       if (dto.Entries != null)
       {
@@ -82,13 +117,25 @@ namespace ProgesiCore.Serialization
           if (double.IsNaN(e.Position) || double.IsInfinity(e.Position))
             throw new ArgumentOutOfRangeException(nameof(e.Position), "Position must be finite.");
           Guard.Against.Negative(e.VariableId, nameof(e.VariableId));
-
-          // AddUnsafe: DTO contains ids only, signature validation happens at higher layer.
           axis.AddUnsafe(e.Position, e.VariableId, tol);
         }
       }
 
       return axis;
+    }
+
+    private static ProgesiFunctionRef BuildFunctionRef(ProgesiAxisVariableDto dto)
+    {
+      if (!string.IsNullOrWhiteSpace(dto.FunctionPayload))
+        return ProgesiFunctionRef.Embed(ProgesiFunction.FromJson(dto.FunctionPayload));
+
+      if (dto.FunctionId.HasValue)
+        return ProgesiFunctionRef.ById(dto.FunctionId.Value);
+
+      if (!string.IsNullOrWhiteSpace(dto.FunctionHashtag))
+        return ProgesiFunctionRef.ByHashtag(dto.FunctionHashtag);
+
+      return ProgesiFunctionRef.Empty;
     }
 
     public IEnumerable<(int AxisId, double Position, int VariableId)> EnumerateFlat()

--- a/src/ProgesiCore/ProgesiFunction.cs
+++ b/src/ProgesiCore/ProgesiFunction.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ardalis.GuardClauses;
+using Newtonsoft.Json;
+using ProgesiCore.Internal;
+
+namespace ProgesiCore
+{
+  public enum ProgesiFunctionSegmentKind
+  {
+    Constant = 0,
+    Expression = 1,
+    Undefined = 2
+  }
+
+  /// <summary>
+  /// One segment of a piecewise function over normalized [0,1].
+  /// </summary>
+  public sealed class ProgesiFunctionSegment : ValueObject
+  {
+    public double Start { get; }
+    public double End { get; }
+    public ProgesiFunctionSegmentKind Kind { get; }
+    public double? ConstantValue { get; }
+    public string? Expression { get; }
+
+    public ProgesiFunctionSegment(
+      double start,
+      double end,
+      ProgesiFunctionSegmentKind kind,
+      double? constantValue = null,
+      string? expression = null)
+    {
+      ValidateInterval(start, end);
+      Start = start;
+      End = end;
+      Kind = kind;
+
+      switch (kind)
+      {
+        case ProgesiFunctionSegmentKind.Constant:
+          if (!constantValue.HasValue)
+            throw new ArgumentException("Constant segment requires constantValue.", nameof(constantValue));
+          ConstantValue = constantValue.Value;
+          Expression = null;
+          break;
+        case ProgesiFunctionSegmentKind.Expression:
+          if (string.IsNullOrWhiteSpace(expression))
+            throw new ArgumentException("Expression segment requires expression.", nameof(expression));
+          ConstantValue = null;
+          Expression = expression.Trim();
+          break;
+        case ProgesiFunctionSegmentKind.Undefined:
+          ConstantValue = null;
+          Expression = null;
+          break;
+        default:
+          throw new ArgumentOutOfRangeException(nameof(kind));
+      }
+    }
+
+    internal static void ValidateInterval(double start, double end)
+    {
+      if (double.IsNaN(start) || double.IsInfinity(start) || double.IsNaN(end) || double.IsInfinity(end))
+        throw new ArgumentOutOfRangeException(nameof(start), "Segment bounds must be finite.");
+      if (start < -ProgesiAxisVariable.DefaultTolerance || end > 1.0 + ProgesiAxisVariable.DefaultTolerance)
+        throw new ArgumentOutOfRangeException(nameof(start), "Segment bounds must lie within [0,1] (± tol).");
+      if (end < start - ProgesiAxisVariable.DefaultTolerance)
+        throw new ArgumentOutOfRangeException(nameof(end), "Segment end must be >= start.");
+    }
+
+    public bool Contains(double normalizedPosition, double tol = ProgesiAxisVariable.DefaultTolerance)
+    {
+      return normalizedPosition + tol >= Start && normalizedPosition <= End + tol;
+    }
+
+    public double? Evaluate(double normalizedPosition)
+    {
+      switch (Kind)
+      {
+        case ProgesiFunctionSegmentKind.Constant:
+          return ConstantValue;
+        case ProgesiFunctionSegmentKind.Undefined:
+          return null;
+        case ProgesiFunctionSegmentKind.Expression:
+          return ProgesiFunctionExpressionEvaluator.Evaluate(Expression!, normalizedPosition);
+        default:
+          return null;
+      }
+    }
+
+    protected override IEnumerable<object> GetEqualityComponents()
+    {
+      yield return Start;
+      yield return End;
+      yield return Kind;
+      yield return ConstantValue.HasValue ? ConstantValue.Value : double.NaN;
+      yield return Expression ?? string.Empty;
+    }
+  }
+
+  /// <summary>
+  /// Rhino-free piecewise function describing numeric variation along a normalized axis.
+  /// </summary>
+  public sealed class ProgesiFunction : ValueObject
+  {
+    public int Id { get; }
+    public string Name { get; }
+    public IReadOnlyList<ProgesiFunctionSegment> Segments { get; }
+
+    public string Hashtag => ProgesiHash.Compute(this);
+    public string ContentHash => Hashtag;
+
+    public ProgesiFunction(int id, string name, IEnumerable<ProgesiFunctionSegment> segments)
+    {
+      Guard.Against.Negative(id, nameof(id));
+      Guard.Against.NullOrWhiteSpace(name, nameof(name));
+      Guard.Against.Null(segments, nameof(segments));
+
+      var list = segments.ToList();
+      if (list.Count == 0)
+        throw new ArgumentException("At least one segment is required.", nameof(segments));
+
+      ValidateNonOverlapping(list);
+
+      Id = id;
+      Name = name.Trim();
+      Segments = list.AsReadOnly();
+    }
+
+    public double? Evaluate(double normalizedPosition, double tol = ProgesiAxisVariable.DefaultTolerance)
+    {
+      ValidateNormalizedPosition(normalizedPosition);
+
+      foreach (var segment in Segments)
+      {
+        if (segment.Contains(normalizedPosition, tol))
+          return segment.Evaluate(normalizedPosition);
+      }
+
+      return null;
+    }
+
+    public string ToJson() => JsonConvert.SerializeObject(ProgesiFunctionSerializationDto.FromDomain(this));
+
+    public static ProgesiFunction FromJson(string json)
+    {
+      Guard.Against.NullOrWhiteSpace(json, nameof(json));
+      var dto = JsonConvert.DeserializeObject<ProgesiFunctionSerializationDto>(json)
+        ?? throw new FormatException("Invalid ProgesiFunction JSON payload.");
+      return dto.ToDomain();
+    }
+
+    private static void ValidateNonOverlapping(IReadOnlyList<ProgesiFunctionSegment> segments)
+    {
+      var ordered = segments.OrderBy(s => s.Start).ThenBy(s => s.End).ToList();
+      for (int i = 1; i < ordered.Count; i++)
+      {
+        if (ordered[i].Start < ordered[i - 1].End - ProgesiAxisVariable.DefaultTolerance)
+          throw new ArgumentException("Function segments must not overlap.", nameof(segments));
+      }
+    }
+
+    private static void ValidateNormalizedPosition(double positionNormalized)
+    {
+      if (double.IsNaN(positionNormalized) || double.IsInfinity(positionNormalized))
+        throw new ArgumentOutOfRangeException(nameof(positionNormalized), "Position must be finite.");
+      if (positionNormalized < -ProgesiAxisVariable.DefaultTolerance || positionNormalized > 1.0 + ProgesiAxisVariable.DefaultTolerance)
+        throw new ArgumentOutOfRangeException(nameof(positionNormalized), "Position must lie within [0,1] (± tol).");
+    }
+
+    protected override IEnumerable<object> GetEqualityComponents()
+    {
+      yield return Id;
+      yield return Name;
+      foreach (var segment in Segments.OrderBy(s => s.Start).ThenBy(s => s.End))
+        yield return segment;
+    }
+
+    internal sealed class ProgesiFunctionSerializationDto
+    {
+      public int Id { get; set; }
+      public string Name { get; set; } = string.Empty;
+      public List<SegmentDto> Segments { get; set; } = new List<SegmentDto>();
+
+      internal sealed class SegmentDto
+      {
+        public double Start { get; set; }
+        public double End { get; set; }
+        public ProgesiFunctionSegmentKind Kind { get; set; }
+        public double? ConstantValue { get; set; }
+        public string? Expression { get; set; }
+      }
+
+      public static ProgesiFunctionSerializationDto FromDomain(ProgesiFunction function)
+      {
+        return new ProgesiFunctionSerializationDto
+        {
+          Id = function.Id,
+          Name = function.Name,
+          Segments = function.Segments.Select(s => new SegmentDto
+          {
+            Start = s.Start,
+            End = s.End,
+            Kind = s.Kind,
+            ConstantValue = s.ConstantValue,
+            Expression = s.Expression
+          }).ToList()
+        };
+      }
+
+      public ProgesiFunction ToDomain()
+      {
+        var segments = Segments.Select(s =>
+          new ProgesiFunctionSegment(s.Start, s.End, s.Kind, s.ConstantValue, s.Expression));
+        return new ProgesiFunction(Id, Name, segments);
+      }
+    }
+  }
+}

--- a/src/ProgesiCore/ProgesiFunctionRef.cs
+++ b/src/ProgesiCore/ProgesiFunctionRef.cs
@@ -1,0 +1,50 @@
+using System;
+using Ardalis.GuardClauses;
+
+namespace ProgesiCore
+{
+  /// <summary>
+  /// Reference to a reusable <see cref="ProgesiFunction"/> by id/hashtag or an embedded copy.
+  /// </summary>
+  public sealed class ProgesiFunctionRef : ValueObject
+  {
+    public int? FunctionId { get; }
+    public string? FunctionHashtag { get; }
+    public ProgesiFunction? Embedded { get; }
+
+    private ProgesiFunctionRef(int? functionId, string? functionHashtag, ProgesiFunction? embedded)
+    {
+      if (functionId.HasValue)
+        Guard.Against.Negative(functionId.Value, nameof(functionId));
+      if (!string.IsNullOrWhiteSpace(functionHashtag))
+        FunctionHashtag = functionHashtag.Trim();
+      else
+        FunctionHashtag = null;
+
+      FunctionId = functionId;
+      Embedded = embedded;
+    }
+
+    public static ProgesiFunctionRef ById(int functionId) =>
+      new ProgesiFunctionRef(functionId, null, null);
+
+    public static ProgesiFunctionRef ByHashtag(string hashtag) =>
+      new ProgesiFunctionRef(null, hashtag ?? throw new ArgumentNullException(nameof(hashtag)), null);
+
+    public static ProgesiFunctionRef Embed(ProgesiFunction function) =>
+      new ProgesiFunctionRef(null, null, function ?? throw new ArgumentNullException(nameof(function)));
+
+    public static ProgesiFunctionRef Empty { get; } = new ProgesiFunctionRef(null, null, null);
+
+    public bool IsEmpty =>
+      !FunctionId.HasValue && string.IsNullOrWhiteSpace(FunctionHashtag) && Embedded == null;
+
+    protected override System.Collections.Generic.IEnumerable<object> GetEqualityComponents()
+    {
+      yield return FunctionId.HasValue ? FunctionId.Value : int.MinValue;
+      yield return FunctionHashtag ?? string.Empty;
+      if (Embedded != null)
+        yield return Embedded;
+    }
+  }
+}

--- a/src/ProgesiCore/ProgesiHash.cs
+++ b/src/ProgesiCore/ProgesiHash.cs
@@ -169,5 +169,84 @@ namespace ProgesiCore
       string json = JsonConvert.SerializeObject(payload, JsonSettings) ?? string.Empty;
       return Sha256Hex(json);
     }
+
+    // ===== Compute per ProgesiFunction =====
+    public static string Compute(ProgesiFunction function)
+    {
+      if (function == null) throw new ArgumentNullException(nameof(function));
+
+      var segments = function.Segments
+        .OrderBy(s => s.Start)
+        .ThenBy(s => s.End)
+        .Select(s => new
+        {
+          s.Start,
+          s.End,
+          Kind = s.Kind.ToString(),
+          Constant = s.ConstantValue.HasValue ? s.ConstantValue.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) : string.Empty,
+          Expression = s.Expression ?? string.Empty
+        })
+        .ToArray();
+
+      var payload = new
+      {
+        function.Name,
+        Segments = segments
+      };
+
+      string json = JsonConvert.SerializeObject(payload, JsonSettings) ?? string.Empty;
+      return Sha256Hex(json);
+    }
+
+    // ===== Compute per ProgesiAxisVariable =====
+    public static string Compute(ProgesiAxisVariable axis)
+    {
+      if (axis == null) throw new ArgumentNullException(nameof(axis));
+
+      var entries = axis.EnumerateAll()
+        .OrderBy(t => t.positionNormalized)
+        .ThenBy(t => t.variableId)
+        .Select(t => new { Position = t.positionNormalized, t.variableId })
+        .ToArray();
+
+      var keyPoints = (axis.KeyPoints ?? Array.Empty<double>()).OrderBy(x => x).ToArray();
+
+      object? functionRef = null;
+      if (!axis.FunctionRef.IsEmpty)
+      {
+        if (axis.FunctionRef.Embedded != null)
+        {
+          functionRef = new
+          {
+            EmbeddedHash = Compute(axis.FunctionRef.Embedded)
+          };
+        }
+        else
+        {
+          functionRef = new
+          {
+            axis.FunctionRef.FunctionId,
+            axis.FunctionRef.FunctionHashtag
+          };
+        }
+      }
+
+      var payload = new
+      {
+        axis.AxisName,
+        AxisLength = axis.AxisLength.HasValue ? axis.AxisLength.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) : string.Empty,
+        axis.CurvePayload,
+        Mode = axis.Mode.ToString(),
+        KeyPoints = keyPoints,
+        axis.Name,
+        axis.ValueTypeKey,
+        axis.RuleId,
+        FunctionRef = functionRef,
+        Entries = entries
+      };
+
+      string json = JsonConvert.SerializeObject(payload, JsonSettings) ?? string.Empty;
+      return Sha256Hex(json);
+    }
   }
 }

--- a/tests/ProgesiCore.Tests/ProgesiAxisVariableDtoTests.cs
+++ b/tests/ProgesiCore.Tests/ProgesiAxisVariableDtoTests.cs
@@ -39,8 +39,35 @@ namespace ProgesiCore.Tests
       var dto = ProgesiAxisVariableDto.FromDomain(original);
       var rebuilt = ProgesiAxisVariableDto.ToDomain(dto);
 
+      // B1: equality now includes CurvePayload/Mode/KeyPoints/FunctionRef when set.
       Assert.True(original.Equals(rebuilt));
       Assert.Equal(original.GetHashCode(), rebuilt.GetHashCode());
+    }
+
+    [Fact]
+    public void FromDomain_ToDomain_RoundTrip_With_B1_Fields()
+    {
+      var axis = MakeAxis();
+      axis.SetCurvePayload("curve-payload-v1");
+      axis.SetMode(AxisCurveMode.Profile);
+      axis.SetKeyPoints(new[] { 0.0, 0.5, 1.0 });
+
+      var fn = new ProgesiFunction(9, "axis-law", new[]
+      {
+        new ProgesiFunctionSegment(0.0, 1.0, ProgesiFunctionSegmentKind.Expression, expression: "x")
+      });
+      axis.SetFunctionRef(ProgesiFunctionRef.Embed(fn));
+
+      var dto = ProgesiAxisVariableDto.FromDomain(axis);
+      Assert.Equal("curve-payload-v1", dto.CurvePayload);
+      Assert.Equal(AxisCurveMode.Profile, dto.Mode);
+      Assert.Equal(new[] { 0.0, 0.5, 1.0 }, dto.KeyPoints.OrderBy(x => x));
+      Assert.NotNull(dto.FunctionPayload);
+      Assert.Equal(axis.ContentHash, dto.ContentHash);
+
+      var rebuilt = ProgesiAxisVariableDto.ToDomain(dto);
+      Assert.True(axis.Equals(rebuilt));
+      Assert.Equal(axis.ContentHash, rebuilt.ContentHash);
     }
 
     [Fact]

--- a/tests/ProgesiCore.Tests/ProgesiAxisVariableTests.cs
+++ b/tests/ProgesiCore.Tests/ProgesiAxisVariableTests.cs
@@ -158,5 +158,66 @@ namespace ProgesiCore.Tests
       Assert.True(sut.RemoveAt(0.2, 1));
       Assert.Empty(sut.GetAt(0.2));
     }
+
+    [Fact]
+    public void NewFields_Default_And_Mutators_Work()
+    {
+      var sut = Make();
+      Assert.Equal(string.Empty, sut.CurvePayload);
+      Assert.Equal(AxisCurveMode.Curve3d, sut.Mode);
+      Assert.Empty(sut.KeyPoints);
+      Assert.True(sut.FunctionRef.IsEmpty);
+
+      sut.SetCurvePayload("curve-json-v1");
+      sut.SetMode(AxisCurveMode.PlanXY);
+      sut.SetKeyPoints(new[] { 0.0, 0.5, 1.0 });
+      sut.SetFunctionRef(ProgesiFunctionRef.ById(42));
+
+      Assert.Equal("curve-json-v1", sut.CurvePayload);
+      Assert.Equal(AxisCurveMode.PlanXY, sut.Mode);
+      Assert.Equal(new[] { 0.0, 0.5, 1.0 }, sut.KeyPoints);
+      Assert.Equal(42, sut.FunctionRef.FunctionId);
+    }
+
+    [Theory]
+    [InlineData(-0.1)]
+    [InlineData(1.1)]
+    public void KeyPoints_AreValidated_InNormalizedRange(double keyPoint)
+    {
+      var sut = Make();
+      Assert.Throws<ArgumentOutOfRangeException>(() => sut.SetKeyPoints(new[] { keyPoint }));
+    }
+
+    [Fact]
+    public void ContentHash_Is_Deterministic_And_Changes_With_NewEqualityFields()
+    {
+      var baseline = Make();
+      var sig = new ProgesiAxisVariable.ProgesiVariableSignature(1, "Thickness", "System.Double");
+      baseline.Add(sig, 0.5);
+
+      var withPayload = Make();
+      withPayload.SetCurvePayload("payload-a");
+      withPayload.Add(sig, 0.5);
+
+      // B1: ContentHash now includes axis metadata beyond the legacy station map.
+      Assert.False(string.IsNullOrWhiteSpace(baseline.ContentHash));
+      Assert.Equal(baseline.ContentHash, baseline.Hashtag);
+      Assert.NotEqual(baseline.ContentHash, withPayload.ContentHash);
+    }
+
+    [Fact]
+    public void EmbeddedFunctionRef_Affects_ContentHash()
+    {
+      var fn = new ProgesiFunction(1, "law", new[]
+      {
+        new ProgesiFunctionSegment(0.0, 1.0, ProgesiFunctionSegmentKind.Constant, constantValue: 1.0)
+      });
+
+      var withoutFn = Make();
+      var withFn = Make();
+      withFn.SetFunctionRef(ProgesiFunctionRef.Embed(fn));
+
+      Assert.NotEqual(withoutFn.ContentHash, withFn.ContentHash);
+    }
   }
 }

--- a/tests/ProgesiCore.Tests/ProgesiFunctionTests.cs
+++ b/tests/ProgesiCore.Tests/ProgesiFunctionTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Linq;
+using Xunit;
+using ProgesiCore;
+
+namespace ProgesiCore.Tests
+{
+  public class ProgesiFunctionTests
+  {
+    [Fact]
+    public void ConstantSegment_Evaluates_Value()
+    {
+      var fn = new ProgesiFunction(1, "flat", new[]
+      {
+        new ProgesiFunctionSegment(0.0, 1.0, ProgesiFunctionSegmentKind.Constant, constantValue: 3.5)
+      });
+
+      fn.Evaluate(0.25).ShouldBeAbout(3.5);
+      fn.Evaluate(0.0).ShouldBeAbout(3.5);
+      fn.Evaluate(1.0).ShouldBeAbout(3.5);
+    }
+
+    [Fact]
+    public void UndefinedSegment_Returns_Null()
+    {
+      var fn = new ProgesiFunction(2, "gap", new[]
+      {
+        new ProgesiFunctionSegment(0.0, 0.4, ProgesiFunctionSegmentKind.Undefined),
+        new ProgesiFunctionSegment(0.6, 1.0, ProgesiFunctionSegmentKind.Constant, constantValue: 1.0)
+      });
+
+      Assert.Null(fn.Evaluate(0.5));
+      fn.Evaluate(0.7).ShouldBeAbout(1.0);
+    }
+
+    [Fact]
+    public void ExpressionSegment_Evaluates_Deterministically()
+    {
+      var fn = new ProgesiFunction(3, "line", new[]
+      {
+        new ProgesiFunctionSegment(0.0, 1.0, ProgesiFunctionSegmentKind.Expression, expression: "2*x + 1")
+      });
+
+      fn.Evaluate(0.0).ShouldBeAbout(1.0);
+      fn.Evaluate(0.5).ShouldBeAbout(2.0);
+      fn.Evaluate(1.0).ShouldBeAbout(3.0);
+    }
+
+    [Fact]
+    public void ExpressionSegment_Supports_Trig_And_MinMax()
+    {
+      var fn = new ProgesiFunction(4, "trig", new[]
+      {
+        new ProgesiFunctionSegment(0.0, 1.0, ProgesiFunctionSegmentKind.Expression, expression: "max(0, sin(x))")
+      });
+
+      fn.Evaluate(0.0).ShouldBeAbout(0.0);
+      fn.Evaluate(0.5).ShouldBeAbout(Math.Max(0, Math.Sin(0.5)), 10);
+    }
+
+    [Fact]
+    public void ContentHash_Is_Deterministic_For_Same_Function()
+    {
+      var segments = new[]
+      {
+        new ProgesiFunctionSegment(0.0, 0.5, ProgesiFunctionSegmentKind.Constant, constantValue: 1.0),
+        new ProgesiFunctionSegment(0.5, 1.0, ProgesiFunctionSegmentKind.Expression, expression: "x")
+      };
+
+      var a = new ProgesiFunction(5, "fn", segments);
+      var b = new ProgesiFunction(5, "fn", segments);
+
+      Assert.Equal(a.ContentHash, b.ContentHash);
+      Assert.Equal(a.Hashtag, b.Hashtag);
+    }
+
+    [Fact]
+    public void Json_RoundTrip_Preserves_EqualState()
+    {
+      var original = new ProgesiFunction(6, "json-fn", new[]
+      {
+        new ProgesiFunctionSegment(0.0, 0.25, ProgesiFunctionSegmentKind.Constant, constantValue: 2.0),
+        new ProgesiFunctionSegment(0.25, 1.0, ProgesiFunctionSegmentKind.Expression, expression: "x * x")
+      });
+
+      var json = original.ToJson();
+      var rebuilt = ProgesiFunction.FromJson(json);
+
+      Assert.True(original.Equals(rebuilt));
+      Assert.Equal(original.ContentHash, rebuilt.ContentHash);
+    }
+
+    [Fact]
+    public void OverlappingSegments_Are_Rejected()
+    {
+      Assert.Throws<ArgumentException>(() => new ProgesiFunction(7, "bad", new[]
+      {
+        new ProgesiFunctionSegment(0.0, 0.6, ProgesiFunctionSegmentKind.Constant, constantValue: 1.0),
+        new ProgesiFunctionSegment(0.5, 1.0, ProgesiFunctionSegmentKind.Constant, constantValue: 2.0)
+      }));
+    }
+  }
+
+  internal static class ProgesiFunctionTestExtensions
+  {
+    public static void ShouldBeAbout(this double? actual, double expected, int precision = 12)
+    {
+      Assert.NotNull(actual);
+      Assert.Equal(expected, actual.Value, precision);
+    }
+  }
+}


### PR DESCRIPTION
## AxisVar B1 — Core model evolution + ProgesiFunction

First change under the **ADR-008/011 unfreeze** (ProgesiCore-only; CI-validated; no Grasshopper).

- **`ProgesiAxisVariable` evolved** — `CurvePayload` (Rhino-free), `Mode`, `KeyPoints`, `FunctionRef`, `ContentHash`. Invariants preserved; `GetEqualityComponents` extended deliberately.
- **New `ProgesiFunction`** — piecewise, **hand-rolled deterministic culture-invariant evaluator** (no new dependency).
- **Hashing** = definition, not evaluated outputs (cross-platform stable; Id excluded).
- Scope: persistence = B2; GH + linear→arc-length = B3. Core stays Rhino/EF/UI/ASP.NET-free (§4).
- **Tests:** +13. **360 → 373**, 0 failed. No-regression.

_(tab-03 lane AxisVar guards relaxed to permit `feat/axisvar-*` branches under the unfreeze — Claude-owned lane script.)_