### PR TITLE
feat(axisvar): B2 - tiered SQLite + EF persistence + parity for ProgesiAxisVariable

### DIFF
--- a/src/Progesi.Infrastructure.EF/Entities/AxisEntity.cs
+++ b/src/Progesi.Infrastructure.EF/Entities/AxisEntity.cs
@@ -1,0 +1,20 @@
+namespace Progesi.Infrastructure.EF.Entities;
+
+public sealed class AxisEntity
+{
+  public int Id { get; set; }
+  public string AxisName { get; set; } = string.Empty;
+  public string Name { get; set; } = string.Empty;
+  public string ValueTypeKey { get; set; } = string.Empty;
+  public double? AxisLength { get; set; }
+  public string CurvePayload { get; set; } = string.Empty;
+  public int Mode { get; set; }
+  public string KeyPointsJson { get; set; } = "[]";
+  public int? RuleId { get; set; }
+  public int? FunctionId { get; set; }
+  public string? FunctionHashtag { get; set; }
+  public string FunctionPayload { get; set; } = string.Empty;
+  public string StationsJson { get; set; } = "[]";
+  public string ContentHash { get; set; } = string.Empty;
+  public string Hashtag { get; set; } = string.Empty;
+}

--- a/src/Progesi.Infrastructure.EF/Migrations/20260730131511_AddAxisTable.Designer.cs
+++ b/src/Progesi.Infrastructure.EF/Migrations/20260730131511_AddAxisTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Progesi.Infrastructure.EF;
 
@@ -10,9 +11,11 @@ using Progesi.Infrastructure.EF;
 namespace Progesi.Infrastructure.EF.Migrations
 {
     [DbContext(typeof(ProgesiDbContext))]
-    partial class ProgesiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260730131511_AddAxisTable")]
+    partial class AddAxisTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.11");

--- a/src/Progesi.Infrastructure.EF/Migrations/20260730131511_AddAxisTable.cs
+++ b/src/Progesi.Infrastructure.EF/Migrations/20260730131511_AddAxisTable.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Progesi.Infrastructure.EF.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAxisTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Axis",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    AxisName = table.Column<string>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    ValueTypeKey = table.Column<string>(type: "TEXT", nullable: false),
+                    AxisLength = table.Column<double>(type: "REAL", nullable: true),
+                    CurvePayload = table.Column<string>(type: "TEXT", nullable: false, defaultValue: ""),
+                    Mode = table.Column<int>(type: "INTEGER", nullable: false),
+                    KeyPointsJson = table.Column<string>(type: "TEXT", nullable: false),
+                    RuleId = table.Column<int>(type: "INTEGER", nullable: true),
+                    FunctionId = table.Column<int>(type: "INTEGER", nullable: true),
+                    FunctionHashtag = table.Column<string>(type: "TEXT", nullable: true),
+                    FunctionPayload = table.Column<string>(type: "TEXT", nullable: false, defaultValue: ""),
+                    StationsJson = table.Column<string>(type: "TEXT", nullable: false),
+                    ContentHash = table.Column<string>(type: "TEXT", nullable: false),
+                    Hashtag = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Axis", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Axis_ContentHash",
+                table: "Axis",
+                column: "ContentHash",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Axis_Hashtag",
+                table: "Axis",
+                column: "Hashtag");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Axis");
+        }
+    }
+}

--- a/src/Progesi.Infrastructure.EF/ProgesiDbContext.cs
+++ b/src/Progesi.Infrastructure.EF/ProgesiDbContext.cs
@@ -13,6 +13,7 @@ public sealed class ProgesiDbContext : DbContext
   public DbSet<VariableEntity> Variables => Set<VariableEntity>();
   public DbSet<MetadataEntity> Metadata => Set<MetadataEntity>();
   public DbSet<ClusterEntity> Clusters => Set<ClusterEntity>();
