### PR TITLE
feat(api): Entra External ID JWT auth + reader/writer policies (Phase 4 / A3.2)

### DIFF
--- a/src/Progesi.Api/Auth/AuthPolicies.cs
+++ b/src/Progesi.Api/Auth/AuthPolicies.cs
@@ -1,0 +1,7 @@
+namespace Progesi.Api.Auth;
+
+public static class AuthPolicies
+{
+  public const string Reader = "Reader";
+  public const string Writer = "Writer";
+}

--- a/src/Progesi.Api/Auth/AuthRoles.cs
+++ b/src/Progesi.Api/Auth/AuthRoles.cs
@@ -1,0 +1,7 @@
+namespace Progesi.Api.Auth;
+
+public static class AuthRoles
+{
+  public const string Reader = "reader";
+  public const string Writer = "writer";
+}

--- a/src/Progesi.Api/Controllers/ClustersController.cs
+++ b/src/Progesi.Api/Controllers/ClustersController.cs
@@ -1,4 +1,6 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Progesi.Api.Auth;
 using Progesi.Api.Dtos;
 using Progesi.Api.Mapping;
 using ProgesiCore;
@@ -16,6 +18,7 @@ public sealed class ClustersController : ControllerBase
     _repository = repository;
   }
 
+  [Authorize(Policy = AuthPolicies.Reader)]
   [HttpGet]
   public async Task<ActionResult<IReadOnlyList<ClusterDto>>> GetAll(CancellationToken ct)
   {
@@ -23,6 +26,7 @@ public sealed class ClustersController : ControllerBase
     return Ok(clusters.Select(DomainMapping.ToDto).ToList());
   }
 
+  [Authorize(Policy = AuthPolicies.Reader)]
   [HttpGet("{id:int}")]
   public async Task<ActionResult<ClusterDto>> GetById(int id, CancellationToken ct)
   {
@@ -33,6 +37,7 @@ public sealed class ClustersController : ControllerBase
     return Ok(DomainMapping.ToDto(cluster));
   }
 
+  [Authorize(Policy = AuthPolicies.Writer)]
   [HttpPost]
   public async Task<ActionResult<ClusterDto>> Create([FromBody] ClusterUpsertDto dto, CancellationToken ct)
   {
@@ -48,6 +53,7 @@ public sealed class ClustersController : ControllerBase
     return CreatedAtAction(nameof(GetById), new { id = saved.Id }, DomainMapping.ToDto(saved));
   }
 
+  [Authorize(Policy = AuthPolicies.Writer)]
   [HttpPut("{id:int}")]
   public async Task<ActionResult<ClusterDto>> Update(int id, [FromBody] ClusterUpsertDto dto, CancellationToken ct)
   {
@@ -66,6 +72,7 @@ public sealed class ClustersController : ControllerBase
     return Ok(DomainMapping.ToDto(saved));
   }
 
+  [Authorize(Policy = AuthPolicies.Writer)]
   [HttpDelete("{id:int}")]
   public async Task<IActionResult> Delete(int id, CancellationToken ct)
   {

--- a/src/Progesi.Api/Controllers/MetadataController.cs
+++ b/src/Progesi.Api/Controllers/MetadataController.cs
@@ -1,4 +1,6 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Progesi.Api.Auth;
 using Progesi.Api.Dtos;
 using Progesi.Api.Mapping;
 using ProgesiCore;
@@ -16,6 +18,7 @@ public sealed class MetadataController : ControllerBase
     _repository = repository;
   }
 
+  [Authorize(Policy = AuthPolicies.Reader)]
   [HttpGet]
   public async Task<ActionResult<IReadOnlyList<MetadataDto>>> GetAll(
     [FromQuery] int skip = 0,
@@ -29,6 +32,7 @@ public sealed class MetadataController : ControllerBase
     return Ok(items.Select(DomainMapping.ToDto).ToList());
   }
 
+  [Authorize(Policy = AuthPolicies.Reader)]
   [HttpGet("{id:int}")]
   public async Task<ActionResult<MetadataDto>> GetById(int id, CancellationToken ct)
   {
@@ -39,6 +43,7 @@ public sealed class MetadataController : ControllerBase
     return Ok(DomainMapping.ToDto(metadata));
   }
 
+  [Authorize(Policy = AuthPolicies.Writer)]
   [HttpPost]
   public async Task<ActionResult<MetadataDto>> Create([FromBody] MetadataUpsertDto dto, CancellationToken ct)
   {
@@ -61,6 +66,7 @@ public sealed class MetadataController : ControllerBase
     return CreatedAtAction(nameof(GetById), new { id = saved.Id }, DomainMapping.ToDto(saved));
   }
 
