### PR TITLE
feat(api): per-project template databases + provisioning (Phase 4 / A3.3)

### DIFF
--- a/src/Progesi.Api/Controllers/ProjectsController.cs
+++ b/src/Progesi.Api/Controllers/ProjectsController.cs
@@ -1,0 +1,60 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Progesi.Api.Auth;
+using Progesi.Api.Dtos;
+using Progesi.Api.Projects;
+
+namespace Progesi.Api.Controllers;
+
+[ApiController]
+[Route("api/projects")]
+public sealed class ProjectsController : ControllerBase
+{
+  private readonly IProjectProvisioningService _provisioningService;
+  private readonly IProjectRegistry _registry;
+
+  public ProjectsController(
+      IProjectProvisioningService provisioningService,
+      IProjectRegistry registry)
+  {
+    _provisioningService = provisioningService;
+    _registry = registry;
+  }
+
+  [Authorize(Policy = AuthPolicies.Writer)]
+  [HttpPost]
+  public ActionResult<ProjectDto> Create([FromBody] CreateProjectRequest request)
+  {
+    if (string.IsNullOrWhiteSpace(request.Name))
+      return BadRequest("Project name is required.");
+
+    var entry = _provisioningService.Provision(request.Name);
+    var dto = ToDto(entry);
+    return CreatedAtAction(nameof(GetById), new { id = dto.Id }, dto);
+  }
+
+  [Authorize(Policy = AuthPolicies.Writer)]
+  [HttpGet]
+  public ActionResult<IReadOnlyList<ProjectDto>> List()
+  {
+    var projects = _registry.GetAll().Select(ToDto).ToList();
+    return Ok(projects);
+  }
+
+  [Authorize(Policy = AuthPolicies.Writer)]
+  [HttpGet("{id}")]
+  public ActionResult<ProjectDto> GetById(string id)
+  {
+    var entry = _registry.GetById(id);
+    if (entry == null)
+      return NotFound($"Project '{id}' was not found.");
+
+    return Ok(ToDto(entry));
+  }
+
+  private static ProjectDto ToDto(ProjectEntry entry) => new()
+  {
+    Id = entry.Id,
+    Name = entry.Name
+  };
+}

--- a/src/Progesi.Api/Dtos/ProjectDtos.cs
+++ b/src/Progesi.Api/Dtos/ProjectDtos.cs
@@ -1,0 +1,12 @@
+namespace Progesi.Api.Dtos;
+
+public sealed class ProjectDto
+{
+  public string Id { get; set; } = string.Empty;
+  public string Name { get; set; } = string.Empty;
+}
+
+public sealed class CreateProjectRequest
+{
+  public string Name { get; set; } = string.Empty;
+}

--- a/src/Progesi.Api/Infrastructure/ProjectNotFoundExceptionFilter.cs
+++ b/src/Progesi.Api/Infrastructure/ProjectNotFoundExceptionFilter.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Progesi.Api.Projects;
+
+namespace Progesi.Api.Infrastructure;
+
+public sealed class ProjectNotFoundExceptionFilter : IExceptionFilter
+{
+  public void OnException(ExceptionContext context)
+  {
+    if (context.Exception is not ProjectNotFoundException ex)
+      return;
+
+    context.Result = new NotFoundObjectResult(ex.Message);
+    context.ExceptionHandled = true;
+  }
+}

--- a/src/Progesi.Api/Progesi.Api.csproj
+++ b/src/Progesi.Api/Progesi.Api.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.14.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>

--- a/src/Progesi.Api/Program.cs
+++ b/src/Progesi.Api/Program.cs
@@ -1,15 +1,19 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Identity.Web;
 using Microsoft.OpenApi.Models;
 using Progesi.Api.Auth;
+using Progesi.Api.Infrastructure;
+using Progesi.Api.Projects;
 using Progesi.Infrastructure.EF;
 using Progesi.Infrastructure.EF.Repositories;
 using ProgesiCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddControllers();
+builder.Services.AddControllers(options =>
+{
+  options.Filters.Add<ProjectNotFoundExceptionFilter>();
+});
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {
@@ -39,7 +43,8 @@ builder.Services.AddSwaggerGen(options =>
   });
 });
 
-var useTestAuth = builder.Configuration.GetValue<bool>("Progesi:UseTestAuthentication");
+var useTestAuth = builder.Environment.IsDevelopment()
+    && builder.Configuration.GetValue<bool>("Progesi:UseTestAuthentication");
 if (useTestAuth)
 {
   // Integration tests register TestAuthHandler via WebApplicationFactory.ConfigureTestServices.
@@ -59,16 +64,11 @@ builder.Services.AddAuthorization(options =>
       policy.RequireRole(AuthRoles.Writer));
 });
 
