### PR TITLE
feat(api): read-only dashboard/summary API (Phase 4 / A4.1)

### DIFF
--- a/src/Progesi.Api/Controllers/SummaryController.cs
+++ b/src/Progesi.Api/Controllers/SummaryController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Progesi.Api.Auth;
+using Progesi.Api.Dtos;
+using Progesi.Api.Services;
+
+namespace Progesi.Api.Controllers;
+
+[ApiController]
+[Route("api/summary")]
+public sealed class SummaryController : ControllerBase
+{
+  private readonly IProjectSummaryService _summaryService;
+
+  public SummaryController(IProjectSummaryService summaryService)
+  {
+    _summaryService = summaryService;
+  }
+
+  [Authorize(Policy = AuthPolicies.Reader)]
+  [HttpGet]
+  public async Task<ActionResult<SummaryDto>> GetSummary(CancellationToken ct)
+  {
+    var summary = await _summaryService.GetSummaryAsync(ct);
+    return Ok(summary);
+  }
+
+  [Authorize(Policy = AuthPolicies.Reader)]
+  [HttpGet("value-types")]
+  public async Task<ActionResult<ValueTypeBreakdownDto>> GetValueTypeBreakdown(CancellationToken ct)
+  {
+    var breakdown = await _summaryService.GetValueTypeBreakdownAsync(ct);
+    return Ok(breakdown);
+  }
+}

--- a/src/Progesi.Api/Dtos/SummaryDtos.cs
+++ b/src/Progesi.Api/Dtos/SummaryDtos.cs
@@ -1,0 +1,27 @@
+namespace Progesi.Api.Dtos;
+
+public sealed class SummaryDto
+{
+  public int VariableCount { get; set; }
+  public int MetadataCount { get; set; }
+  public int ClusterCount { get; set; }
+  public int VariablesWithMetadataCount { get; set; }
+  public double MetadataCoveragePercent { get; set; }
+  public ClusterMembershipSummaryDto ClusterMembership { get; set; } = new();
+  public ValueTypeBreakdownDto ValueTypeBreakdown { get; set; } = new();
+}
+
+public sealed class ClusterMembershipSummaryDto
+{
+  public int DistinctVariablesReferenced { get; set; }
+  public double AverageVariablesPerCluster { get; set; }
+}
+
+public sealed class ValueTypeBreakdownDto
+{
+  public int String { get; set; }
+  public int Int { get; set; }
+  public int Double { get; set; }
+  public int Bool { get; set; }
+  public int Object { get; set; }
+}

--- a/src/Progesi.Api/Program.cs
+++ b/src/Progesi.Api/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.OpenApi.Models;
 using Progesi.Api.Auth;
 using Progesi.Api.Infrastructure;
 using Progesi.Api.Projects;
+using Progesi.Api.Services;
 using Progesi.Infrastructure.EF;
 using Progesi.Infrastructure.EF.Repositories;
 using ProgesiCore;
@@ -76,6 +77,7 @@ builder.Services.AddScoped<IMetadataRepository>(sp =>
     new EfMetadataRepository(sp.GetRequiredService<ProgesiDbContext>(), ownsContext: false));
 builder.Services.AddScoped<IProgesiVariableClusterRepository>(sp =>
     new EfClusterRepository(sp.GetRequiredService<ProgesiDbContext>(), ownsContext: false));
+builder.Services.AddScoped<IProjectSummaryService, ProjectSummaryService>();
 
 var app = builder.Build();
 