+  [Authorize(Policy = AuthPolicies.Writer)]
   [HttpPut("{id:int}")]
   public async Task<ActionResult<MetadataDto>> Update(int id, [FromBody] MetadataUpsertDto dto, CancellationToken ct)
   {
@@ -82,6 +88,7 @@ public sealed class MetadataController : ControllerBase
     return Ok(DomainMapping.ToDto(saved!));
   }
 
+  [Authorize(Policy = AuthPolicies.Writer)]
   [HttpDelete("{id:int}")]
   public async Task<IActionResult> Delete(int id, CancellationToken ct)
   {

--- a/src/Progesi.Api/Controllers/VariablesController.cs
+++ b/src/Progesi.Api/Controllers/VariablesController.cs
@@ -1,4 +1,6 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Progesi.Api.Auth;
 using Progesi.Api.Dtos;
 using Progesi.Api.Mapping;
 using ProgesiCore;
@@ -16,6 +18,7 @@ public sealed class VariablesController : ControllerBase
     _repository = repository;
   }
 
+  [Authorize(Policy = AuthPolicies.Reader)]
   [HttpGet]
   public async Task<ActionResult<IReadOnlyList<VariableDto>>> GetAll(CancellationToken ct)
   {
@@ -23,6 +26,7 @@ public sealed class VariablesController : ControllerBase
     return Ok(variables.Select(DomainMapping.ToDto).ToList());
   }
 
+  [Authorize(Policy = AuthPolicies.Reader)]
   [HttpGet("{id:int}")]
   public async Task<ActionResult<VariableDto>> GetById(int id, CancellationToken ct)
   {
@@ -33,6 +37,7 @@ public sealed class VariablesController : ControllerBase
     return Ok(DomainMapping.ToDto(variable));
   }
 
+  [Authorize(Policy = AuthPolicies.Writer)]
   [HttpPost]
   public async Task<ActionResult<VariableDto>> Create([FromBody] VariableUpsertDto dto, CancellationToken ct)
   {
@@ -48,6 +53,7 @@ public sealed class VariablesController : ControllerBase
     return CreatedAtAction(nameof(GetById), new { id = saved.Id }, DomainMapping.ToDto(saved));
   }
 
+  [Authorize(Policy = AuthPolicies.Writer)]
   [HttpPut("{id:int}")]
   public async Task<ActionResult<VariableDto>> Update(int id, [FromBody] VariableUpsertDto dto, CancellationToken ct)
   {
@@ -66,6 +72,7 @@ public sealed class VariablesController : ControllerBase
     return Ok(DomainMapping.ToDto(saved));
   }
 
+  [Authorize(Policy = AuthPolicies.Writer)]
   [HttpDelete("{id:int}")]
   public async Task<IActionResult> Delete(int id, CancellationToken ct)
   {

--- a/src/Progesi.Api/Progesi.Api.csproj
+++ b/src/Progesi.Api/Progesi.Api.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.14.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 

--- a/src/Progesi.Api/Program.cs
+++ b/src/Progesi.Api/Program.cs
@@ -1,4 +1,8 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Identity.Web;
+using Microsoft.OpenApi.Models;
+using Progesi.Api.Auth;
 using Progesi.Infrastructure.EF;
 using Progesi.Infrastructure.EF.Repositories;
 using ProgesiCore;
@@ -7,7 +11,53 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(options =>
+{
+  options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+  {
+    Description = "JWT Authorization header using the Bearer scheme. Example: \"Bearer {token}\"",
+    Name = "Authorization",
+    In = ParameterLocation.Header,
+    Type = SecuritySchemeType.Http,
+    Scheme = "bearer",
+    BearerFormat = "JWT"
+  });
+
+  options.AddSecurityRequirement(new OpenApiSecurityRequirement
+  {
+    {
+      new OpenApiSecurityScheme
+      {
+        Reference = new OpenApiReference
+        {
+          Type = ReferenceType.SecurityScheme,
+          Id = "Bearer"
+        }
+      },
+      Array.Empty<string>()
+    }
+  });
+});
+
+var useTestAuth = builder.Configuration.GetValue<bool>("Progesi:UseTestAuthentication");
+if (useTestAuth)
+{
+  // Integration tests register TestAuthHandler via WebApplicationFactory.ConfigureTestServices.
+  builder.Services.AddAuthentication();
+}
+else
+{
+  builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+      .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"));
+}
+
+builder.Services.AddAuthorization(options =>
+{
+  options.AddPolicy(AuthPolicies.Reader, policy =>
+      policy.RequireRole(AuthRoles.Reader, AuthRoles.Writer));
+  options.AddPolicy(AuthPolicies.Writer, policy =>
+      policy.RequireRole(AuthRoles.Writer));
+});
 
 var connectionString = builder.Configuration.GetConnectionString("ProgesiDb")
     ?? throw new InvalidOperationException("Connection string 'ProgesiDb' is not configured.");