-var connectionString = builder.Configuration.GetConnectionString("ProgesiDb")
-    ?? throw new InvalidOperationException("Connection string 'ProgesiDb' is not configured.");
-
-builder.Services.AddDbContext<ProgesiDbContext>(options =>
-{
-  var normalized = ProgesiDbContextFactory.NormalizeConnectionString(connectionString);
-  options.UseSqlite(
-      normalized,
-      sqlite => sqlite.ExecutionStrategy(deps => new Progesi.Infrastructure.EF.Internal.SqliteBusyRetryExecutionStrategy(deps)));
-});
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddSingleton<IProjectRegistry, JsonFileProjectRegistry>();
+builder.Services.AddScoped<IProjectProvisioningService, ProjectProvisioningService>();
+builder.Services.AddScoped<IProjectContext, ProjectContext>();
+builder.Services.AddScoped(sp => sp.GetRequiredService<IProjectContext>().DbContext);
 
 builder.Services.AddScoped<IVariableRepository>(sp =>
     new EfVariableRepository(sp.GetRequiredService<ProgesiDbContext>(), ownsContext: false));
@@ -81,9 +81,19 @@ var app = builder.Build();
 
 using (var scope = app.Services.CreateScope())
 {
-  var db = scope.ServiceProvider.GetRequiredService<ProgesiDbContext>();
-  var resetSchema = app.Configuration.GetValue<bool>("Progesi:ResetSchemaOnStartup");
-  ProgesiDbContextFactory.EnsureSchema(db, resetSchema);
+  var registry = scope.ServiceProvider.GetRequiredService<IProjectRegistry>();
+  registry.EnsureDefaultProject();
+
+  if (app.Configuration.GetValue<bool>("Progesi:ResetSchemaOnStartup"))
+  {
+    var defaultProjectId = app.Configuration["Progesi:DefaultProjectId"] ?? "default";
+    var defaultEntry = registry.GetById(defaultProjectId)
+        ?? throw new InvalidOperationException($"Default project '{defaultProjectId}' is not registered.");
+
+    var options = ProgesiDbContextOptionsBuilder.Build(defaultEntry.ConnectionString, app.Configuration);
+    using var db = new ProgesiDbContext(options);
+    ProgesiDbContextFactory.EnsureSchema(db, resetSchema: true);
+  }
 }
 
 if (app.Environment.IsDevelopment())

--- a/src/Progesi.Api/Projects/IProjectProvisioningService.cs
+++ b/src/Progesi.Api/Projects/IProjectProvisioningService.cs
@@ -1,0 +1,6 @@
+namespace Progesi.Api.Projects;
+
+public interface IProjectProvisioningService
+{
+  ProjectEntry Provision(string name);
+}

--- a/src/Progesi.Api/Projects/IProjectRegistry.cs
+++ b/src/Progesi.Api/Projects/IProjectRegistry.cs
@@ -1,0 +1,9 @@
+namespace Progesi.Api.Projects;
+
+public interface IProjectRegistry
+{
+  ProjectEntry? GetById(string projectId);
+  IReadOnlyList<ProjectEntry> GetAll();
+  void Add(ProjectEntry entry);
+  void EnsureDefaultProject();
+}