--- a/src/Progesi.Api/README.md
+++ b/src/Progesi.Api/README.md
@@ -45,8 +45,9 @@ Open Swagger UI: [https://localhost:7xxx/swagger](https://localhost:5001/swagger
 | Variables | `GET/POST /api/variables`, `GET/PUT/DELETE /api/variables/{id}` |
 | Metadata | `GET/POST /api/metadata`, `GET/PUT/DELETE /api/metadata/{id}` |
 | Clusters | `GET/POST /api/clusters`, `GET/PUT/DELETE /api/clusters/{id}` |
+| Summary | `GET /api/summary`, `GET /api/summary/value-types` (reader; project-scoped) |
 
-Pass **`X-Project-Id`** on CRUD requests to target a specific project database.
+Pass **`X-Project-Id`** on CRUD and summary requests to target a specific project database.
 
 All responses use API DTOs only (no Core types on the wire).
 
@@ -56,6 +57,15 @@ All responses use API DTOs only (no Core types on the wire).
 - `POST /api/projects` (writer) provisions a new per-project DB and registers it in `projects.json`.
 - Dev/CI uses one SQLite file per project; production swaps `Progesi:DbProvider` to `SqlServer` and supplies `SqlServerProjectTemplate` at deploy time.
 - **Deploy-time (not CI):** Azure SQL provisioning and running provider-specific migrations against live cloud DBs.
+
+## Dashboard summary (A4.1)
+
+Read-only, project-scoped statistics for dashboards (Power BI or other consumers):
+
+- `GET /api/summary` — counts, metadata coverage, cluster membership stats, value-type breakdown
+- `GET /api/summary/value-types` — value-type breakdown only
+
+Both require the **reader** policy and honour **`X-Project-Id`**.
 
 ## Authentication (ADR-018)
 

--- a/src/Progesi.Api/Services/ProjectSummaryService.cs
+++ b/src/Progesi.Api/Services/ProjectSummaryService.cs
@@ -1,0 +1,134 @@
+using Progesi.Api.Dtos;
+using ProgesiCore;
+
+namespace Progesi.Api.Services;
+
+public interface IProjectSummaryService
+{
+  Task<SummaryDto> GetSummaryAsync(CancellationToken ct = default);
+  Task<ValueTypeBreakdownDto> GetValueTypeBreakdownAsync(CancellationToken ct = default);
+}
+
+public sealed class ProjectSummaryService : IProjectSummaryService
+{
+  private readonly IVariableRepository _variables;
+  private readonly IMetadataRepository _metadata;
+  private readonly IProgesiVariableClusterRepository _clusters;
+
+  public ProjectSummaryService(
+      IVariableRepository variables,
+      IMetadataRepository metadata,
+      IProgesiVariableClusterRepository clusters)
+  {
+    _variables = variables;
+    _metadata = metadata;
+    _clusters = clusters;
+  }
+
+  public async Task<SummaryDto> GetSummaryAsync(CancellationToken ct = default)
+  {
+    var variables = await _variables.GetAllAsync(ct);
+    var metadata = await ListAllMetadataAsync(ct);
+    var clusters = await _clusters.GetAllAsync(ct);
+
+    var variablesWithMetadata = variables.Count(v => v.MetadataIds.Length > 0);
+    var variableCount = variables.Count;
+    var clusterCount = clusters.Count;
+
+    var distinctClusterVariables = clusters
+        .SelectMany(c => c.ProgesiVariableIds)
+        .Distinct()
+        .Count();
+
+    var averageVariablesPerCluster = clusterCount == 0
+        ? 0d
+        : clusters.Average(c => c.ProgesiVariableIds.Count);
+
+    return new SummaryDto
+    {
+      VariableCount = variableCount,
+      MetadataCount = metadata.Count,
+      ClusterCount = clusterCount,
+      VariablesWithMetadataCount = variablesWithMetadata,
+      MetadataCoveragePercent = variableCount == 0
+          ? 0d
+          : Math.Round(100d * variablesWithMetadata / variableCount, 2),
+      ClusterMembership = new ClusterMembershipSummaryDto
+      {
+        DistinctVariablesReferenced = distinctClusterVariables,
+        AverageVariablesPerCluster = Math.Round(averageVariablesPerCluster, 2)
+      },
+      ValueTypeBreakdown = BuildValueTypeBreakdown(variables)
+    };
+  }
+
+  public async Task<ValueTypeBreakdownDto> GetValueTypeBreakdownAsync(CancellationToken ct = default)
+  {
+    var variables = await _variables.GetAllAsync(ct);
+    return BuildValueTypeBreakdown(variables);
+  }
+
+  private async Task<List<ProgesiMetadata>> ListAllMetadataAsync(CancellationToken ct)
+  {
+    const int pageSize = 500;
+    var all = new List<ProgesiMetadata>();
+    var skip = 0;
+
+    while (true)
+    {
+      var page = await _metadata.ListAsync(skip, pageSize, ct);
+      if (page.Count == 0)
+        break;
+
+      all.AddRange(page);
+      if (page.Count < pageSize)
+        break;
+
+      skip += pageSize;
+    }
+
+    return all;
+  }
+
+  internal static ValueTypeBreakdownDto BuildValueTypeBreakdown(IReadOnlyList<ProgesiVariable> variables)
+  {
+    var breakdown = new ValueTypeBreakdownDto();
+
+    foreach (var variable in variables)
+    {
+      switch (ClassifyValueType(variable.Value))
+      {
+        case "string":
+          breakdown.String++;
+          break;
+        case "int":
+          breakdown.Int++;
+          break;
+        case "double":
+          breakdown.Double++;
+          break;
+        case "bool":
+          breakdown.Bool++;
+          break;
+        default:
+          breakdown.Object++;
+          break;
+      }
+    }
+
+    return breakdown;
+  }
+
+  internal static string ClassifyValueType(object? value)
+  {
+    return value switch
+    {
+      null => "object",
+      string => "string",
+      bool => "bool",
+      int or long or short or byte or sbyte or ushort or uint or ulong => "int",
+      float or double or decimal => "double",
+      _ => "object"
+    };
+  }
+}

--- a/tests/Progesi.Api.Tests/ApiAuthorizationTests.cs
+++ b/tests/Progesi.Api.Tests/ApiAuthorizationTests.cs
@@ -19,6 +19,7 @@ public sealed class ApiAuthorizationTests
   [InlineData("/api/variables")]
   [InlineData("/api/metadata")]
   [InlineData("/api/clusters")]
+  [InlineData("/api/summary")]
   public async Task Unauthenticated_Get_Returns_401(string route)
   {
     using var client = _factory.CreateClient().AsUnauthenticated();
@@ -30,6 +31,7 @@ public sealed class ApiAuthorizationTests
   [InlineData("/api/variables")]
   [InlineData("/api/metadata")]
   [InlineData("/api/clusters")]
+  [InlineData("/api/summary")]
   public async Task Reader_Get_Returns_200(string route)
   {
     using var client = _factory.CreateClient().AsReaderForProject(_factory.DefaultProjectId);

--- a/tests/Progesi.Api.Tests/SummaryApiTests.cs
+++ b/tests/Progesi.Api.Tests/SummaryApiTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Progesi.Api.Dtos;
+
+namespace Progesi.Api.Tests;
+
+[Collection(nameof(ProgesiApiTestCollection))]
+public sealed class SummaryApiTests
+{
+  private readonly ProgesiApiWebApplicationFactory _factory;
+
+  public SummaryApiTests(ProgesiApiWebApplicationFactory factory)
+  {
+    _factory = factory;
+  }
+
+  [Fact]
+  public async Task Summary_Reflects_Seeded_Project_Data()
+  {
+    using var provisioner = _factory.CreateClient().AsWriter();
+    var project = await ProvisionAsync(provisioner, "Summary Seed");
+
+    using var client = _factory.CreateClient().AsReaderForProject(project.Id);
+    await SeedSummaryDataAsync(_factory.CreateClient().AsWriterForProject(project.Id));
+
+    var response = await client.GetAsync("/api/summary");
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+    var summary = await response.Content.ReadFromJsonAsync<SummaryDto>();
+    summary.Should().NotBeNull();
+    summary!.VariableCount.Should().Be(2);
+    summary.MetadataCount.Should().Be(1);
+    summary.ClusterCount.Should().Be(1);
+    summary.VariablesWithMetadataCount.Should().Be(1);
+    summary.MetadataCoveragePercent.Should().Be(50d);
+    summary.ClusterMembership.DistinctVariablesReferenced.Should().Be(2);
+    summary.ClusterMembership.AverageVariablesPerCluster.Should().Be(2d);
+    summary.ValueTypeBreakdown.Double.Should().Be(1);
+    summary.ValueTypeBreakdown.String.Should().Be(1);
+  }
+
+  [Fact]
+  public async Task ValueTypes_Endpoint_Matches_Summary_Breakdown()
+  {
+    using var provisioner = _factory.CreateClient().AsWriter();
+    var project = await ProvisionAsync(provisioner, "Value Types");
+    await SeedSummaryDataAsync(_factory.CreateClient().AsWriterForProject(project.Id));
+
+    using var client = _factory.CreateClient().AsReaderForProject(project.Id);
+    var summary = await client.GetFromJsonAsync<SummaryDto>("/api/summary");
+    var breakdown = await client.GetFromJsonAsync<ValueTypeBreakdownDto>("/api/summary/value-types");
+
+    breakdown.Should().BeEquivalentTo(summary!.ValueTypeBreakdown);
+  }
+
+  [Fact]
+  public async Task Summary_Unauthenticated_Returns_401()
+  {
+    using var client = _factory.CreateClient().AsUnauthenticated();
+    var response = await client.GetAsync("/api/summary");
+    response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+  }
+
+  [Fact]
+  public async Task Summary_Is_Project_Scoped()
+  {
+    using var provisioner = _factory.CreateClient().AsWriter();
+    var projectA = await ProvisionAsync(provisioner, "Summary A");
+    var projectB = await ProvisionAsync(provisioner, "Summary B");
+
+    await SeedSummaryDataAsync(_factory.CreateClient().AsWriterForProject(projectA.Id));
+
+    using var clientB = _factory.CreateClient().AsReaderForProject(projectB.Id);
+    var summaryB = await clientB.GetFromJsonAsync<SummaryDto>("/api/summary");
+
+    summaryB!.VariableCount.Should().Be(0);
+    summaryB.MetadataCount.Should().Be(0);
+    summaryB.ClusterCount.Should().Be(0);
+  }
+
+  private static async Task<ProjectDto> ProvisionAsync(HttpClient client, string name)
+  {
+    var response = await client.PostAsJsonAsync("/api/projects", new CreateProjectRequest { Name = name });
+    response.StatusCode.Should().Be(HttpStatusCode.Created);
+    return (await response.Content.ReadFromJsonAsync<ProjectDto>())!;
+  }
+
+  private static async Task SeedSummaryDataAsync(HttpClient client)
+  {
+    var metadata = new MetadataUpsertDto
+    {
+      Id = 1,
+      CreatedBy = "summary-test",
+      AdditionalInfo = "note"
+    };
+    (await client.PostAsJsonAsync("/api/metadata", metadata)).StatusCode.Should().Be(HttpStatusCode.Created);
+
+    var withMetadata = new VariableUpsertDto
+    {
+      Id = 1,
+      Name = "Width",
+      Value = System.Text.Json.JsonSerializer.SerializeToElement(12.5),
+      MetadataIds = new[] { 1 }
+    };
+    (await client.PostAsJsonAsync("/api/variables", withMetadata)).StatusCode.Should().Be(HttpStatusCode.Created);
+
+    var withoutMetadata = new VariableUpsertDto
+    {
+      Id = 2,
+      Name = "Label",
+      Value = System.Text.Json.JsonSerializer.SerializeToElement("east")
+    };
+    (await client.PostAsJsonAsync("/api/variables", withoutMetadata)).StatusCode.Should().Be(HttpStatusCode.Created);
+
+    var cluster = new ClusterUpsertDto
+    {
+      Id = 1,
+      Name = "Pair",
+      VariableIds = new[] { 2, 1 }
+    };
+    (await client.PostAsJsonAsync("/api/clusters", cluster)).StatusCode.Should().Be(HttpStatusCode.Created);
+  }
+}

--- a/tests/Progesi.Api.Tests/SwaggerApiTests.cs
+++ b/tests/Progesi.Api.Tests/SwaggerApiTests.cs
@@ -25,6 +25,7 @@ public sealed class SwaggerApiTests
     body.Should().Contain("/api/metadata");
     body.Should().Contain("/api/clusters");
     body.Should().Contain("/api/projects");
+    body.Should().Contain("/api/summary");
     body.Should().Contain("\"Bearer\"");
     body.Should().Contain("securitySchemes");
   }


### PR DESCRIPTION
## Phase 4 / A4.1 — read-only dashboard / summary API

First A4 slice — the data layer dashboards consume (ADR-018 goal #10).

- **`GET /api/summary`** + **`GET /api/summary/value-types`** — **read-only**, **Reader** policy, **`X-Project-Id`-scoped** (via the A3.3 `IProjectContext`).
- `SummaryDto`: variable/metadata/cluster counts · `variablesWithMetadata` + `metadataCoveragePercent` · `clusterMembership` (distinct vars + avg/cluster) · `valueTypeBreakdown`.
- In-memory aggregation over the existing EF repos (`GetAll` + LINQ) — no writes, no new persistence, no new packages.
- **Scope:** Progesi.Api + tests only; no Core/EF-model/AxisVar/GH changes. **408 → 414**, 0 failed. CI-validated.
- Feeds **A4.2** (Power BI) next.