@@ -43,6 +93,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+app.UseAuthentication();
+app.UseAuthorization();
 app.MapControllers();
 
 app.Run();

--- a/src/Progesi.Api/README.md
+++ b/src/Progesi.Api/README.md
@@ -50,8 +50,32 @@ Open Swagger UI: [https://localhost:7xxx/swagger](https://localhost:5001/swagger
 
 All responses use API DTOs only (no Core types on the wire).
 
+## Authentication (ADR-018)
+
+The API uses **Entra External ID** (Azure AD) JWT bearer tokens via `Microsoft.Identity.Web`.
+
+Configuration section: `AzureAd` in `appsettings.json` (placeholders only — inject real values at deploy via environment variables or user-secrets):
+
+| Key | Purpose |
+|---|---|
+| `Instance` | Entra authority URL (e.g. `https://login.microsoftonline.com/` or CIAM tenant URL) |
+| `TenantId` | Directory / tenant ID |
+| `ClientId` | App registration client ID |
+| `Audience` | API audience (app ID URI) |
+
+**App roles** (assign in Entra app registration):
+
+| Role | Access |
+|---|---|
+| `reader` | `GET` on Variables, Metadata, Clusters |
+| `writer` | `POST` / `PUT` / `DELETE` (writers also satisfy reader policy) |
+
+Swagger UI exposes a **Bearer** token field for interactive testing once a token is available.
+
+**Deploy-time step (not CI):** provision the Entra External ID tenant, register the API app, define `reader`/`writer` app roles, and configure the deployed `AzureAd` settings. CI validates auth behaviour with a test scheme — no live tenant required.
+
 ## Architecture notes
 
 - `ProgesiDbContext` and EF repositories are **scoped per request** (see `Progesi.Infrastructure.EF/README.md`).
 - Schema is applied via `Database.Migrate()` on startup.
-- Authentication, cloud DB provisioning, and Rhino sync are out of scope for this MVP.
+- Cloud DB provisioning and Rhino sync are out of scope for this MVP.

--- a/src/Progesi.Api/appsettings.json
+++ b/src/Progesi.Api/appsettings.json
@@ -8,5 +8,11 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "ProgesiDb": "Data Source=progesi-api.sqlite"
+  },
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "TenantId": "00000000-0000-0000-0000-000000000000",
+    "ClientId": "00000000-0000-0000-0000-000000000000",
+    "Audience": "api://progesi-api-placeholder"
   }
 }