+  public DbSet<AxisEntity> Axis => Set<AxisEntity>();
 
   protected override void OnModelCreating(ModelBuilder modelBuilder)
   {
@@ -48,6 +49,23 @@ public sealed class ProgesiDbContext : DbContext
       entity.Property(e => e.Name).IsRequired();
       entity.Property(e => e.Description).HasDefaultValue(string.Empty);
       entity.Property(e => e.VariableIdsJson).IsRequired();
+      entity.Property(e => e.ContentHash).IsRequired();
+      entity.Property(e => e.Hashtag).IsRequired();
+      entity.HasIndex(e => e.ContentHash).IsUnique();
+      entity.HasIndex(e => e.Hashtag);
+    });
+
+    modelBuilder.Entity<AxisEntity>(entity =>
+    {
+      entity.ToTable("Axis");
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.AxisName).IsRequired();
+      entity.Property(e => e.Name).IsRequired();
+      entity.Property(e => e.ValueTypeKey).IsRequired();
+      entity.Property(e => e.CurvePayload).HasDefaultValue(string.Empty);
+      entity.Property(e => e.KeyPointsJson).IsRequired();
+      entity.Property(e => e.FunctionPayload).HasDefaultValue(string.Empty);
+      entity.Property(e => e.StationsJson).IsRequired();
       entity.Property(e => e.ContentHash).IsRequired();
       entity.Property(e => e.Hashtag).IsRequired();
       entity.HasIndex(e => e.ContentHash).IsUnique();

--- a/src/Progesi.Infrastructure.EF/Repositories/EfAxisVariableRepository.cs
+++ b/src/Progesi.Infrastructure.EF/Repositories/EfAxisVariableRepository.cs
@@ -1,0 +1,216 @@
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using ProgesiCore;
+using ProgesiCore.Serialization;
+using Progesi.Infrastructure.EF.Entities;
+
+namespace Progesi.Infrastructure.EF.Repositories;
+
+/// <summary>
+/// EF Core implementation of <see cref="IProgesiVariableAxisRepository"/> for the web tier.
+/// Not thread-safe — scope one instance (and its DbContext) per request/unit-of-work.
+/// </summary>
+public sealed class EfAxisVariableRepository : IProgesiVariableAxisRepository, IDisposable, IAsyncDisposable
+{
+  private readonly ProgesiDbContext _context;
+  private readonly bool _ownsContext;
+
+  public EfAxisVariableRepository(ProgesiDbContext context, bool ownsContext = false)
+  {
+    _context = context ?? throw new ArgumentNullException(nameof(context));
+    _ownsContext = ownsContext;
+  }
+
+  public EfAxisVariableRepository(string connectionString, bool resetSchema = false)
+      : this(ProgesiDbContextFactory.Create(connectionString, resetSchema), ownsContext: true)
+  {
+  }
+
+  public async Task<ProgesiAxisVariable> SaveAsync(ProgesiAxisVariable axis, CancellationToken ct = default)
+  {
+    if (axis is null) throw new ArgumentNullException(nameof(axis));
+
+    var hash = ProgesiHash.Compute(axis);
+    var dto = ProgesiAxisVariableDto.FromDomain(axis);
+
+    var existing = await _context.Axis
+        .AsNoTracking()
+        .Where(a => a.ContentHash == hash)
+        .Select(a => new { a.Id })
+        .FirstOrDefaultAsync(ct);
+
+    if (existing != null && existing.Id != axis.Id)
+      return (await GetByIdAsync(existing.Id, ct))!;
+
+    var entity = await _context.Axis.FindAsync(new object[] { axis.Id }, ct);
+    if (entity == null)
+    {
+      entity = new AxisEntity { Id = axis.Id };
+      _context.Axis.Add(entity);
+    }
+
+    entity.AxisName = dto.AxisName ?? string.Empty;
+    entity.Name = dto.Name ?? string.Empty;
+    entity.ValueTypeKey = dto.ValueTypeKey ?? string.Empty;
+    entity.AxisLength = dto.AxisLength;
+    entity.CurvePayload = dto.CurvePayload ?? string.Empty;
+    entity.Mode = (int)dto.Mode;
+    entity.KeyPointsJson = JsonConvert.SerializeObject(dto.KeyPoints ?? new List<double>());
+    entity.RuleId = dto.RuleId;
+    entity.FunctionId = dto.FunctionId;
+    entity.FunctionHashtag = dto.FunctionHashtag;
+    entity.FunctionPayload = dto.FunctionPayload ?? string.Empty;
+    entity.StationsJson = SerializeStations(dto.Entries);
+    entity.ContentHash = hash;
+    entity.Hashtag = axis.Hashtag ?? string.Empty;
+
+    await _context.SaveChangesAsync(ct);
+    return (await GetByIdAsync(axis.Id, ct))!;
+  }
+
+  public async Task<ProgesiAxisVariable?> GetByIdAsync(int id, CancellationToken ct = default)
+  {
+    var entity = await _context.Axis
+        .AsNoTracking()
+        .FirstOrDefaultAsync(a => a.Id == id, ct);
+
+    if (entity == null) return null;
+    return ToDomain(entity);
+  }
+
+  public async Task<ProgesiAxisVariable?> GetByHashtagAsync(string hashtag, CancellationToken ct = default)
+  {
+    if (string.IsNullOrWhiteSpace(hashtag))
+      return null;
+
+    var id = await _context.Axis
+        .AsNoTracking()
+        .Where(a => a.Hashtag == hashtag)
+        .Select(a => (int?)a.Id)
+        .FirstOrDefaultAsync(ct);
+
+    if (!id.HasValue)
+    {
+      id = await _context.Axis
+          .AsNoTracking()
+          .Where(a => a.ContentHash == hashtag)
+          .Select(a => (int?)a.Id)
+          .FirstOrDefaultAsync(ct);
+    }
+
+    if (!id.HasValue)
+      return null;
+
+    return await GetByIdAsync(id.Value, ct);
+  }
+
+  public async Task<IReadOnlyList<ProgesiAxisVariable>> GetAllAsync(CancellationToken ct = default)
+  {
+    var ids = await _context.Axis
+        .AsNoTracking()
+        .OrderBy(a => a.Id)
+        .Select(a => a.Id)
+        .ToListAsync(ct);
+
+    var list = new List<ProgesiAxisVariable>(ids.Count);
+    foreach (var id in ids)
+    {
+      var axis = await GetByIdAsync(id, ct);
+      if (axis != null) list.Add(axis);
+    }
+
+    return list;
+  }
+
+  public async Task<bool> DeleteAsync(int id, CancellationToken ct = default)
+  {
+    var entity = await _context.Axis.FindAsync(new object[] { id }, ct);
+    if (entity == null) return false;
+
+    _context.Axis.Remove(entity);
+    await _context.SaveChangesAsync(ct);
+    return true;
+  }
+
+  public async Task<int> DeleteManyAsync(IEnumerable<int> idsToDelete, CancellationToken ct = default)
+  {
+    if (idsToDelete == null) return 0;
+
+    var ids = idsToDelete.ToArray();
+    if (ids.Length == 0) return 0;
+
+    var entities = await _context.Axis
+        .Where(a => ids.Contains(a.Id))
+        .ToListAsync(ct);
+
+    if (entities.Count == 0) return 0;
+
+    _context.Axis.RemoveRange(entities);
+    await _context.SaveChangesAsync(ct);
+    return entities.Count;
+  }
+
+  public void Dispose()
+  {
+    if (_ownsContext)
+      _context.Dispose();
+  }
+
+  public async ValueTask DisposeAsync()
+  {
+    if (_ownsContext)
+      await _context.DisposeAsync().ConfigureAwait(false);
+  }
+
+  private static ProgesiAxisVariable ToDomain(AxisEntity entity)
+  {
+    var dto = new ProgesiAxisVariableDto
+    {
+      AxisId = entity.Id,
+      AxisName = entity.AxisName,
+      Name = entity.Name,
+      ValueTypeKey = entity.ValueTypeKey,
+      AxisLength = entity.AxisLength,
+      CurvePayload = entity.CurvePayload,
+      Mode = (AxisCurveMode)entity.Mode,
+      KeyPoints = JsonConvert.DeserializeObject<List<double>>(entity.KeyPointsJson) ?? new List<double>(),
+      RuleId = entity.RuleId,
+      FunctionId = entity.FunctionId,
+      FunctionHashtag = entity.FunctionHashtag,
+      FunctionPayload = string.IsNullOrWhiteSpace(entity.FunctionPayload) ? null : entity.FunctionPayload,
+      ContentHash = entity.ContentHash,
+      Entries = DeserializeStations(entity.StationsJson)
+    };
+
+    return ProgesiAxisVariableDto.ToDomain(dto);
+  }
+
+  private sealed class StationJsonEntry
+  {
+    public double Position { get; set; }
+    public int VariableId { get; set; }
+  }
+
+  private static string SerializeStations(IEnumerable<ProgesiAxisVariableDto.Entry> entries)
+  {
+    var payload = entries
+      .Select(e => new StationJsonEntry { Position = e.Position, VariableId = e.VariableId })
+      .OrderBy(e => e.Position)
+      .ThenBy(e => e.VariableId)
+      .ToArray();
+    return JsonConvert.SerializeObject(payload);
+  }
+
+  private static List<ProgesiAxisVariableDto.Entry> DeserializeStations(string? json)
+  {
+    if (string.IsNullOrWhiteSpace(json))
+      return new List<ProgesiAxisVariableDto.Entry>();
+
+    var rows = JsonConvert.DeserializeObject<StationJsonEntry[]>(json) ?? Array.Empty<StationJsonEntry>();
+    return rows.Select(r => new ProgesiAxisVariableDto.Entry
+    {
+      Position = r.Position,
+      VariableId = r.VariableId
+    }).ToList();
+  }
+}

--- a/src/ProgesiCore/IProgesiVariableAxisRepository.cs
+++ b/src/ProgesiCore/IProgesiVariableAxisRepository.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ProgesiCore
+{
+  /// <summary>
+  /// Repository for persisting <see cref="ProgesiAxisVariable"/> (tiered SQLite / EF implementations).
+  /// </summary>
+  public interface IProgesiVariableAxisRepository
+  {
+    Task<ProgesiAxisVariable> SaveAsync(ProgesiAxisVariable axis, CancellationToken ct = default);
+
+    Task<ProgesiAxisVariable?> GetByIdAsync(int id, CancellationToken ct = default);
+
+    Task<ProgesiAxisVariable?> GetByHashtagAsync(string hashtag, CancellationToken ct = default);
+
+    Task<IReadOnlyList<ProgesiAxisVariable>> GetAllAsync(CancellationToken ct = default);
+
+    Task<bool> DeleteAsync(int id, CancellationToken ct = default);
+
+    Task<int> DeleteManyAsync(IEnumerable<int> ids, CancellationToken ct = default);
+  }
+}

--- a/src/ProgesiRepositories.Sqlite/AxisPersistenceMapping.cs
+++ b/src/ProgesiRepositories.Sqlite/AxisPersistenceMapping.cs
@@ -1,0 +1,74 @@
+#nullable enable
+using Microsoft.Data.Sqlite;
+using Newtonsoft.Json;
+using ProgesiCore;
+using ProgesiCore.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ProgesiRepositories.Sqlite
+{
+  internal static class AxisPersistenceMapping
+  {
+    internal sealed class StationJsonEntry
+    {
+      public double Position { get; set; }
+      public int VariableId { get; set; }
+    }
+
+    public static ProgesiAxisVariableDto FromDomain(ProgesiAxisVariable axis)
+      => ProgesiAxisVariableDto.FromDomain(axis);
+
+    public static ProgesiAxisVariable ToDomain(ProgesiAxisVariableDto dto)
+      => ProgesiAxisVariableDto.ToDomain(dto);
+
+    public static string SerializeStations(IEnumerable<ProgesiAxisVariableDto.Entry> entries)
+    {
+      var payload = entries
+        .Select(e => new StationJsonEntry { Position = e.Position, VariableId = e.VariableId })
+        .OrderBy(e => e.Position)
+        .ThenBy(e => e.VariableId)
+        .ToArray();
+      return JsonConvert.SerializeObject(payload);
+    }
+
+    public static List<ProgesiAxisVariableDto.Entry> DeserializeStations(string? json)
+    {
+      if (string.IsNullOrWhiteSpace(json))
+        return new List<ProgesiAxisVariableDto.Entry>();
+
+      var rows = JsonConvert.DeserializeObject<StationJsonEntry[]>(json) ?? Array.Empty<StationJsonEntry>();
+      return rows.Select(r => new ProgesiAxisVariableDto.Entry
+      {
+        Position = r.Position,
+        VariableId = r.VariableId
+      }).ToList();
+    }
+
+    public static ProgesiAxisVariableDto ReadDto(SqliteDataReader reader)
+    {
+      return new ProgesiAxisVariableDto
+      {
+        AxisId = reader.GetInt32(0),
+        AxisName = reader.GetString(1),
+        Name = reader.GetString(2),
+        ValueTypeKey = reader.GetString(3),
+        AxisLength = reader.IsDBNull(4) ? (double?)null : reader.GetDouble(4),
+        CurvePayload = reader.IsDBNull(5) ? string.Empty : reader.GetString(5),
+        Mode = (AxisCurveMode)reader.GetInt32(6),
+        KeyPoints = JsonConvert.DeserializeObject<List<double>>(reader.IsDBNull(7) ? "[]" : reader.GetString(7)) ?? new List<double>(),
+        RuleId = reader.IsDBNull(8) ? (int?)null : reader.GetInt32(8),
+        FunctionId = reader.IsDBNull(9) ? (int?)null : reader.GetInt32(9),
+        FunctionHashtag = reader.IsDBNull(10) ? null : reader.GetString(10),
+        FunctionPayload = reader.IsDBNull(11) ? null : reader.GetString(11),
+        ContentHash = reader.IsDBNull(13) ? string.Empty : reader.GetString(13),
+        Entries = DeserializeStations(reader.IsDBNull(12) ? "[]" : reader.GetString(12))
+      };
+    }
+
+    public const string SelectColumns = @"
+Id, AxisName, Name, ValueTypeKey, AxisLength, CurvePayload, Mode, KeyPointsJson,
+RuleId, FunctionId, FunctionHashtag, FunctionPayload, StationsJson, ContentHash, Hashtag";
+  }
+}

--- a/src/ProgesiRepositories.Sqlite/SqliteAxisVariableRepository.cs
+++ b/src/ProgesiRepositories.Sqlite/SqliteAxisVariableRepository.cs
@@ -1,0 +1,303 @@
+#nullable enable
+using Microsoft.Data.Sqlite;
+using Newtonsoft.Json;
+using ProgesiCore;
+using ProgesiCore.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ProgesiRepositories.Sqlite
+{
+  public sealed class SqliteAxisVariableRepository : SqliteRepositoryBase, IProgesiVariableAxisRepository
+  {
+    public SqliteAxisVariableRepository(string dbPath, bool resetSchema = false)
+        : base(dbPath, resetSchema)
+    {
+      EnsureSchema();
+    }
+
+    public SqliteAxisVariableRepository(string dbPath, bool resetSchema, IProgesiLogger logger)
+        : base(dbPath, resetSchema, logger)
+    {
+      EnsureSchema();
+    }
+
+    private void EnsureSchema()
+    {
+      using var conn = OpenConnection();
+      using (var cmd = conn.CreateCommand())
+      {
+        if (_resetSchema)
+        {
+          cmd.CommandText = @"
+DROP TABLE IF EXISTS Axis;
+
+CREATE TABLE Axis (
+    Id              INTEGER PRIMARY KEY,
+    AxisName        TEXT NOT NULL DEFAULT '',
+    Name            TEXT NOT NULL,
+    ValueTypeKey    TEXT NOT NULL,
+    AxisLength      REAL NULL,
+    CurvePayload    TEXT NOT NULL DEFAULT '',
+    Mode            INTEGER NOT NULL DEFAULT 0,
+    KeyPointsJson   TEXT NOT NULL DEFAULT '[]',
+    RuleId          INTEGER NULL,
+    FunctionId      INTEGER NULL,
+    FunctionHashtag TEXT NULL,
+    FunctionPayload TEXT NOT NULL DEFAULT '',
+    StationsJson    TEXT NOT NULL DEFAULT '[]',
+    ContentHash     TEXT NOT NULL,
+    Hashtag         TEXT NOT NULL DEFAULT ''
+);";
+          cmd.ExecuteNonQuery();
+          _log.Info("[SQLite] Recreated table 'Axis' due to resetSchema=true.");
+        }
+        else
+        {
+          cmd.CommandText = @"
+CREATE TABLE IF NOT EXISTS Axis (
+    Id              INTEGER PRIMARY KEY,
+    AxisName        TEXT NOT NULL DEFAULT '',
+    Name            TEXT NOT NULL,
+    ValueTypeKey    TEXT NOT NULL,
+    AxisLength      REAL NULL,
+    CurvePayload    TEXT NOT NULL DEFAULT '',
+    Mode            INTEGER NOT NULL DEFAULT 0,
+    KeyPointsJson   TEXT NOT NULL DEFAULT '[]',
+    RuleId          INTEGER NULL,
+    FunctionId      INTEGER NULL,
+    FunctionHashtag TEXT NULL,
+    FunctionPayload TEXT NOT NULL DEFAULT '',
+    StationsJson    TEXT NOT NULL DEFAULT '[]',
+    ContentHash     TEXT NOT NULL,
+    Hashtag         TEXT NOT NULL DEFAULT ''
+);";
+          cmd.ExecuteNonQuery();
+
+          AddColumnIfMissing(conn, "Axis", "AxisName", "TEXT NOT NULL DEFAULT ''");
+          AddColumnIfMissing(conn, "Axis", "CurvePayload", "TEXT NOT NULL DEFAULT ''");
+          AddColumnIfMissing(conn, "Axis", "Mode", "INTEGER NOT NULL DEFAULT 0");
+          AddColumnIfMissing(conn, "Axis", "KeyPointsJson", "TEXT NOT NULL DEFAULT '[]'");
+          AddColumnIfMissing(conn, "Axis", "FunctionId", "INTEGER NULL");
+          AddColumnIfMissing(conn, "Axis", "FunctionHashtag", "TEXT NULL");
+          AddColumnIfMissing(conn, "Axis", "FunctionPayload", "TEXT NOT NULL DEFAULT ''");
+          AddColumnIfMissing(conn, "Axis", "StationsJson", "TEXT NOT NULL DEFAULT '[]'");
+          AddColumnIfMissing(conn, "Axis", "ContentHash", "TEXT NOT NULL DEFAULT ''");
+          AddColumnIfMissing(conn, "Axis", "Hashtag", "TEXT NOT NULL DEFAULT ''");
+        }
+      }
+
+      EnsureSchemaInfoAndCleanup(conn, "Axis");
+
+      using (var idx = conn.CreateCommand())
+      {
+        idx.CommandText = "CREATE INDEX IF NOT EXISTS IX_Axis_Hashtag ON Axis(Hashtag);";
+        idx.ExecuteNonQuery();
+      }
+    }
+
+    public Task<ProgesiAxisVariable> SaveAsync(ProgesiAxisVariable axis, CancellationToken ct = default)
+    {
+      if (axis is null) throw new ArgumentNullException(nameof(axis));
+      return SaveInternalAsync(axis, ct);
+    }
+
+    private Task<ProgesiAxisVariable> SaveInternalAsync(ProgesiAxisVariable axis, CancellationToken ct)
+    {
+      return WithRetryAsync(async () =>
+      {
+        using var conn = OpenConnection();
+        using var tx = conn.BeginTransaction();
+
+        var hash = ProgesiHash.Compute(axis);
+        var dto = AxisPersistenceMapping.FromDomain(axis);
+        var stationsJson = AxisPersistenceMapping.SerializeStations(dto.Entries);
+        var keyPointsJson = JsonConvert.SerializeObject(dto.KeyPoints ?? new List<double>());
+        var hashtag = axis.Hashtag ?? string.Empty;
+
+        int? existingId = null;
+        using (var find = conn.CreateCommand())
+        {
+          find.Transaction = tx;
+          find.CommandText = "SELECT Id FROM Axis WHERE ContentHash=$h LIMIT 1;";
+          find.Parameters.AddWithValue("$h", hash);
+          var obj = await find.ExecuteScalarAsync(ct);
+          if (obj != null && obj != DBNull.Value)
+            existingId = Convert.ToInt32(obj);
+        }
+
+        if (existingId.HasValue && existingId.Value != axis.Id)
+        {
+          tx.Commit();
+          _log.Debug($"[SQLite] Axis upsert dedup: reused Id={existingId.Value} for ContentHash={hash}.");
+          return (await GetByIdAsync(existingId.Value, ct))!;
+        }
+
+        using (var cmd = conn.CreateCommand())
+        {
+          cmd.Transaction = tx;
+          cmd.CommandText = @"
+INSERT INTO Axis (
+  Id, AxisName, Name, ValueTypeKey, AxisLength, CurvePayload, Mode, KeyPointsJson,
+  RuleId, FunctionId, FunctionHashtag, FunctionPayload, StationsJson, ContentHash, Hashtag)
+VALUES (
+  $id, $axisName, $name, $valueTypeKey, $axisLength, $curvePayload, $mode, $keyPointsJson,
+  $ruleId, $functionId, $functionHashtag, $functionPayload, $stationsJson, $h, $tag)
+ON CONFLICT(Id) DO UPDATE SET
+  AxisName=excluded.AxisName,
+  Name=excluded.Name,
+  ValueTypeKey=excluded.ValueTypeKey,
+  AxisLength=excluded.AxisLength,
+  CurvePayload=excluded.CurvePayload,
+  Mode=excluded.Mode,
+  KeyPointsJson=excluded.KeyPointsJson,
+  RuleId=excluded.RuleId,
+  FunctionId=excluded.FunctionId,
+  FunctionHashtag=excluded.FunctionHashtag,
+  FunctionPayload=excluded.FunctionPayload,
+  StationsJson=excluded.StationsJson,
+  ContentHash=excluded.ContentHash,
+  Hashtag=excluded.Hashtag;";
+          cmd.Parameters.AddWithValue("$id", axis.Id);
+          cmd.Parameters.AddWithValue("$axisName", dto.AxisName ?? string.Empty);
+          cmd.Parameters.AddWithValue("$name", dto.Name ?? string.Empty);
+          cmd.Parameters.AddWithValue("$valueTypeKey", dto.ValueTypeKey ?? string.Empty);
+          cmd.Parameters.AddWithValue("$axisLength", (object?)dto.AxisLength ?? DBNull.Value);
+          cmd.Parameters.AddWithValue("$curvePayload", dto.CurvePayload ?? string.Empty);
+          cmd.Parameters.AddWithValue("$mode", (int)dto.Mode);
+          cmd.Parameters.AddWithValue("$keyPointsJson", keyPointsJson);
+          cmd.Parameters.AddWithValue("$ruleId", (object?)dto.RuleId ?? DBNull.Value);
+          cmd.Parameters.AddWithValue("$functionId", (object?)dto.FunctionId ?? DBNull.Value);
+          cmd.Parameters.AddWithValue("$functionHashtag", (object?)dto.FunctionHashtag ?? DBNull.Value);
+          cmd.Parameters.AddWithValue("$functionPayload", dto.FunctionPayload ?? string.Empty);
+          cmd.Parameters.AddWithValue("$stationsJson", stationsJson);
+          cmd.Parameters.AddWithValue("$h", hash);
+          cmd.Parameters.AddWithValue("$tag", hashtag);
+          await cmd.ExecuteNonQueryAsync(ct);
+        }
+
+        tx.Commit();
+        return (await GetByIdAsync(axis.Id, ct))!;
+      }, ct: ct);
+    }
+
+    public async Task<ProgesiAxisVariable?> GetByIdAsync(int id, CancellationToken ct = default)
+    {
+      return await WithRetryAsync(async () =>
+      {
+        using var conn = OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT {AxisPersistenceMapping.SelectColumns} FROM Axis WHERE Id=$id;";
+        cmd.Parameters.AddWithValue("$id", id);
+
+        using var r = await cmd.ExecuteReaderAsync(ct);
+        if (!await r.ReadAsync(ct))
+          return null;
+
+        var dto = AxisPersistenceMapping.ReadDto(r);
+        return AxisPersistenceMapping.ToDomain(dto);
+      }, ct: ct);
+    }
+
+    public async Task<ProgesiAxisVariable?> GetByHashtagAsync(string hashtag, CancellationToken ct = default)
+    {
+      if (string.IsNullOrWhiteSpace(hashtag))
+        return null;
+
+      return await WithRetryAsync(async () =>
+      {
+        using var conn = OpenConnection();
+
+        int? id = null;
+        using (var cmd = conn.CreateCommand())
+        {
+          cmd.CommandText = "SELECT Id FROM Axis WHERE Hashtag=$h LIMIT 1;";
+          cmd.Parameters.AddWithValue("$h", hashtag);
+          var scalar = await cmd.ExecuteScalarAsync(ct);
+          if (scalar != null && scalar != DBNull.Value)
+            id = Convert.ToInt32(scalar);
+        }
+
+        if (!id.HasValue)
+        {
+          using var cmd = conn.CreateCommand();
+          cmd.CommandText = "SELECT Id FROM Axis WHERE ContentHash=$h LIMIT 1;";
+          cmd.Parameters.AddWithValue("$h", hashtag);
+          var scalar = await cmd.ExecuteScalarAsync(ct);
+          if (scalar != null && scalar != DBNull.Value)
+            id = Convert.ToInt32(scalar);
+        }
+
+        if (!id.HasValue)
+          return null;
+
+        return await GetByIdAsync(id.Value, ct);
+      }, ct: ct);
+    }
+
+    public async Task<IReadOnlyList<ProgesiAxisVariable>> GetAllAsync(CancellationToken ct = default)
+    {
+      return await WithRetryAsync(async () =>
+      {
+        var list = new List<ProgesiAxisVariable>();
+        using var conn = OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT Id FROM Axis ORDER BY Id;";
+
+        using var r = await cmd.ExecuteReaderAsync(ct);
+        var ids = new List<int>();
+        while (await r.ReadAsync(ct))
+          ids.Add(r.GetInt32(0));
+
+        foreach (var id in ids)
+        {
+          var axis = await GetByIdAsync(id, ct);
+          if (axis != null)
+            list.Add(axis);
+        }
+
+        return (IReadOnlyList<ProgesiAxisVariable>)list;
+      }, ct: ct);
+    }
+
+    public async Task<bool> DeleteAsync(int id, CancellationToken ct = default)
+    {
+      return await WithRetryAsync(async () =>
+      {
+        using var conn = OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "DELETE FROM Axis WHERE Id=$id;";
+        cmd.Parameters.AddWithValue("$id", id);
+        var n = await cmd.ExecuteNonQueryAsync(ct);
+        return n > 0;
+      }, ct: ct);
+    }
+
+    public async Task<int> DeleteManyAsync(IEnumerable<int> idsToDelete, CancellationToken ct = default)
+    {
+      if (idsToDelete == null) return 0;
+      var ids = idsToDelete.ToArray();
+      if (ids.Length == 0) return 0;
+
+      return await WithRetryAsync(async () =>
+      {
+        using var conn = OpenConnection();
+        using var tx = conn.BeginTransaction();
+        int count = 0;
+        foreach (var id in ids)
+        {
+          using var cmd = conn.CreateCommand();
+          cmd.Transaction = tx;
+          cmd.CommandText = "DELETE FROM Axis WHERE Id=$id;";
+          cmd.Parameters.AddWithValue("$id", id);
+          count += await cmd.ExecuteNonQueryAsync(ct);
+        }
+        tx.Commit();
+        return count;
+      }, ct: ct);
+    }
+  }
+}

--- a/tests/Progesi.Infrastructure.EF.Tests/EfAxisVariableRepositoryTests.cs
+++ b/tests/Progesi.Infrastructure.EF.Tests/EfAxisVariableRepositoryTests.cs
@@ -1,0 +1,170 @@
+using FluentAssertions;
+using ProgesiCore;
+using Progesi.Infrastructure.EF.Repositories;
+
+namespace Progesi.Infrastructure.EF.Tests;
+
+public sealed class EfAxisVariableRepositoryTests : IDisposable
+{
+  private readonly string _connectionString;
+  private readonly EfAxisVariableRepository _repo;
+
+  public EfAxisVariableRepositoryTests()
+  {
+    _connectionString = EfTestBootstrap.CreateTempFileConnectionString();
+    _repo = new EfAxisVariableRepository(_connectionString, resetSchema: true);
+  }
+
+  private static ProgesiAxisVariable MakeRichAxis(int id)
+  {
+    var fn = new ProgesiFunction(1, "law", new[]
+    {
+      new ProgesiFunctionSegment(0.0, 1.0, ProgesiFunctionSegmentKind.Constant, constantValue: 1.0)
+    });
+
+    var axis = new ProgesiAxisVariable(
+      id,
+      "Axis-Repo",
+      "Thickness",
+      "System.Double",
+      100.0,
+      99,
+      "curve-json-v1",
+      AxisCurveMode.PlanXY,
+      new[] { 0.0, 0.5, 1.0 },
+      ProgesiFunctionRef.Embed(fn));
+
+    var sig = new ProgesiAxisVariable.ProgesiVariableSignature(2, "Thickness", "System.Double");
+    axis.Add(sig, 0.25);
+    axis.Add(sig, 0.75);
+    return axis;
+  }
+
+  [Fact]
+  public async Task SaveAsync_Then_GetByIdAsync_RoundTrips_Axis()
+  {
+    var axis = MakeRichAxis(7);
+
+    await _repo.SaveAsync(axis);
+    var loaded = await _repo.GetByIdAsync(7);
+
+    loaded.Should().NotBeNull();
+    loaded!.Id.Should().Be(7);
+    loaded.AxisName.Should().Be("Axis-Repo");
+    loaded.Name.Should().Be("Thickness");
+    loaded.CurvePayload.Should().Be("curve-json-v1");
+    loaded.Mode.Should().Be(AxisCurveMode.PlanXY);
+    loaded.KeyPoints.Should().Equal(0.0, 0.5, 1.0);
+    loaded.FunctionRef.Embedded.Should().NotBeNull();
+    loaded.Hashtag.Should().Be(axis.Hashtag);
+    ProgesiHash.Compute(loaded).Should().Be(ProgesiHash.Compute(axis));
+  }
+
+  [Fact]
+  public async Task GetByHashtagAsync_Finds_Saved_Axis_By_Current_Hashtag()
+  {
+    var axis = MakeRichAxis(3);
+    await _repo.SaveAsync(axis);
+
+    var loaded = await _repo.GetByHashtagAsync(axis.Hashtag);
+
+    loaded.Should().NotBeNull();
+    loaded!.Id.Should().Be(3);
+  }
+
+  [Fact]
+  public async Task GetByHashtagAsync_Finds_Saved_Axis_By_ContentHash()
+  {
+    var axis = MakeRichAxis(5);
+    await _repo.SaveAsync(axis);
+
+    var loaded = await _repo.GetByHashtagAsync(axis.ContentHash);
+
+    loaded.Should().NotBeNull();
+    loaded!.Id.Should().Be(5);
+  }
+
+  [Fact]
+  public async Task GetByHashtagAsync_Returns_Null_For_Empty_Or_Whitespace_Hashtag()
+  {
+    await _repo.SaveAsync(MakeRichAxis(1));
+
+    (await _repo.GetByHashtagAsync("")).Should().BeNull();
+    (await _repo.GetByHashtagAsync("   ")).Should().BeNull();
+  }
+
+  [Fact]
+  public async Task SaveAsync_Deduplicates_By_ContentHash()
+  {
+    var first = MakeRichAxis(1);
+    await _repo.SaveAsync(first);
+
+    var second = MakeRichAxis(2);
+    var returned = await _repo.SaveAsync(second);
+
+    returned.Id.Should().Be(1);
+
+    var all = await _repo.GetAllAsync();
+    all.Should().HaveCount(1);
+    all[0].Id.Should().Be(1);
+  }
+
+  [Fact]
+  public async Task GetAllAsync_Returns_Axes_Ordered_By_Id()
+  {
+    var a1 = MakeRichAxis(1);
+    var a2 = MakeRichAxis(2);
+    a2.SetCurvePayload("curve-json-v2");
+    await _repo.SaveAsync(a1);
+    await _repo.SaveAsync(a2);
+
+    var all = await _repo.GetAllAsync();
+
+    all.Should().HaveCount(2);
+    all.Select(a => a.Id).Should().Equal(1, 2);
+  }
+
+  [Fact]
+  public async Task DeleteAsync_Removes_Existing_Axis()
+  {
+    await _repo.SaveAsync(MakeRichAxis(4));
+
+    (await _repo.DeleteAsync(4)).Should().BeTrue();
+    (await _repo.GetByIdAsync(4)).Should().BeNull();
+  }
+
+  [Fact]
+  public async Task DeleteAsync_Returns_False_When_Not_Found()
+  {
+    (await _repo.DeleteAsync(999)).Should().BeFalse();
+  }
+
+  [Fact]
+  public async Task DeleteManyAsync_Removes_Only_Existing_Ids()
+  {
+    var a1 = MakeRichAxis(1);
+    var a2 = MakeRichAxis(2);
+    a2.SetCurvePayload("curve-json-v2");
+    await _repo.SaveAsync(a1);
+    await _repo.SaveAsync(a2);
+
+    var removed = await _repo.DeleteManyAsync(new[] { 1, 99, 2 });
+
+    removed.Should().Be(2);
+    (await _repo.GetAllAsync()).Should().BeEmpty();
+  }
+
+  public void Dispose()
+  {
+    _repo.Dispose();
+    var path = _connectionString.Replace("Data Source=", string.Empty);
+    try
+    {
+      if (File.Exists(path)) File.Delete(path);
+    }
+    catch
+    {
+      // best-effort cleanup
+    }
+  }
+}

--- a/tests/Progesi.Repositories.Conformance.Tests/SqliteEfAxisParityTests.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/SqliteEfAxisParityTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using ProgesiCore;
+using Progesi.Repositories.Conformance.Tests.Support;
+
+namespace Progesi.Repositories.Conformance.Tests;
+
+public sealed class SqliteEfAxisParityTests
+{
+  private static ProgesiAxisVariable MakeRichAxis(int id)
+  {
+    var fn = new ProgesiFunction(1, "law", new[]
+    {
+      new ProgesiFunctionSegment(0.0, 1.0, ProgesiFunctionSegmentKind.Constant, constantValue: 1.0)
+    });
+
+    var axis = new ProgesiAxisVariable(
+      id,
+      "Axis-Parity",
+      "Thickness",
+      "System.Double",
+      100.0,
+      99,
+      "curve-json-v1",
+      AxisCurveMode.PlanXY,
+      new[] { 0.0, 0.5, 1.0 },
+      ProgesiFunctionRef.Embed(fn));
+
+    var sig = new ProgesiAxisVariable.ProgesiVariableSignature(2, "Thickness", "System.Double");
+    axis.Add(sig, 0.25);
+    axis.Add(sig, 0.75);
+    return axis;
+  }
+
+  [Fact]
+  public async Task SaveAndRead_Axis_Produces_Equivalent_Results()
+  {
+    using var stores = new SqliteEfAxisParityStores();
+    var original = MakeRichAxis(7);
+
+    await stores.Sqlite.SaveAsync(original);
+    await stores.Ef.SaveAsync(original);
+
+    var sqliteLoaded = await stores.Sqlite.GetByIdAsync(7);
+    var efLoaded = await stores.Ef.GetByIdAsync(7);
+
+    ParityAssertions.AxisShouldMatch(sqliteLoaded!, efLoaded!, original);
+  }
+
+  [Fact]
+  public async Task Save_Deduplicates_ContentDuplicate_With_Identical_Behaviour()
+  {
+    using var stores = new SqliteEfAxisParityStores();
+    var a1 = MakeRichAxis(1);
+    var a2 = MakeRichAxis(2);
+
+    await stores.Sqlite.SaveAsync(a1);
+    await stores.Ef.SaveAsync(a1);
+
+    var sqliteDeduped = await stores.Sqlite.SaveAsync(a2);
+    var efDeduped = await stores.Ef.SaveAsync(a2);
+
+    sqliteDeduped.Id.Should().Be(1);
+    efDeduped.Id.Should().Be(1);
+    sqliteDeduped.Id.Should().Be(efDeduped.Id);
+    sqliteDeduped.Hashtag.Should().Be(efDeduped.Hashtag);
+
+    var sqliteByTag = await stores.Sqlite.GetByHashtagAsync(a1.Hashtag);
+    var efByTag = await stores.Ef.GetByHashtagAsync(a1.Hashtag);
+
+    ParityAssertions.AxisShouldMatch(sqliteByTag!, efByTag!, a1);
+  }
+
+  [Fact]
+  public async Task GetByHashtagAsync_Returns_Equivalent_Axis_On_Both_Providers()
+  {
+    using var stores = new SqliteEfAxisParityStores();
+    var original = MakeRichAxis(3);
+
+    await stores.Sqlite.SaveAsync(original);
+    await stores.Ef.SaveAsync(original);
+
+    var sqliteLoaded = await stores.Sqlite.GetByHashtagAsync(original.Hashtag);
+    var efLoaded = await stores.Ef.GetByHashtagAsync(original.Hashtag);
+
+    ParityAssertions.AxisShouldMatch(sqliteLoaded!, efLoaded!, original);
+  }
+}

--- a/tests/Progesi.Repositories.Conformance.Tests/SqliteEfSchemaParityTests.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/SqliteEfSchemaParityTests.cs
@@ -23,6 +23,7 @@ public sealed class SqliteEfSchemaParityTests : IDisposable
     _ = new SqliteVariableRepository(_sqlitePath, resetSchema: true);
     _ = new SqliteMetadataRepository(_sqlitePath, resetSchema: false);
     _ = new SqliteClusterRepository(_sqlitePath, resetSchema: false);
+    _ = new SqliteAxisVariableRepository(_sqlitePath, resetSchema: false);
 
     using var efContext = ProgesiDbContextFactory.Create($"Data Source={_efPath}", resetSchema: true);
   }