--- a/src/Progesi.Api/Projects/JsonFileProjectRegistry.cs
+++ b/src/Progesi.Api/Projects/JsonFileProjectRegistry.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+using Progesi.Infrastructure.EF;
+
+namespace Progesi.Api.Projects;
+
+public sealed class JsonFileProjectRegistry : IProjectRegistry
+{
+  private readonly string _registryPath;
+  private readonly string _defaultProjectId;
+  private readonly IConfiguration _configuration;
+  private readonly object _sync = new();
+  private RegistryDocument? _cache;
+
+  public JsonFileProjectRegistry(IConfiguration configuration)
+  {
+    _configuration = configuration;
+    _defaultProjectId = configuration["Progesi:DefaultProjectId"] ?? "default";
+    var projectsDirectory = ProgesiDbContextOptionsBuilder.ResolveProjectsDirectory(configuration);
+    Directory.CreateDirectory(projectsDirectory);
+    _registryPath = Path.Combine(projectsDirectory, "projects.json");
+  }
+
+  public ProjectEntry? GetById(string projectId)
+  {
+    lock (_sync)
+    {
+      return LoadDocument().Projects.FirstOrDefault(p =>
+          string.Equals(p.Id, projectId, StringComparison.OrdinalIgnoreCase));
+    }
+  }
+
+  public IReadOnlyList<ProjectEntry> GetAll()
+  {
+    lock (_sync)
+    {
+      return LoadDocument().Projects
+          .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+          .ToList();
+    }
+  }
+
+  public void Add(ProjectEntry entry)
+  {
+    if (entry is null) throw new ArgumentNullException(nameof(entry));
+    if (string.IsNullOrWhiteSpace(entry.Id)) throw new ArgumentException("Project id is required.", nameof(entry));
+    if (string.IsNullOrWhiteSpace(entry.Name)) throw new ArgumentException("Project name is required.", nameof(entry));
+    if (string.IsNullOrWhiteSpace(entry.ConnectionString))
+      throw new ArgumentException("Connection string is required.", nameof(entry));
+
+    lock (_sync)
+    {
+      var document = LoadDocument();
+      if (document.Projects.Any(p => string.Equals(p.Id, entry.Id, StringComparison.OrdinalIgnoreCase)))
+        throw new InvalidOperationException($"Project '{entry.Id}' already exists.");
+
+      document.Projects.Add(new ProjectEntry
+      {
+        Id = entry.Id.Trim(),
+        Name = entry.Name.Trim(),
+        ConnectionString = entry.ConnectionString
+      });
+      SaveDocument(document);
+    }
+  }
+
+  public void EnsureDefaultProject()
+  {
+    lock (_sync)
+    {
+      var document = LoadDocument();
+      if (document.Projects.Any(p => string.Equals(p.Id, _defaultProjectId, StringComparison.OrdinalIgnoreCase)))
+        return;
+
+      var connectionString = ProgesiDbContextOptionsBuilder.BuildConnectionStringForProject(
+          _defaultProjectId,
+          _configuration);
+
+      MigrateEmptyDatabase(connectionString);
+
+      document.Projects.Add(new ProjectEntry
+      {
+        Id = _defaultProjectId,
+        Name = "Default",
+        ConnectionString = connectionString
+      });
+      SaveDocument(document);
+    }
+  }
+
+  internal static void MigrateEmptyDatabase(string connectionString, IConfiguration configuration)
+  {
+    var options = ProgesiDbContextOptionsBuilder.Build(connectionString, configuration);
+    using var context = new ProgesiDbContext(options);
+    ProgesiDbContextFactory.EnsureSchema(context, resetSchema: false);
+  }
+
+  private void MigrateEmptyDatabase(string connectionString)
+      => MigrateEmptyDatabase(connectionString, _configuration);
+
+  private RegistryDocument LoadDocument()
+  {
+    if (_cache != null)
+      return _cache;
+
+    if (!File.Exists(_registryPath))
+    {
+      _cache = new RegistryDocument();
+      return _cache;
+    }
+
+    var json = File.ReadAllText(_registryPath);
+    _cache = JsonSerializer.Deserialize<RegistryDocument>(json, SerializerOptions)
+             ?? new RegistryDocument();
+    return _cache;
+  }
+
+  private void SaveDocument(RegistryDocument document)
+  {
+    _cache = document;
+    var json = JsonSerializer.Serialize(document, SerializerOptions);
+    File.WriteAllText(_registryPath, json);
+  }
+
+  private sealed class RegistryDocument
+  {
+    public List<ProjectEntry> Projects { get; set; } = new();
+  }
+
+  private static readonly JsonSerializerOptions SerializerOptions = new()
+  {
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+  };
+}