--- a/tests/Progesi.Api.Tests/ApiAuthorizationTests.cs
+++ b/tests/Progesi.Api.Tests/ApiAuthorizationTests.cs
@@ -1,0 +1,129 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Progesi.Api.Dtos;
+
+namespace Progesi.Api.Tests;
+
+[Collection(nameof(ProgesiApiTestCollection))]
+public sealed class ApiAuthorizationTests
+{
+  private readonly ProgesiApiWebApplicationFactory _factory;
+
+  public ApiAuthorizationTests(ProgesiApiWebApplicationFactory factory)
+  {
+    _factory = factory;
+  }
+
+  [Theory]
+  [InlineData("/api/variables")]
+  [InlineData("/api/metadata")]
+  [InlineData("/api/clusters")]
+  public async Task Unauthenticated_Get_Returns_401(string route)
+  {
+    using var client = _factory.CreateClient().AsUnauthenticated();
+    var response = await client.GetAsync(route);
+    response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+  }
+
+  [Theory]
+  [InlineData("/api/variables")]
+  [InlineData("/api/metadata")]
+  [InlineData("/api/clusters")]
+  public async Task Reader_Get_Returns_200(string route)
+  {
+    using var client = _factory.CreateClient().AsReader();
+    var response = await client.GetAsync(route);
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+  }
+
+  [Fact]
+  public async Task Variables_Reader_Post_Returns_403()
+  {
+    using var client = _factory.CreateClient().AsReader();
+    var dto = new VariableUpsertDto
+    {
+      Id = 9001,
+      Name = "AuthTest",
+      Value = System.Text.Json.JsonSerializer.SerializeToElement(1.0)
+    };
+
+    var response = await client.PostAsJsonAsync("/api/variables", dto);
+    response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+  }
+
+  [Fact]
+  public async Task Metadata_Reader_Post_Returns_403()
+  {
+    using var client = _factory.CreateClient().AsReader();
+    var dto = new MetadataUpsertDto
+    {
+      Id = 9002,
+      CreatedBy = "auth",
+      AdditionalInfo = "note"
+    };
+
+    var response = await client.PostAsJsonAsync("/api/metadata", dto);
+    response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+  }
+
+  [Fact]
+  public async Task Clusters_Reader_Post_Returns_403()
+  {
+    using var client = _factory.CreateClient().AsReader();
+    var dto = new ClusterUpsertDto
+    {
+      Id = 9003,
+      Name = "AuthCluster",
+      VariableIds = new[] { 1 }
+    };
+
+    var response = await client.PostAsJsonAsync("/api/clusters", dto);
+    response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+  }
+
+  [Fact]
+  public async Task Variables_Writer_Post_Returns_201()
+  {
+    using var client = _factory.CreateClient().AsWriter();
+    var dto = new VariableUpsertDto
+    {
+      Id = 9010,
+      Name = "WriterVar",
+      Value = System.Text.Json.JsonSerializer.SerializeToElement(2.0)
+    };
+
+    var response = await client.PostAsJsonAsync("/api/variables", dto);
+    response.StatusCode.Should().Be(HttpStatusCode.Created);
+  }
+
+  [Fact]
+  public async Task Metadata_Writer_Post_Returns_201()
+  {
+    using var client = _factory.CreateClient().AsWriter();
+    var dto = new MetadataUpsertDto
+    {
+      Id = 9011,
+      CreatedBy = "writer",
+      AdditionalInfo = "note"
+    };
+
+    var response = await client.PostAsJsonAsync("/api/metadata", dto);
+    response.StatusCode.Should().Be(HttpStatusCode.Created);
+  }
+
+  [Fact]
+  public async Task Clusters_Writer_Post_Returns_201()
+  {
+    using var client = _factory.CreateClient().AsWriter();
+    var dto = new ClusterUpsertDto
+    {
+      Id = 9012,
+      Name = "WriterCluster",
+      VariableIds = new[] { 1 }
+    };
+
+    var response = await client.PostAsJsonAsync("/api/clusters", dto);
+    response.StatusCode.Should().Be(HttpStatusCode.Created);
+  }
+}

--- a/tests/Progesi.Api.Tests/ClustersApiTests.cs
+++ b/tests/Progesi.Api.Tests/ClustersApiTests.cs
@@ -12,7 +12,7 @@ public sealed class ClustersApiTests
 
   public ClustersApiTests(ProgesiApiWebApplicationFactory factory)
   {
-    _client = factory.CreateClient();
+    _client = factory.CreateClient().AsWriter();
   }
 
   [Fact]

--- a/tests/Progesi.Api.Tests/MetadataApiTests.cs
+++ b/tests/Progesi.Api.Tests/MetadataApiTests.cs
@@ -12,7 +12,7 @@ public sealed class MetadataApiTests
 
   public MetadataApiTests(ProgesiApiWebApplicationFactory factory)
   {
-    _client = factory.CreateClient();
+    _client = factory.CreateClient().AsWriter();
   }
 
   [Fact]

--- a/tests/Progesi.Api.Tests/ProgesiApiWebApplicationFactory.cs
+++ b/tests/Progesi.Api.Tests/ProgesiApiWebApplicationFactory.cs
@@ -1,5 +1,8 @@
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Progesi.Api.Tests;
 
@@ -12,6 +15,15 @@ public sealed class ProgesiApiWebApplicationFactory : WebApplicationFactory<Prog
     builder.UseEnvironment("Development");
     builder.UseSetting("ConnectionStrings:ProgesiDb", $"Data Source={_dbPath}");
     builder.UseSetting("Progesi:ResetSchemaOnStartup", "true");
+    builder.UseSetting("Progesi:UseTestAuthentication", "true");
+
+    builder.ConfigureTestServices(services =>
+    {
+      services.AddAuthentication(TestAuthHandler.SchemeName)
+          .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+              TestAuthHandler.SchemeName,
+              _ => { });
+    });
   }
 
   protected override void Dispose(bool disposing)

--- a/tests/Progesi.Api.Tests/SwaggerApiTests.cs
+++ b/tests/Progesi.Api.Tests/SwaggerApiTests.cs
@@ -24,5 +24,7 @@ public sealed class SwaggerApiTests
     body.Should().Contain("/api/variables");
     body.Should().Contain("/api/metadata");
     body.Should().Contain("/api/clusters");