@@ -31,6 +32,7 @@ public sealed class SqliteEfSchemaParityTests : IDisposable
   [InlineData("Variables")]
   [InlineData("Metadata")]
   [InlineData("Clusters")]
+  [InlineData("Axis")]
   public void Sqlite_And_Ef_Schemas_Agree_On_Columns_ContentHash_NotNull_And_Unique_Index(string table)
   {
     var sqliteColumns = ReadColumns(_sqlitePath, table);

--- a/tests/Progesi.Repositories.Conformance.Tests/Support/ParityAssertions.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/Support/ParityAssertions.cs
@@ -38,6 +38,56 @@ internal static class ParityAssertions
     ProgesiHash.Compute(sqlite).Should().Be(ProgesiHash.Compute(original));
   }
 
+  public static void AxisShouldMatch(
+      ProgesiAxisVariable sqlite,
+      ProgesiAxisVariable ef,
+      ProgesiAxisVariable original)
+  {
+    sqlite.Should().NotBeNull();
+    ef.Should().NotBeNull();
+
+    sqlite!.Id.Should().Be(ef!.Id);
+    sqlite.AxisName.Should().Be(ef.AxisName);
+    sqlite.Name.Should().Be(ef.Name);
+    sqlite.ValueTypeKey.Should().Be(ef.ValueTypeKey);
+    sqlite.AxisLength.Should().Be(ef.AxisLength);
+    sqlite.CurvePayload.Should().Be(ef.CurvePayload);
+    sqlite.Mode.Should().Be(ef.Mode);
+    sqlite.KeyPoints.Should().Equal(ef.KeyPoints);
+    sqlite.RuleId.Should().Be(ef.RuleId);
+    sqlite.Hashtag.Should().Be(ef.Hashtag);
+
+    AssertFunctionRefEquivalent(sqlite.FunctionRef, ef.FunctionRef);
+
+    var sqliteStations = sqlite.EnumerateAll()
+        .OrderBy(t => t.positionNormalized)
+        .ThenBy(t => t.variableId)
+        .Select(t => (t.positionNormalized, t.variableId))
+        .ToArray();
+    var efStations = ef.EnumerateAll()
+        .OrderBy(t => t.positionNormalized)
+        .ThenBy(t => t.variableId)
+        .Select(t => (t.positionNormalized, t.variableId))
+        .ToArray();
+    sqliteStations.Should().Equal(efStations);
+
+    ProgesiHash.Compute(sqlite).Should().Be(ProgesiHash.Compute(ef));
+    ProgesiHash.Compute(sqlite).Should().Be(ProgesiHash.Compute(original));
+  }
+
+  private static void AssertFunctionRefEquivalent(ProgesiFunctionRef sqlite, ProgesiFunctionRef ef)
+  {
+    sqlite.FunctionId.Should().Be(ef.FunctionId);
+    sqlite.FunctionHashtag.Should().Be(ef.FunctionHashtag);
+
+    if (sqlite.Embedded == null && ef.Embedded == null)
+      return;
+
+    sqlite.Embedded.Should().NotBeNull();
+    ef.Embedded.Should().NotBeNull();
+    ProgesiHash.Compute(sqlite.Embedded!).Should().Be(ProgesiHash.Compute(ef.Embedded!));
+  }
+
   public static void MetadataShouldMatch(ProgesiMetadata? sqlite, ProgesiMetadata? ef, ProgesiMetadata original)
   {
     sqlite.Should().NotBeNull();

--- a/tests/Progesi.Repositories.Conformance.Tests/Support/SqliteEfParityStores.cs
+++ b/tests/Progesi.Repositories.Conformance.Tests/Support/SqliteEfParityStores.cs
@@ -114,3 +114,40 @@ internal sealed class SqliteEfClusterParityStores : IDisposable
     }
   }
 }