--- a/src/Progesi.Api/Projects/ProgesiDbContextOptionsBuilder.cs
+++ b/src/Progesi.Api/Projects/ProgesiDbContextOptionsBuilder.cs
@@ -1,0 +1,61 @@
+using Microsoft.EntityFrameworkCore;
+using Progesi.Infrastructure.EF;
+using Progesi.Infrastructure.EF.Internal;
+
+namespace Progesi.Api.Projects;
+
+internal static class ProgesiDbContextOptionsBuilder
+{
+  public static DbContextOptions<ProgesiDbContext> Build(
+      string connectionString,
+      IConfiguration configuration)
+  {
+    var provider = configuration["Progesi:DbProvider"] ?? "Sqlite";
+    var normalized = ProgesiDbContextFactory.NormalizeConnectionString(connectionString);
+    var builder = new DbContextOptionsBuilder<ProgesiDbContext>();
+
+    if (provider.Equals("SqlServer", StringComparison.OrdinalIgnoreCase))
+    {
+      builder.UseSqlServer(normalized);
+      return builder.Options;
+    }
+
+    builder.UseSqlite(
+        normalized,
+        sqlite => sqlite.ExecutionStrategy(deps => new SqliteBusyRetryExecutionStrategy(deps)));
+    return builder.Options;
+  }
+
+  public static string BuildConnectionStringForProject(string projectId, IConfiguration configuration)
+  {
+    var provider = configuration["Progesi:DbProvider"] ?? "Sqlite";
+
+    if (provider.Equals("SqlServer", StringComparison.OrdinalIgnoreCase))
+    {
+      var template = configuration.GetConnectionString("SqlServerProjectTemplate");
+      if (string.IsNullOrWhiteSpace(template))
+      {
+        throw new InvalidOperationException(
+            "ConnectionStrings:SqlServerProjectTemplate is required when Progesi:DbProvider is SqlServer.");
+      }
+
+      return template.Replace("{ProjectId}", projectId, StringComparison.Ordinal);
+    }
+
+    var projectsDirectory = ResolveProjectsDirectory(configuration);
+    Directory.CreateDirectory(projectsDirectory);
+    var dbPath = Path.Combine(projectsDirectory, $"{projectId}.sqlite");
+    return $"Data Source={dbPath}";
+  }
+
+  public static string ResolveProjectsDirectory(IConfiguration configuration)
+  {
+    var configured = configuration["Progesi:ProjectsDirectory"];
+    if (string.IsNullOrWhiteSpace(configured))
+      return Path.Combine(AppContext.BaseDirectory, "projects");
+
+    return Path.IsPathRooted(configured)
+        ? configured
+        : Path.Combine(AppContext.BaseDirectory, configured);
+  }
+}

--- a/src/Progesi.Api/Projects/ProjectContext.cs
+++ b/src/Progesi.Api/Projects/ProjectContext.cs
@@ -1,0 +1,51 @@
+using Microsoft.EntityFrameworkCore;
+using Progesi.Infrastructure.EF;
+
+namespace Progesi.Api.Projects;
+
+public interface IProjectContext
+{
+  string ProjectId { get; }
+  ProgesiDbContext DbContext { get; }
+}
+
+public sealed class ProjectContext : IProjectContext, IDisposable
+{
+  public string ProjectId { get; }
+  public ProgesiDbContext DbContext { get; }
+
+  public ProjectContext(
+      IHttpContextAccessor httpContextAccessor,
+      IProjectRegistry registry,
+      IConfiguration configuration)
+  {
+    ProjectId = ResolveProjectId(httpContextAccessor, configuration);
+    var entry = registry.GetById(ProjectId)
+                ?? throw new ProjectNotFoundException(ProjectId);
+
+    var options = ProgesiDbContextOptionsBuilder.Build(entry.ConnectionString, configuration);
+    DbContext = new ProgesiDbContext(options);
+  }
+
+  public void Dispose()
+  {
+    DbContext.Dispose();
+  }
+
+  internal static string ResolveProjectId(IHttpContextAccessor httpContextAccessor, IConfiguration configuration)
+  {
+    var defaultProjectId = configuration["Progesi:DefaultProjectId"] ?? "default";
+    var httpContext = httpContextAccessor.HttpContext;
+    if (httpContext == null)
+      return defaultProjectId;
+
+    if (httpContext.Request.Headers.TryGetValue(ProjectHeaders.ProjectId, out var headerValues))
+    {
+      var headerValue = headerValues.FirstOrDefault();
+      if (!string.IsNullOrWhiteSpace(headerValue))
+        return headerValue.Trim();
+    }
+
+    return defaultProjectId;
+  }
+}

--- a/src/Progesi.Api/Projects/ProjectEntry.cs
+++ b/src/Progesi.Api/Projects/ProjectEntry.cs
@@ -1,0 +1,8 @@
+namespace Progesi.Api.Projects;
+
+public sealed class ProjectEntry
+{
+  public string Id { get; set; } = string.Empty;
+  public string Name { get; set; } = string.Empty;
+  public string ConnectionString { get; set; } = string.Empty;
+}

--- a/src/Progesi.Api/Projects/ProjectHeaders.cs
+++ b/src/Progesi.Api/Projects/ProjectHeaders.cs
@@ -1,0 +1,6 @@
+namespace Progesi.Api.Projects;
+
+public static class ProjectHeaders
+{
+  public const string ProjectId = "X-Project-Id";
+}