+    body.Should().Contain("\"Bearer\"");
+    body.Should().Contain("securitySchemes");
   }
 }

--- a/tests/Progesi.Api.Tests/TestAuthClientExtensions.cs
+++ b/tests/Progesi.Api.Tests/TestAuthClientExtensions.cs
@@ -1,0 +1,26 @@
+using Progesi.Api.Auth;
+
+namespace Progesi.Api.Tests;
+
+internal static class TestAuthClientExtensions
+{
+  public static HttpClient AsReader(this HttpClient client)
+  {
+    client.DefaultRequestHeaders.Remove(TestAuthHandler.RolesHeaderName);
+    client.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeaderName, AuthRoles.Reader);
+    return client;
+  }
+
+  public static HttpClient AsWriter(this HttpClient client)
+  {
+    client.DefaultRequestHeaders.Remove(TestAuthHandler.RolesHeaderName);
+    client.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeaderName, AuthRoles.Writer);
+    return client;
+  }
+
+  public static HttpClient AsUnauthenticated(this HttpClient client)
+  {
+    client.DefaultRequestHeaders.Remove(TestAuthHandler.RolesHeaderName);
+    return client;
+  }
+}

--- a/tests/Progesi.Api.Tests/TestAuthHandler.cs
+++ b/tests/Progesi.Api.Tests/TestAuthHandler.cs
@@ -1,0 +1,50 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Progesi.Api.Tests;
+
+/// <summary>
+/// Test-only authentication handler. Activated when <c>Progesi:UseTestAuthentication</c> is true.
+/// Supply roles via the <see cref="RolesHeaderName"/> request header (comma-separated).
+/// </summary>
+public sealed class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+  public const string SchemeName = "Test";
+  public const string RolesHeaderName = "X-Test-Roles";
+
+  public TestAuthHandler(
+      IOptionsMonitor<AuthenticationSchemeOptions> options,
+      ILoggerFactory logger,
+      UrlEncoder encoder)
+      : base(options, logger, encoder)
+  {
+  }
+
+  protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+  {
+    if (!Request.Headers.TryGetValue(RolesHeaderName, out var roleHeader) ||
+        string.IsNullOrWhiteSpace(roleHeader))
+    {
+      return Task.FromResult(AuthenticateResult.NoResult());
+    }
+
+    var claims = new List<Claim>
+    {
+      new(ClaimTypes.Name, "test-user"),
+      new(ClaimTypes.NameIdentifier, "test-user-id")
+    };
+
+    foreach (var role in roleHeader.ToString().Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+    {
+      claims.Add(new Claim(ClaimTypes.Role, role));
+    }
+
+    var identity = new ClaimsIdentity(claims, SchemeName);
+    var principal = new ClaimsPrincipal(identity);
+    var ticket = new AuthenticationTicket(principal, SchemeName);
+    return Task.FromResult(AuthenticateResult.Success(ticket));
+  }
+}

--- a/tests/Progesi.Api.Tests/VariablesApiTests.cs
+++ b/tests/Progesi.Api.Tests/VariablesApiTests.cs
@@ -12,7 +12,7 @@ public sealed class VariablesApiTests
 
   public VariablesApiTests(ProgesiApiWebApplicationFactory factory)
   {
-    _client = factory.CreateClient();
+    _client = factory.CreateClient().AsWriter();
   }
 
   [Fact]


### PR DESCRIPTION
## Phase 4 / A3.2 — API authentication (Entra External ID)

Adds auth + role-based authorization to `Progesi.Api` per ADR-018.

- **Production:** `Microsoft.Identity.Web` JWT bearer (`AddMicrosoftIdentityWebApi` from `AzureAd` config). **Reader** policy on GET, **Writer** on POST/PUT/DELETE (Variables/Metadata/Clusters). Swagger Bearer scheme.
- **CI-safe test auth:** an **opt-in** `Progesi:UseTestAuthentication` flag — **off by default, absent from committed config**, enabled only by the test `WebApplicationFactory` (registers a `TestAuthHandler` reading `X-Test-Roles`). So the default/production path is real Entra JWT.
- **Tests:** +12 (401 unauth / 403 wrong-role / 201 writer across all 3 resources); A3.1 CRUD tests updated to authenticate; Swagger-Bearer asserted. **395 → 407**, 0 failed.
- **Scope:** Progesi.Api + tests only; no Core/EF/GH/AxisVar; no secrets committed. Real-tenant validation = deploy-time.
- **Follow-up (noted):** additionally gate `UseTestAuthentication` to the Development environment (defence-in-depth).