+
+internal sealed class SqliteEfAxisParityStores : IDisposable
+{
+  private readonly string _sqlitePath;
+  private readonly string _efConnectionString;
+
+  public IProgesiVariableAxisRepository Sqlite { get; }
+  public IProgesiVariableAxisRepository Ef { get; }
+
+  public SqliteEfAxisParityStores()
+  {
+    SqliteTestBootstrap.EnsureInitialized();
+    _sqlitePath = Path.Combine(Path.GetTempPath(), $"progesi_parity_axis_sqlite_{Guid.NewGuid():N}.sqlite");
+    _efConnectionString = $"Data Source={Path.Combine(Path.GetTempPath(), $"progesi_parity_axis_ef_{Guid.NewGuid():N}.sqlite")}";
+
+    Sqlite = new SqliteAxisVariableRepository(_sqlitePath, resetSchema: true);
+    Ef = new EfAxisVariableRepository(_efConnectionString, resetSchema: true);
+  }
+
+  public void Dispose()
+  {
+    TryDelete(_sqlitePath);
+    TryDelete(_efConnectionString.Replace("Data Source=", string.Empty));
+  }
+
+  private static void TryDelete(string path)
+  {
+    try
+    {
+      if (File.Exists(path)) File.Delete(path);
+    }
+    catch
+    {
+      // best-effort cleanup
+    }
+  }
+}