--- a/src/Progesi.Api/Projects/ProjectNotFoundException.cs
+++ b/src/Progesi.Api/Projects/ProjectNotFoundException.cs
@@ -1,0 +1,12 @@
+namespace Progesi.Api.Projects;
+
+public sealed class ProjectNotFoundException : Exception
+{
+  public ProjectNotFoundException(string projectId)
+      : base($"Project '{projectId}' was not found.")
+  {
+    ProjectId = projectId;
+  }
+
+  public string ProjectId { get; }
+}

--- a/src/Progesi.Api/Projects/ProjectProvisioningService.cs
+++ b/src/Progesi.Api/Projects/ProjectProvisioningService.cs
@@ -1,0 +1,36 @@
+namespace Progesi.Api.Projects;
+
+public sealed class ProjectProvisioningService : IProjectProvisioningService
+{
+  private readonly IProjectRegistry _registry;
+  private readonly IConfiguration _configuration;
+
+  public ProjectProvisioningService(IProjectRegistry registry, IConfiguration configuration)
+  {
+    _registry = registry;
+    _configuration = configuration;
+  }
+
+  public ProjectEntry Provision(string name)
+  {
+    if (string.IsNullOrWhiteSpace(name))
+      throw new ArgumentException("Project name is required.", nameof(name));
+
+    var projectId = Guid.NewGuid().ToString("N");
+    var connectionString = ProgesiDbContextOptionsBuilder.BuildConnectionStringForProject(
+        projectId,
+        _configuration);
+
+    JsonFileProjectRegistry.MigrateEmptyDatabase(connectionString, _configuration);
+
+    var entry = new ProjectEntry
+    {
+      Id = projectId,
+      Name = name.Trim(),
+      ConnectionString = connectionString
+    };
+
+    _registry.Add(entry);
+    return entry;
+  }
+}

--- a/src/Progesi.Api/README.md
+++ b/src/Progesi.Api/README.md
@@ -9,17 +9,14 @@ ASP.NET Core Web API for the Progesi web tier (ADR-016). EF-backed CRUD over Var
 
 ## Configuration
 
-Connection string key: `ConnectionStrings:ProgesiDb`.
+Per-project databases are resolved via the **`X-Project-Id`** request header (falls back to `Progesi:DefaultProjectId`, default `"default"`).
 
-Default (local dev SQLite file):
-
-```json
-"ConnectionStrings": {
-  "ProgesiDb": "Data Source=progesi-api.sqlite"
-}
-```
-
-The provider is selected via EF configuration; swap the connection string later for Azure SQL or Postgres without changing controllers.
+| Key | Purpose |
+|---|---|
+| `Progesi:DbProvider` | `Sqlite` (dev/CI default) or `SqlServer` (prod-ready seam) |
+| `Progesi:DefaultProjectId` | Project used when `X-Project-Id` is absent |
+| `Progesi:ProjectsDirectory` | Folder for SQLite project DBs + `projects.json` registry |
+| `ConnectionStrings:SqlServerProjectTemplate` | SqlServer template with `{ProjectId}` placeholder (deploy only) |
 
 Optional test/bootstrap flag:
 