--- a/tests/ProgesiRepositories.Sqlite.Tests/SqliteAxisVariableRepositoryTests.cs
+++ b/tests/ProgesiRepositories.Sqlite.Tests/SqliteAxisVariableRepositoryTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ProgesiCore;
+using ProgesiRepositories.Sqlite;
+using Xunit;
+
+namespace ProgesiRepositories.Sqlite.Tests
+{
+  public sealed class SqliteAxisVariableRepositoryTests : IDisposable
+  {
+    private readonly string _dbPath;
+    private readonly SqliteAxisVariableRepository _repo;
+
+    public SqliteAxisVariableRepositoryTests()
+    {
+      SqliteTestBootstrap.EnsureInitialized();
+      _dbPath = Path.Combine(Path.GetTempPath(), $"progesi_axis_{Guid.NewGuid():N}.sqlite");
+      _repo = new SqliteAxisVariableRepository(_dbPath, resetSchema: true);
+    }
+
+    private static ProgesiAxisVariable MakeRichAxis(int id)
+    {
+      var fn = new ProgesiFunction(1, "law", new[]
+      {
+        new ProgesiFunctionSegment(0.0, 1.0, ProgesiFunctionSegmentKind.Constant, constantValue: 1.0)
+      });
+
+      var axis = new ProgesiAxisVariable(
+        id,
+        "Axis-Repo",
+        "Thickness",
+        "System.Double",
+        100.0,
+        99,
+        "curve-json-v1",
+        AxisCurveMode.PlanXY,
+        new[] { 0.0, 0.5, 1.0 },
+        ProgesiFunctionRef.Embed(fn));
+
+      var sig = new ProgesiAxisVariable.ProgesiVariableSignature(2, "Thickness", "System.Double");
+      axis.Add(sig, 0.25);
+      axis.Add(sig, 0.75);
+      return axis;
+    }
+
+    [Fact]
+    public async Task SaveAsync_Then_GetByIdAsync_RoundTrips_Axis()
+    {
+      var axis = MakeRichAxis(7);
+
+      await _repo.SaveAsync(axis);
+      var loaded = await _repo.GetByIdAsync(7);
+
+      loaded.Should().NotBeNull();
+      loaded!.Id.Should().Be(7);
+      loaded.AxisName.Should().Be("Axis-Repo");
+      loaded.Name.Should().Be("Thickness");
+      loaded.CurvePayload.Should().Be("curve-json-v1");
+      loaded.Mode.Should().Be(AxisCurveMode.PlanXY);
+      loaded.KeyPoints.Should().Equal(0.0, 0.5, 1.0);
+      loaded.FunctionRef.Embedded.Should().NotBeNull();
+      loaded.Hashtag.Should().Be(axis.Hashtag);
+      ProgesiHash.Compute(loaded).Should().Be(ProgesiHash.Compute(axis));
+    }
+
+    [Fact]
+    public async Task GetByHashtagAsync_Finds_Saved_Axis_By_Current_Hashtag()
+    {
+      var axis = MakeRichAxis(3);
+      await _repo.SaveAsync(axis);
+
+      var loaded = await _repo.GetByHashtagAsync(axis.Hashtag);
+
+      loaded.Should().NotBeNull();
+      loaded!.Id.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GetByHashtagAsync_Finds_Saved_Axis_By_ContentHash()
+    {
+      var axis = MakeRichAxis(5);
+      await _repo.SaveAsync(axis);
+
+      var loaded = await _repo.GetByHashtagAsync(axis.ContentHash);
+
+      loaded.Should().NotBeNull();
+      loaded!.Id.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task GetByHashtagAsync_Returns_Null_For_Empty_Or_Whitespace_Hashtag()
+    {
+      await _repo.SaveAsync(MakeRichAxis(1));
+
+      (await _repo.GetByHashtagAsync("")).Should().BeNull();
+      (await _repo.GetByHashtagAsync("   ")).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SaveAsync_Deduplicates_By_ContentHash()
+    {
+      var first = MakeRichAxis(1);
+      await _repo.SaveAsync(first);
+
+      var second = MakeRichAxis(2);
+      var returned = await _repo.SaveAsync(second);
+
+      returned.Id.Should().Be(1);
+
+      var all = await _repo.GetAllAsync();
+      all.Should().HaveCount(1);
+      all[0].Id.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_Returns_Axes_Ordered_By_Id()
+    {
+      var a1 = MakeRichAxis(1);
+      var a2 = MakeRichAxis(2);
+      a2.SetCurvePayload("curve-json-v2");
+      await _repo.SaveAsync(a1);
+      await _repo.SaveAsync(a2);
+
+      var all = await _repo.GetAllAsync();
+
+      all.Should().HaveCount(2);
+      all.Select(a => a.Id).Should().Equal(1, 2);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Removes_Existing_Axis()
+    {
+      await _repo.SaveAsync(MakeRichAxis(4));
+
+      (await _repo.DeleteAsync(4)).Should().BeTrue();
+      (await _repo.GetByIdAsync(4)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Returns_False_When_Not_Found()
+    {
+      (await _repo.DeleteAsync(999)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeleteManyAsync_Removes_Only_Existing_Ids()
+    {
+      var a1 = MakeRichAxis(1);
+      var a2 = MakeRichAxis(2);
+      a2.SetCurvePayload("curve-json-v2");
+      await _repo.SaveAsync(a1);
+      await _repo.SaveAsync(a2);
+
+      var removed = await _repo.DeleteManyAsync(new[] { 1, 99, 2 });
+
+      removed.Should().Be(2);
+      (await _repo.GetAllAsync()).Should().BeEmpty();
+    }
+
+    public void Dispose()
+    {
+      try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+  }
+}


### PR DESCRIPTION
## AxisVar B2 — tiered persistence (ADR-008, under the unfreeze)

Gives ProgesiAxisVariable the same tiered persistence as Variables/Metadata/Clusters. **Additive** — the legacy in-Core ADO.NET repo is left untouched (retired later as **B2-retire** under ADR-014).

- **`IProgesiVariableAxisRepository`** (Core interface) + **`SqliteAxisVariableRepository`** (WAL/retry/ContentHash dedup) + **`EfAxisVariableRepository`** + `AxisEntity` + **`AddAxisTable`** migration — mirrors the Cluster pattern (#97/#98).
- Persists the evolved **B1** model: CurvePayload, Mode, KeyPoints, FunctionPayload, **stations as `StationsJson`** (refines ADR-008s junction to match the Cluster `VariableIdsJson` pattern — Gianluca-approved), `ContentHash` **NOT NULL + UNIQUE** on both tiers.
- **SQLite↔EF parity suite** (`AxisShouldMatch` covers curve/function/stations/keypoints) + the A1 **schema-parity test extended to `Axis`** + 18 unit tests.
- **Scope:** no DataExchange / GH / Core-model changes; Core stays Rhino/EF/UI/ASP.NET-free (§4). GH wiring + arc-length = **B3**.
- **Tests:** +22. **373 → 395**, 19 stress skipped, 0 failed. CI-validated (no manual GH).