@@ -29,7 +26,7 @@ Optional test/bootstrap flag:
 }
 ```
 
-When `true`, deletes and re-migrates the database on startup (integration tests only).
+When `true`, deletes and re-migrates the **default** project database on startup (integration tests only).
 
 ## Run locally
 
@@ -44,11 +41,21 @@ Open Swagger UI: [https://localhost:7xxx/swagger](https://localhost:5001/swagger
 
 | Resource | Routes |
 |---|---|
+| Projects | `GET/POST /api/projects`, `GET /api/projects/{id}` (writer only) |
 | Variables | `GET/POST /api/variables`, `GET/PUT/DELETE /api/variables/{id}` |
 | Metadata | `GET/POST /api/metadata`, `GET/PUT/DELETE /api/metadata/{id}` |
 | Clusters | `GET/POST /api/clusters`, `GET/PUT/DELETE /api/clusters/{id}` |
 
+Pass **`X-Project-Id`** on CRUD requests to target a specific project database.
+
 All responses use API DTOs only (no Core types on the wire).
+
+## Multi-project provisioning (A3.3)
+
+- **Template clone = Migrate()** on a fresh empty database (EF migrations are the schema template).
+- `POST /api/projects` (writer) provisions a new per-project DB and registers it in `projects.json`.
+- Dev/CI uses one SQLite file per project; production swaps `Progesi:DbProvider` to `SqlServer` and supplies `SqlServerProjectTemplate` at deploy time.
+- **Deploy-time (not CI):** Azure SQL provisioning and running provider-specific migrations against live cloud DBs.
 
 ## Authentication (ADR-018)
 
@@ -76,6 +83,6 @@ Swagger UI exposes a **Bearer** token field for interactive testing once a token
 
 ## Architecture notes
 
-- `ProgesiDbContext` and EF repositories are **scoped per request** (see `Progesi.Infrastructure.EF/README.md`).
-- Schema is applied via `Database.Migrate()` on startup.
-- Cloud DB provisioning and Rhino sync are out of scope for this MVP.
+- `ProgesiDbContext` and EF repositories are **scoped per request per project** (see `Progesi.Infrastructure.EF/README.md`).
+- Schema is applied via `Database.Migrate()` when a project is provisioned.
+- Auth↔project membership mapping and Rhino sync are out of scope for this MVP.

--- a/src/Progesi.Api/appsettings.json
+++ b/src/Progesi.Api/appsettings.json
@@ -7,7 +7,13 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "ProgesiDb": "Data Source=progesi-api.sqlite"
+    "ProgesiDb": "Data Source=progesi-api.sqlite",
+    "SqlServerProjectTemplate": "Server=localhost;Database=Progesi_{ProjectId};Trusted_Connection=True;TrustServerCertificate=True"
+  },
+  "Progesi": {
+    "DbProvider": "Sqlite",
+    "DefaultProjectId": "default",
+    "ProjectsDirectory": "projects"
   },
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",

--- a/tests/Progesi.Api.Tests/ApiAuthorizationTests.cs
+++ b/tests/Progesi.Api.Tests/ApiAuthorizationTests.cs
@@ -32,7 +32,7 @@ public sealed class ApiAuthorizationTests
   [InlineData("/api/clusters")]
   public async Task Reader_Get_Returns_200(string route)
   {
-    using var client = _factory.CreateClient().AsReader();
+    using var client = _factory.CreateClient().AsReaderForProject(_factory.DefaultProjectId);
     var response = await client.GetAsync(route);
     response.StatusCode.Should().Be(HttpStatusCode.OK);
   }
@@ -40,7 +40,7 @@ public sealed class ApiAuthorizationTests
   [Fact]
   public async Task Variables_Reader_Post_Returns_403()
   {
-    using var client = _factory.CreateClient().AsReader();
+    using var client = _factory.CreateClient().AsReaderForProject(_factory.DefaultProjectId);
     var dto = new VariableUpsertDto
     {
       Id = 9001,
@@ -55,7 +55,7 @@ public sealed class ApiAuthorizationTests
   [Fact]
   public async Task Metadata_Reader_Post_Returns_403()
   {
-    using var client = _factory.CreateClient().AsReader();
+    using var client = _factory.CreateClient().AsReaderForProject(_factory.DefaultProjectId);
     var dto = new MetadataUpsertDto
     {
       Id = 9002,
@@ -70,7 +70,7 @@ public sealed class ApiAuthorizationTests
   [Fact]
   public async Task Clusters_Reader_Post_Returns_403()
   {
-    using var client = _factory.CreateClient().AsReader();
+    using var client = _factory.CreateClient().AsReaderForProject(_factory.DefaultProjectId);
     var dto = new ClusterUpsertDto
     {
       Id = 9003,
@@ -85,7 +85,7 @@ public sealed class ApiAuthorizationTests
   [Fact]
   public async Task Variables_Writer_Post_Returns_201()
   {
-    using var client = _factory.CreateClient().AsWriter();
+    using var client = _factory.CreateClient().AsWriterForProject(_factory.DefaultProjectId);
     var dto = new VariableUpsertDto
     {
       Id = 9010,
@@ -100,7 +100,7 @@ public sealed class ApiAuthorizationTests
   [Fact]
   public async Task Metadata_Writer_Post_Returns_201()
   {
-    using var client = _factory.CreateClient().AsWriter();
+    using var client = _factory.CreateClient().AsWriterForProject(_factory.DefaultProjectId);
     var dto = new MetadataUpsertDto
     {
       Id = 9011,
@@ -115,7 +115,7 @@ public sealed class ApiAuthorizationTests
   [Fact]
   public async Task Clusters_Writer_Post_Returns_201()
   {
-    using var client = _factory.CreateClient().AsWriter();
+    using var client = _factory.CreateClient().AsWriterForProject(_factory.DefaultProjectId);
     var dto = new ClusterUpsertDto
     {
       Id = 9012,

--- a/tests/Progesi.Api.Tests/ClustersApiTests.cs
+++ b/tests/Progesi.Api.Tests/ClustersApiTests.cs
@@ -12,7 +12,7 @@ public sealed class ClustersApiTests
 
   public ClustersApiTests(ProgesiApiWebApplicationFactory factory)
   {
-    _client = factory.CreateClient().AsWriter();
+    _client = factory.CreateClient().AsWriterForProject(factory.DefaultProjectId);
   }
 
   [Fact]

--- a/tests/Progesi.Api.Tests/MetadataApiTests.cs
+++ b/tests/Progesi.Api.Tests/MetadataApiTests.cs
@@ -12,7 +12,7 @@ public sealed class MetadataApiTests
 
   public MetadataApiTests(ProgesiApiWebApplicationFactory factory)
   {
-    _client = factory.CreateClient().AsWriter();
+    _client = factory.CreateClient().AsWriterForProject(factory.DefaultProjectId);
   }
 
   [Fact]

--- a/tests/Progesi.Api.Tests/ProgesiApiWebApplicationFactory.cs
+++ b/tests/Progesi.Api.Tests/ProgesiApiWebApplicationFactory.cs
@@ -3,17 +3,23 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Progesi.Api.Projects;
 
 namespace Progesi.Api.Tests;
 
 public sealed class ProgesiApiWebApplicationFactory : WebApplicationFactory<Program>
 {
-  private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"progesi_api_{Guid.NewGuid():N}.sqlite");
+  private readonly string _projectsDirectory = Path.Combine(
+      Path.GetTempPath(),
+      $"progesi_projects_{Guid.NewGuid():N}");
+
+  public string DefaultProjectId => "default";
 
   protected override void ConfigureWebHost(IWebHostBuilder builder)
   {
     builder.UseEnvironment("Development");
-    builder.UseSetting("ConnectionStrings:ProgesiDb", $"Data Source={_dbPath}");
+    builder.UseSetting("Progesi:ProjectsDirectory", _projectsDirectory);
+    builder.UseSetting("Progesi:DefaultProjectId", DefaultProjectId);
     builder.UseSetting("Progesi:ResetSchemaOnStartup", "true");
     builder.UseSetting("Progesi:UseTestAuthentication", "true");
 
@@ -33,10 +39,15 @@ public sealed class ProgesiApiWebApplicationFactory : WebApplicationFactory<Prog
     if (!disposing)
       return;
 
+    TryDeleteDirectory(_projectsDirectory);
+  }
+
+  private static void TryDeleteDirectory(string path)
+  {
     try
     {
-      if (File.Exists(_dbPath))
-        File.Delete(_dbPath);
+      if (Directory.Exists(path))
+        Directory.Delete(path, recursive: true);
     }
     catch
     {

--- a/tests/Progesi.Api.Tests/ProjectProvisioningTests.cs
+++ b/tests/Progesi.Api.Tests/ProjectProvisioningTests.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Progesi.Api.Dtos;
+
+namespace Progesi.Api.Tests;
+
+[Collection(nameof(ProgesiApiTestCollection))]
+public sealed class ProjectProvisioningTests
+{
+  private readonly ProgesiApiWebApplicationFactory _factory;
+
+  public ProjectProvisioningTests(ProgesiApiWebApplicationFactory factory)
+  {
+    _factory = factory;
+  }
+
+  [Fact]
+  public async Task Writer_Can_Provision_Two_Projects()
+  {
+    using var client = _factory.CreateClient().AsWriter();
+
+    var projectA = await ProvisionAsync(client, "Project A");
+    var projectB = await ProvisionAsync(client, "Project B");
+
+    projectA.Id.Should().NotBe(projectB.Id);
+
+    var listResponse = await client.GetAsync("/api/projects");
+    listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    var projects = await listResponse.Content.ReadFromJsonAsync<List<ProjectDto>>();
+    projects.Should().Contain(p => p.Id == projectA.Id);
+    projects.Should().Contain(p => p.Id == projectB.Id);
+  }
+
+  [Fact]
+  public async Task Reader_Cannot_Provision_Projects()
+  {
+    using var client = _factory.CreateClient().AsReader();
+    var response = await client.PostAsJsonAsync("/api/projects", new CreateProjectRequest { Name = "Blocked" });
+    response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+  }
+
+  [Fact]
+  public async Task Variables_Are_Isolated_Between_Projects()
+  {
+    using var writer = _factory.CreateClient().AsWriter();
+    var projectA = await ProvisionAsync(writer, "Isolation A");
+    var projectB = await ProvisionAsync(writer, "Isolation B");
+
+    var dto = new VariableUpsertDto
+    {
+      Id = 42,
+      Name = "IsoVar",
+      Value = System.Text.Json.JsonSerializer.SerializeToElement(7.5)
+    };
+
+    using (var clientA = _factory.CreateClient().AsWriterForProject(projectA.Id))
+    {
+      var post = await clientA.PostAsJsonAsync("/api/variables", dto);
+      post.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    using (var clientB = _factory.CreateClient().AsReaderForProject(projectB.Id))
+    {
+      var getB = await clientB.GetAsync("/api/variables/42");
+      getB.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    using (var clientA = _factory.CreateClient().AsReaderForProject(projectA.Id))
+    {
+      var getA = await clientA.GetAsync("/api/variables/42");
+      getA.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+  }
+
+  private static async Task<ProjectDto> ProvisionAsync(HttpClient client, string name)
+  {
+    var response = await client.PostAsJsonAsync("/api/projects", new CreateProjectRequest { Name = name });
+    response.StatusCode.Should().Be(HttpStatusCode.Created);
+    var project = await response.Content.ReadFromJsonAsync<ProjectDto>();
+    project.Should().NotBeNull();
+    project!.Name.Should().Be(name);
+    return project;
+  }
+}

--- a/tests/Progesi.Api.Tests/SwaggerApiTests.cs
+++ b/tests/Progesi.Api.Tests/SwaggerApiTests.cs
@@ -24,6 +24,7 @@ public sealed class SwaggerApiTests
     body.Should().Contain("/api/variables");
     body.Should().Contain("/api/metadata");
     body.Should().Contain("/api/clusters");
+    body.Should().Contain("/api/projects");
     body.Should().Contain("\"Bearer\"");
     body.Should().Contain("securitySchemes");
   }

--- a/tests/Progesi.Api.Tests/TestAuthClientExtensions.cs
+++ b/tests/Progesi.Api.Tests/TestAuthClientExtensions.cs
@@ -1,4 +1,5 @@
 using Progesi.Api.Auth;
+using Progesi.Api.Projects;
 
 namespace Progesi.Api.Tests;
 
@@ -23,4 +24,17 @@ internal static class TestAuthClientExtensions
     client.DefaultRequestHeaders.Remove(TestAuthHandler.RolesHeaderName);
     return client;
   }
+
+  public static HttpClient WithProject(this HttpClient client, string projectId)
+  {
+    client.DefaultRequestHeaders.Remove(ProjectHeaders.ProjectId);
+    client.DefaultRequestHeaders.Add(ProjectHeaders.ProjectId, projectId);
+    return client;
+  }
+
+  public static HttpClient AsWriterForProject(this HttpClient client, string projectId)
+    => client.AsWriter().WithProject(projectId);
+
+  public static HttpClient AsReaderForProject(this HttpClient client, string projectId)
+    => client.AsReader().WithProject(projectId);
 }

--- a/tests/Progesi.Api.Tests/VariablesApiTests.cs
+++ b/tests/Progesi.Api.Tests/VariablesApiTests.cs
@@ -12,7 +12,7 @@ public sealed class VariablesApiTests
 
   public VariablesApiTests(ProgesiApiWebApplicationFactory factory)
   {
-    _client = factory.CreateClient().AsWriter();
+    _client = factory.CreateClient().AsWriterForProject(factory.DefaultProjectId);
   }
 
   [Fact]


### PR DESCRIPTION
## Phase 4 / A3.3 — per-project (template) databases + provisioning

Delivers the multi-user / clonable-template-DB capability (ADR-018 goal). **Confirmed design:** database-per-project · template-clone = migrate-fresh-DB · `X-Project-Id` header resolution · `Writer`-gated provisioning.

- **Provisioning:** `IProjectRegistry` (projects.json: id→connection) + `IProjectProvisioningService` (create DB + `Migrate()` = template clone). `POST`/`GET /api/projects` — **Writer** policy.
- **Resolution:** `IProjectContext` reads `X-Project-Id` (fallback `DefaultProjectId=default`) → scoped, **disposed-per-request** `ProgesiDbContext` for that project → genuine **data isolation** (reuses the A1 connection posture).
- **Provider seam:** `Progesi:DbProvider = Sqlite | SqlServer` (SQLite dev/CI; Azure SQL prod). Real Azure SQL provisioning = deploy-time.
- **A3.2 hardening:** `UseTestAuthentication` honoured **only in Development**.
- **Tests:** +3 (provision A/B; reader→403; **cross-project variable isolation**); existing CRUD/auth adapted. **405 → 408**, 0 failed. CI-validated.
- **Scope:** Progesi.Api + tests only; no Core/EF-model/AxisVar/GH changes. New package `Microsoft.EntityFrameworkCore.SqlServer 8.0.11`.