### PR TITLE
feat(sync): Rhino<->cloud push/pull + ContentHash conflict detection (Phase 4 / A3.4a)

### DIFF
--- a/src/Progesi.LiveDataExchange/Cloud/CloudSnapshotMapper.cs
+++ b/src/Progesi.LiveDataExchange/Cloud/CloudSnapshotMapper.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using ProgesiCore;
+
+namespace Progesi.LiveDataExchange.Cloud
+{
+  public static class CloudSnapshotMapper
+  {
+    public static CloudSnapshot FromDomain(
+        IEnumerable<ProgesiVariable> variables,
+        IEnumerable<ProgesiMetadata> metadata,
+        IEnumerable<ProgesiVariableCluster> clusters)
+    {
+      return new CloudSnapshot
+      {
+        Variables = variables.Select(FromVariable).ToList(),
+        Metadata = metadata.Select(FromMetadata).ToList(),
+        Clusters = clusters.Select(FromCluster).ToList()
+      };
+    }
+
+    public static CloudVariableRecord FromVariable(ProgesiVariable variable)
+    {
+      if (variable == null) throw new ArgumentNullException(nameof(variable));
+
+      return new CloudVariableRecord
+      {
+        Id = variable.Id,
+        ContentHash = ProgesiHash.Compute(variable),
+        Name = variable.Name,
+        ValueJson = JsonConvert.SerializeObject(variable.Value),
+        DependsFrom = variable.DependsFrom?.ToArray() ?? Array.Empty<int>(),
+        MetadataIds = variable.MetadataIds?.ToArray() ?? Array.Empty<int>(),
+        IsAssumption = variable.IsAssumption
+      };
+    }
+
+    public static CloudMetadataRecord FromMetadata(ProgesiMetadata metadata)
+    {
+      if (metadata == null) throw new ArgumentNullException(nameof(metadata));
+
+      return new CloudMetadataRecord
+      {
+        Id = metadata.Id,
+        ContentHash = ProgesiHash.Compute(metadata),
+        CreatedBy = metadata.CreatedBy,
+        AdditionalInfo = metadata.AdditionalInfo,
+        References = (metadata.References ?? Array.Empty<Uri>())
+            .Select(u => u.ToString())
+            .ToArray(),
+        Snips = (metadata.Snips ?? Array.Empty<ProgesiSnip>())
+            .Select(s => new CloudMetadataSnipRecord
+            {
+              Id = s.Id,
+              MimeType = s.MimeType,
+              Caption = s.Caption,
+              Source = s.Source?.ToString() ?? string.Empty,
+              ContentBase64 = Convert.ToBase64String(s.Content ?? Array.Empty<byte>())
+            })
+            .ToArray()
+      };
+    }
+
+    public static CloudClusterRecord FromCluster(ProgesiVariableCluster cluster)
+    {
+      if (cluster == null) throw new ArgumentNullException(nameof(cluster));
+
+      return new CloudClusterRecord
+      {
+        Id = cluster.Id,
+        ContentHash = ProgesiHash.Compute(cluster),
+        Name = cluster.Name,
+        Description = cluster.Description ?? string.Empty,
+        VariableIds = cluster.ProgesiVariableIds?.ToArray() ?? Array.Empty<int>()
+      };
+    }
+
+    public static ProgesiVariable ToVariable(CloudVariableRecord record)
+    {
+      if (record == null) throw new ArgumentNullException(nameof(record));
+
+      return new ProgesiVariable(
+          record.Id,
+          record.Name,
+          ParseJsonValue(record.ValueJson),
+          record.DependsFrom,
+          record.MetadataIds,
+          record.IsAssumption);
+    }
+
+    public static ProgesiMetadata ToMetadata(CloudMetadataRecord record)
+    {
+      if (record == null) throw new ArgumentNullException(nameof(record));
+
+      var references = (record.References ?? Array.Empty<string>())
+          .Where(r => !string.IsNullOrWhiteSpace(r))
+          .Select(r => new Uri(r, UriKind.RelativeOrAbsolute));
+
+      var snips = (record.Snips ?? Array.Empty<CloudMetadataSnipRecord>())
+          .Select(s =>
+          {
+            var bytes = string.IsNullOrWhiteSpace(s.ContentBase64)
+                ? Array.Empty<byte>()
+                : Convert.FromBase64String(s.ContentBase64);
+            Uri source = null;
+            if (!string.IsNullOrWhiteSpace(s.Source))
+              Uri.TryCreate(s.Source, UriKind.RelativeOrAbsolute, out source);
+            return ProgesiSnip.Create(bytes, s.MimeType, s.Caption, source);
+          });
+
+      return ProgesiMetadata.Create(
+          record.CreatedBy,
+          record.AdditionalInfo,
+          references,
+          snips,
+          DateTime.UtcNow,
+          record.Id > 0 ? record.Id : (int?)null);
+    }
+
+    public static ProgesiVariableCluster ToCluster(CloudClusterRecord record)
+    {
+      if (record == null) throw new ArgumentNullException(nameof(record));
+
+      return ProgesiVariableCluster.Rehydrate(
+          record.Id,
+          record.Name,
+          record.VariableIds ?? Array.Empty<int>(),
+          record.Description);
+    }
+
+    private static object ParseJsonValue(string json)
+    {
+      if (string.IsNullOrWhiteSpace(json))
+        return string.Empty;
+
+      var token = JsonConvert.DeserializeObject(json);
+      if (token is Newtonsoft.Json.Linq.JValue jValue)
+        return jValue.Value ?? string.Empty;
+
+      return token ?? string.Empty;
+    }
+  }
+}

--- a/src/Progesi.LiveDataExchange/Cloud/CloudSnapshotModels.cs
+++ b/src/Progesi.LiveDataExchange/Cloud/CloudSnapshotModels.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+
+namespace Progesi.LiveDataExchange.Cloud
+{
+  public sealed class CloudVariableRecord
+  {
+    public int Id { get; set; }
+    public string ContentHash { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string ValueJson { get; set; } = "null";
+    public int[] DependsFrom { get; set; } = System.Array.Empty<int>();
+    public int[] MetadataIds { get; set; } = System.Array.Empty<int>();
+    public bool IsAssumption { get; set; }
+  }
+
+  public sealed class CloudMetadataRecord
+  {
+    public int Id { get; set; }
+    public string ContentHash { get; set; } = string.Empty;
+    public string CreatedBy { get; set; } = string.Empty;
+    public string AdditionalInfo { get; set; } = string.Empty;
+    public string[] References { get; set; } = System.Array.Empty<string>();
+    public CloudMetadataSnipRecord[] Snips { get; set; } = System.Array.Empty<CloudMetadataSnipRecord>();
+  }
+
+  public sealed class CloudMetadataSnipRecord
+  {
+    public System.Guid Id { get; set; }
+    public string MimeType { get; set; } = "image/png";
+    public string Caption { get; set; } = string.Empty;
+    public string Source { get; set; } = string.Empty;
+    public string ContentBase64 { get; set; } = string.Empty;
+  }
+
+  public sealed class CloudClusterRecord
+  {
+    public int Id { get; set; }
+    public string ContentHash { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public int[] VariableIds { get; set; } = System.Array.Empty<int>();
+  }
+
+  public sealed class CloudSnapshot
+  {
+    public IList<CloudVariableRecord> Variables { get; set; } = new List<CloudVariableRecord>();
+    public IList<CloudMetadataRecord> Metadata { get; set; } = new List<CloudMetadataRecord>();
+    public IList<CloudClusterRecord> Clusters { get; set; } = new List<CloudClusterRecord>();
+  }
+}

--- a/src/Progesi.LiveDataExchange/Cloud/CloudSyncEngine.cs
+++ b/src/Progesi.LiveDataExchange/Cloud/CloudSyncEngine.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Progesi.LiveDataExchange.Cloud
+{
+  public sealed class CloudSyncEngine
+  {
+    public async Task<CloudSyncResult> ExecuteAsync(
+        CloudSyncDirection direction,
+        CloudSnapshot local,
+        CloudSnapshot cloud,
+        ISyncStateStore syncState,
+        IProgesiCloudClient cloudClient,
+        ICloudSyncLocalApplier localApplier,
+        CancellationToken ct = default)
+    {
+      if (local == null) throw new ArgumentNullException(nameof(local));
+      if (cloud == null) throw new ArgumentNullException(nameof(cloud));
+      if (syncState == null) throw new ArgumentNullException(nameof(syncState));
+      if (cloudClient == null) throw new ArgumentNullException(nameof(cloudClient));
+      if (localApplier == null) throw new ArgumentNullException(nameof(localApplier));
+
+      var result = new CloudSyncResult();
+
+      await ProcessTypeAsync(
+          CloudSyncObjectType.Variable,
+          local.Variables.ToDictionary(v => v.Id),
+          cloud.Variables.ToDictionary(v => v.Id),
+          syncState,
+          direction,
+          result,
+          async record =>
+          {
+            await cloudClient.UpsertVariableAsync(record, ct).ConfigureAwait(false);
+            result.VariablesApplied++;
+          },
+          async record =>
+          {
+            await localApplier.ApplyVariableAsync(record, ct).ConfigureAwait(false);
+            result.VariablesApplied++;
+          }).ConfigureAwait(false);
+
+      await ProcessTypeAsync(
+          CloudSyncObjectType.Metadata,
+          local.Metadata.ToDictionary(m => m.Id),
+          cloud.Metadata.ToDictionary(m => m.Id),
+          syncState,
+          direction,
+          result,
+          async record =>
+          {
+            await cloudClient.UpsertMetadataAsync(record, ct).ConfigureAwait(false);
+            result.MetadataApplied++;
+          },
+          async record =>
+          {
+            await localApplier.ApplyMetadataAsync(record, ct).ConfigureAwait(false);
+            result.MetadataApplied++;
+          }).ConfigureAwait(false);
+
+      await ProcessTypeAsync(
+          CloudSyncObjectType.Cluster,
+          local.Clusters.ToDictionary(c => c.Id),
+          cloud.Clusters.ToDictionary(c => c.Id),
+          syncState,
+          direction,
+          result,
+          async record =>
+          {
+            await cloudClient.UpsertClusterAsync(record, ct).ConfigureAwait(false);
+            result.ClustersApplied++;
+          },
+          async record =>
+          {
+            await localApplier.ApplyClusterAsync(record, ct).ConfigureAwait(false);
+            result.ClustersApplied++;
+          }).ConfigureAwait(false);
+
+      return result;
+    }
+
+    private static async Task ProcessTypeAsync<TRecord>(
+        CloudSyncObjectType objectType,
+        IReadOnlyDictionary<int, TRecord> localMap,
+        IReadOnlyDictionary<int, TRecord> cloudMap,
+        ISyncStateStore syncState,
+        CloudSyncDirection direction,
+        CloudSyncResult result,
+        Func<TRecord, Task> applyToCloud,
+        Func<TRecord, Task> applyToLocal)
+        where TRecord : class
+    {
+      var ids = new HashSet<int>(localMap.Keys);
+      ids.UnionWith(cloudMap.Keys);
+
+      foreach (var id in ids.OrderBy(x => x))
+      {
+        localMap.TryGetValue(id, out var localRecord);
+        cloudMap.TryGetValue(id, out var cloudRecord);
+
+        var localHash = GetHash(localRecord);
+        var cloudHash = GetHash(cloudRecord);
+        var baseHash = syncState.GetLastSyncedHash(objectType, id) ?? string.Empty;
+
+        var localExists = localRecord != null;
+        var cloudExists = cloudRecord != null;
+
+        if (!localExists && !cloudExists)
+          continue;
+
+        var localChanged = localExists && !string.Equals(localHash, baseHash, StringComparison.Ordinal);
+        var cloudChanged = cloudExists && !string.Equals(cloudHash, baseHash, StringComparison.Ordinal);
+
+        if (!localChanged && !cloudChanged)
+        {
+          result.Skipped++;
+          result.Log.Add(SkipMessage(objectType, id, "unchanged"));
+          continue;
+        }
+
+        if (localChanged && cloudChanged)
+        {
+          if (string.Equals(localHash, cloudHash, StringComparison.Ordinal))
+          {
+            syncState.SetLastSyncedHash(objectType, id, localHash);
+            result.Skipped++;
+            result.Log.Add(SkipMessage(objectType, id, "converged"));
+            continue;
+          }
+
+          result.Conflicts.Add(new CloudSyncConflict
+          {
+            ObjectType = objectType,
+            Id = id,
+            LocalHash = localHash ?? string.Empty,
+            CloudHash = cloudHash ?? string.Empty
+          });
+          result.Log.Add(ConflictMessage(objectType, id, localHash, cloudHash));
+          continue;
+        }
+
+        if (direction == CloudSyncDirection.Push && localChanged)
+        {
+          await applyToCloud(localRecord).ConfigureAwait(false);
+          syncState.SetLastSyncedHash(objectType, id, localHash);
+          result.Log.Add(AppliedMessage(objectType, id, "push"));
+          continue;
+        }
+
+        if (direction == CloudSyncDirection.Pull && cloudChanged)
+        {
+          await applyToLocal(cloudRecord).ConfigureAwait(false);
+          syncState.SetLastSyncedHash(objectType, id, cloudHash);
+          result.Log.Add(AppliedMessage(objectType, id, "pull"));
+          continue;
+        }
+
+        result.Skipped++;
+        result.Log.Add(SkipMessage(objectType, id, "other-side-only-change"));
+      }
+    }
+
+    private static string GetHash(object record)
+    {
+      if (record == null)
+        return null;
+
+      switch (record)
+      {
+        case CloudVariableRecord variable:
+          return variable.ContentHash;
+        case CloudMetadataRecord metadata:
+          return metadata.ContentHash;
+        case CloudClusterRecord cluster:
+          return cluster.ContentHash;
+        default:
+          throw new ArgumentException("Unsupported record type.", nameof(record));
+      }
+    }
+
+    private static string SkipMessage(CloudSyncObjectType type, int id, string reason)
+        => type + " " + id + ": skipped (" + reason + ").";
+
+    private static string AppliedMessage(CloudSyncObjectType type, int id, string direction)
+        => type + " " + id + ": applied (" + direction + ").";
+
+    private static string ConflictMessage(CloudSyncObjectType type, int id, string localHash, string cloudHash)
+        => type + " " + id + ": CONFLICT local=" + localHash + " cloud=" + cloudHash + ".";
+  }
+}

--- a/src/Progesi.LiveDataExchange/Cloud/CloudSyncResult.cs
+++ b/src/Progesi.LiveDataExchange/Cloud/CloudSyncResult.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Progesi.LiveDataExchange.Cloud
+{
+  public sealed class CloudSyncConflict
+  {
+    public CloudSyncObjectType ObjectType { get; set; }
+    public int Id { get; set; }
+    public string LocalHash { get; set; } = string.Empty;
+    public string CloudHash { get; set; } = string.Empty;
+  }
+
+  public sealed class CloudSyncResult
+  {
+    public int VariablesApplied { get; set; }
+    public int MetadataApplied { get; set; }
+    public int ClustersApplied { get; set; }
+    public int Skipped { get; set; }
+    public IList<CloudSyncConflict> Conflicts { get; set; } = new List<CloudSyncConflict>();
+    public IList<string> Log { get; set; } = new List<string>();
+  }
+}

--- a/src/Progesi.LiveDataExchange/Cloud/CloudSyncTypes.cs
+++ b/src/Progesi.LiveDataExchange/Cloud/CloudSyncTypes.cs
@@ -1,0 +1,15 @@
+namespace Progesi.LiveDataExchange.Cloud
+{
+  public enum CloudSyncDirection
+  {
+    Push = 0,
+    Pull = 1
+  }
+
+  public enum CloudSyncObjectType
+  {
+    Variable = 0,
+    Metadata = 1,
+    Cluster = 2
+  }
+}

--- a/src/Progesi.LiveDataExchange/Cloud/HttpProgesiCloudClient.cs
+++ b/src/Progesi.LiveDataExchange/Cloud/HttpProgesiCloudClient.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Progesi.LiveDataExchange.Cloud
+{
+  public sealed class ProgesiCloudClientOptions
+  {
+    public string BaseUrl { get; set; } = string.Empty;
+    public string ProjectId { get; set; } = string.Empty;
+    public string BearerToken { get; set; } = string.Empty;
+    public string TestRoles { get; set; } = string.Empty;
+  }
+
+  public sealed class HttpProgesiCloudClient : IProgesiCloudClient, IDisposable
+  {
+    private readonly HttpClient _http;
+    private readonly ProgesiCloudClientOptions _options;
+    private readonly bool _ownsHttpClient;
+
+    public HttpProgesiCloudClient(ProgesiCloudClientOptions options)
+        : this(options, new HttpClient(), ownsHttpClient: true)
+    {
+    }
+
+    public HttpProgesiCloudClient(ProgesiCloudClientOptions options, HttpClient httpClient, bool ownsHttpClient = false)
+    {
+      _options = options ?? throw new ArgumentNullException(nameof(options));
+      _http = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+      _ownsHttpClient = ownsHttpClient;
+    }
+
+    public async Task<CloudSnapshot> GetCloudSnapshotAsync(CancellationToken ct = default)
+    {
+      var variables = await GetAsync<List<WireVariableDto>>("/api/variables", ct).ConfigureAwait(false)
+          ?? new List<WireVariableDto>();
+      var metadata = await GetAsync<List<WireMetadataDto>>("/api/metadata", ct).ConfigureAwait(false)
+          ?? new List<WireMetadataDto>();
+      var clusters = await GetAsync<List<WireClusterDto>>("/api/clusters", ct).ConfigureAwait(false)
+          ?? new List<WireClusterDto>();
+
+      return new CloudSnapshot
+      {
+        Variables = variables.ConvertAll(MapVariable),
+        Metadata = metadata.ConvertAll(MapMetadata),
+        Clusters = clusters.ConvertAll(MapCluster)
+      };
+    }
+
+    public Task UpsertVariableAsync(CloudVariableRecord record, CancellationToken ct = default)
+    {
+      if (record == null) throw new ArgumentNullException(nameof(record));
+
+      var payload = new WireVariableUpsertDto
+      {
+        Id = record.Id,
+        Name = record.Name,
+        Value = JsonConvert.DeserializeObject(record.ValueJson),
+        DependsFrom = record.DependsFrom ?? Array.Empty<int>(),
+        MetadataIds = record.MetadataIds ?? Array.Empty<int>(),
+        IsAssumption = record.IsAssumption
+      };
+
+      return UpsertAsync("/api/variables", record.Id, payload, ct);
+    }
+
+    public Task UpsertMetadataAsync(CloudMetadataRecord record, CancellationToken ct = default)
+    {
+      if (record == null) throw new ArgumentNullException(nameof(record));
+
+      var payload = new WireMetadataUpsertDto
+      {
+        Id = record.Id,
+        CreatedBy = record.CreatedBy,
+        AdditionalInfo = record.AdditionalInfo,
+        References = record.References ?? Array.Empty<string>(),
+        Snips = MapSnips(record.Snips)
+      };
+
+      return UpsertAsync("/api/metadata", record.Id, payload, ct);
+    }
+
+    public Task UpsertClusterAsync(CloudClusterRecord record, CancellationToken ct = default)
+    {
+      if (record == null) throw new ArgumentNullException(nameof(record));
+
+      var payload = new WireClusterUpsertDto
+      {
+        Id = record.Id,
+        Name = record.Name,
+        Description = record.Description,
+        VariableIds = record.VariableIds ?? Array.Empty<int>()
+      };
+
+      return UpsertAsync("/api/clusters", record.Id, payload, ct);
+    }
+
+    public void Dispose()
+    {
+      if (_ownsHttpClient)
+        _http.Dispose();
+    }
+
+    private async Task UpsertAsync(string collectionPath, int id, object payload, CancellationToken ct)
+    {
+      var put = await SendAsync(HttpMethod.Put, collectionPath + "/" + id, payload, ct).ConfigureAwait(false);
+      if (put.StatusCode == HttpStatusCode.NotFound)
+      {
+        var post = await SendAsync(HttpMethod.Post, collectionPath, payload, ct).ConfigureAwait(false);
+        EnsureSuccess(post);
+        return;
+      }
+
+      EnsureSuccess(put);
+    }
+
+    private async Task<T> GetAsync<T>(string path, CancellationToken ct)
+    {
+      using (var response = await SendAsync(HttpMethod.Get, path, null, ct).ConfigureAwait(false))
+      {
+        EnsureSuccess(response);
+        var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        return JsonConvert.DeserializeObject<T>(json);
+      }
+    }
+
+    private Task<HttpResponseMessage> SendAsync(HttpMethod method, string relativePath, object payload, CancellationToken ct)
+    {
+      var request = new HttpRequestMessage(method, CombineUrl(_options.BaseUrl, relativePath));
+      ApplyHeaders(request);
+
+      if (payload != null)
+      {
+        var json = JsonConvert.SerializeObject(payload);
+        request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+      }
+
+      return _http.SendAsync(request, ct);
+    }
+
+    private void ApplyHeaders(HttpRequestMessage request)
+    {
+      if (!string.IsNullOrWhiteSpace(_options.ProjectId))
+        request.Headers.TryAddWithoutValidation("X-Project-Id", _options.ProjectId.Trim());
+
+      if (!string.IsNullOrWhiteSpace(_options.TestRoles))
+      {
+        request.Headers.TryAddWithoutValidation("X-Test-Roles", _options.TestRoles.Trim());
+        return;
+      }
+
+      if (!string.IsNullOrWhiteSpace(_options.BearerToken))
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _options.BearerToken.Trim());
+    }
+
+    private static string CombineUrl(string baseUrl, string relativePath)
+    {
+      if (string.IsNullOrWhiteSpace(baseUrl))
+        throw new InvalidOperationException("Api base URL is required.");
+
+      return baseUrl.TrimEnd('/') + relativePath;
+    }
+
+    private static void EnsureSuccess(HttpResponseMessage response)
+    {
+      if (response.IsSuccessStatusCode)
+        return;
+
+      throw new HttpRequestException(
+          "Cloud API request failed: " + (int)response.StatusCode + " " + response.ReasonPhrase);
+    }
+
+    private static CloudVariableRecord MapVariable(WireVariableDto dto)
+    {
+      return new CloudVariableRecord
+      {
+        Id = dto.Id,
+        ContentHash = dto.Hashtag ?? string.Empty,
+        Name = dto.Name ?? string.Empty,
+        ValueJson = JsonConvert.SerializeObject(dto.Value),
+        DependsFrom = dto.DependsFrom ?? Array.Empty<int>(),
+        MetadataIds = dto.MetadataIds ?? Array.Empty<int>(),
+        IsAssumption = dto.IsAssumption
+      };
+    }
+
+    private static CloudMetadataRecord MapMetadata(WireMetadataDto dto)
+    {
+      return new CloudMetadataRecord
+      {
+        Id = dto.Id,
+        ContentHash = dto.Hashtag ?? string.Empty,
+        CreatedBy = dto.CreatedBy ?? string.Empty,
+        AdditionalInfo = dto.AdditionalInfo ?? string.Empty,
+        References = dto.References ?? Array.Empty<string>(),
+        Snips = MapSnipsBack(dto.Snips)
+      };
+    }
+
+    private static CloudClusterRecord MapCluster(WireClusterDto dto)
+    {
+      return new CloudClusterRecord
+      {
+        Id = dto.Id,
+        ContentHash = dto.Hashtag ?? string.Empty,
+        Name = dto.Name ?? string.Empty,
+        Description = dto.Description ?? string.Empty,
+        VariableIds = dto.VariableIds ?? Array.Empty<int>()
+      };
+    }
+
+    private static WireMetadataSnipDto[] MapSnips(CloudMetadataSnipRecord[] snips)
+    {
+      if (snips == null || snips.Length == 0)
+        return Array.Empty<WireMetadataSnipDto>();
+
+      var mapped = new WireMetadataSnipDto[snips.Length];
+      for (var i = 0; i < snips.Length; i++)
+      {
+        mapped[i] = new WireMetadataSnipDto
+        {
+          Id = snips[i].Id,
+          MimeType = snips[i].MimeType,
+          Caption = snips[i].Caption,
+          Source = snips[i].Source,
+          ContentBase64 = snips[i].ContentBase64
+        };
+      }
+
+      return mapped;
+    }
+
+    private static CloudMetadataSnipRecord[] MapSnipsBack(WireMetadataSnipDto[] snips)
+    {
+      if (snips == null || snips.Length == 0)
+        return Array.Empty<CloudMetadataSnipRecord>();
+
+      var mapped = new CloudMetadataSnipRecord[snips.Length];
+      for (var i = 0; i < snips.Length; i++)
+      {
+        mapped[i] = new CloudMetadataSnipRecord
+        {
+          Id = snips[i].Id,
+          MimeType = snips[i].MimeType,
+          Caption = snips[i].Caption,
+          Source = snips[i].Source,
+          ContentBase64 = snips[i].ContentBase64
+        };
+      }
+
+      return mapped;
+    }
+
+    private sealed class WireVariableDto
+    {
+      public int Id { get; set; }
+      public string Name { get; set; }
+      public object Value { get; set; }
+      public int[] DependsFrom { get; set; }
+      public int[] MetadataIds { get; set; }
+      public bool IsAssumption { get; set; }
+      public string Hashtag { get; set; }
+    }
+
+    private sealed class WireVariableUpsertDto
+    {
+      public int Id { get; set; }
+      public string Name { get; set; }
+      public object Value { get; set; }
+      public int[] DependsFrom { get; set; }
+      public int[] MetadataIds { get; set; }
+      public bool IsAssumption { get; set; }
+    }
+
+    private sealed class WireMetadataDto
+    {
+      public int Id { get; set; }
+      public string CreatedBy { get; set; }
+      public string AdditionalInfo { get; set; }
+      public string[] References { get; set; }
+      public WireMetadataSnipDto[] Snips { get; set; }
+      public string Hashtag { get; set; }
+    }
+
+    private sealed class WireMetadataUpsertDto
+    {
+      public int Id { get; set; }
+      public string CreatedBy { get; set; }
+      public string AdditionalInfo { get; set; }
+      public string[] References { get; set; }
+      public WireMetadataSnipDto[] Snips { get; set; }
+    }
+
+    private sealed class WireMetadataSnipDto
+    {
+      public Guid Id { get; set; }
+      public string MimeType { get; set; }
+      public string Caption { get; set; }
+      public string Source { get; set; }
+      public string ContentBase64 { get; set; }
+    }
+
+    private sealed class WireClusterDto
+    {
+      public int Id { get; set; }
+      public string Name { get; set; }
+      public string Description { get; set; }
+      public int[] VariableIds { get; set; }
+      public string Hashtag { get; set; }
+    }
+
+    private sealed class WireClusterUpsertDto
+    {
+      public int Id { get; set; }
+      public string Name { get; set; }
+      public string Description { get; set; }
+      public int[] VariableIds { get; set; }
+    }
+  }
+}

--- a/src/Progesi.LiveDataExchange/Cloud/IProgesiCloudClient.cs
+++ b/src/Progesi.LiveDataExchange/Cloud/IProgesiCloudClient.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Progesi.LiveDataExchange.Cloud
+{
+  public interface IProgesiCloudClient
+  {
+    Task<CloudSnapshot> GetCloudSnapshotAsync(CancellationToken ct = default);
+    Task UpsertVariableAsync(CloudVariableRecord record, CancellationToken ct = default);
+    Task UpsertMetadataAsync(CloudMetadataRecord record, CancellationToken ct = default);
+    Task UpsertClusterAsync(CloudClusterRecord record, CancellationToken ct = default);
+  }
+
+  public interface ICloudSyncLocalApplier
+  {
+    Task ApplyVariableAsync(CloudVariableRecord record, CancellationToken ct = default);
+    Task ApplyMetadataAsync(CloudMetadataRecord record, CancellationToken ct = default);
+    Task ApplyClusterAsync(CloudClusterRecord record, CancellationToken ct = default);
+  }
+}

--- a/src/Progesi.LiveDataExchange/Cloud/ISyncStateStore.cs
+++ b/src/Progesi.LiveDataExchange/Cloud/ISyncStateStore.cs
@@ -1,0 +1,27 @@
+namespace Progesi.LiveDataExchange.Cloud
+{
+  public interface ISyncStateStore
+  {
+    string GetLastSyncedHash(CloudSyncObjectType objectType, int id);
+    void SetLastSyncedHash(CloudSyncObjectType objectType, int id, string contentHash);
+  }
+
+  public sealed class InMemorySyncStateStore : ISyncStateStore
+  {
+    private readonly System.Collections.Generic.Dictionary<string, string> _hashes
+        = new System.Collections.Generic.Dictionary<string, string>();
+
+    public string GetLastSyncedHash(CloudSyncObjectType objectType, int id)
+    {
+      return _hashes.TryGetValue(Key(objectType, id), out var hash) ? hash : string.Empty;
+    }
+
+    public void SetLastSyncedHash(CloudSyncObjectType objectType, int id, string contentHash)
+    {
+      _hashes[Key(objectType, id)] = contentHash ?? string.Empty;
+    }
+
+    internal static string Key(CloudSyncObjectType objectType, int id)
+        => objectType + ":" + id;
+  }
+}

--- a/src/Progesi.LiveDataExchange/Progesi.LiveDataExchange.csproj
+++ b/src/Progesi.LiveDataExchange/Progesi.LiveDataExchange.csproj
@@ -18,4 +18,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
 </Project>

--- a/src/ProgesiGrasshopperAssembly/Components/ProgesiCloudSyncComponent.cs
+++ b/src/ProgesiGrasshopperAssembly/Components/ProgesiCloudSyncComponent.cs
@@ -1,0 +1,185 @@
+#nullable disable
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Grasshopper.Kernel;
+using Progesi.LiveDataExchange.Cloud;
+using ProgesiGrasshopperAssembly.Infrastructure;
+using ProgesiGrasshopperAssembly.Infrastructure.Cloud;
+using ProgesiRepositories.Rhino;
+using Rhino;
+
+namespace ProgesiGrasshopperAssembly.Components
+{
+  public sealed class ProgesiCloudSyncComponent : GH_Component
+  {
+    public ProgesiCloudSyncComponent()
+      : base("ProgesiData-CloudSync", "CloudSync",
+             "Push/Pull Rhino store ↔ Progesi cloud API with ContentHash conflict detection.",
+             "Progesi", "DataEx — Cloud")
+    {
+    }
+
+    public override Guid ComponentGuid => new Guid("A4F31C2E-6D0B-4E91-9C2A-7E5D4B839016");
+    protected override System.Drawing.Bitmap Icon => ProgesiIcons.DataEx;
+
+    protected override void RegisterInputParams(GH_InputParamManager p)
+    {
+      p.AddBooleanParameter("Run", "Run", "Execute sync when true.", GH_ParamAccess.item, false);
+      p.AddTextParameter("Direction", "Dir", "Push or Pull.", GH_ParamAccess.item, "Push");
+      p.AddTextParameter("ApiBaseUrl", "Url", "Base URL of Progesi.Api (e.g. https://localhost:5001).", GH_ParamAccess.item, "https://localhost:5001");
+      p.AddTextParameter("ProjectId", "Proj", "Cloud project id (X-Project-Id).", GH_ParamAccess.item, "default");
+      p.AddTextParameter("Token", "Token", "Bearer token for cloud auth.", GH_ParamAccess.item, "");
+      for (int i = 1; i < Params.Input.Count; i++)
+        Params.Input[i].Optional = true;
+    }
+
+    protected override void RegisterOutputParams(GH_OutputParamManager p)
+    {
+      p.AddTextParameter("Summary", "Sum", "Applied/skipped/conflict counts.", GH_ParamAccess.item);
+      p.AddTextParameter("Conflicts", "Conf", "Reported conflicts (type,id,local,cloud).", GH_ParamAccess.item);
+      p.AddTextParameter("Log", "Log", "Sync log lines.", GH_ParamAccess.item);
+    }
+
+    protected override void SolveInstance(IGH_DataAccess da)
+    {
+      bool run = false;
+      string directionText = "Push";
+      string apiBaseUrl = "https://localhost:5001";
+      string projectId = "default";
+      string token = string.Empty;
+
+      da.GetData(0, ref run);
+      da.GetData(1, ref directionText);
+      da.GetData(2, ref apiBaseUrl);
+      da.GetData(3, ref projectId);
+      da.GetData(4, ref token);
+
+      if (!run)
+      {
+        da.SetData(0, "Idle");
+        da.SetData(1, string.Empty);
+        da.SetData(2, string.Empty);
+        return;
+      }
+
+      try
+      {
+        var doc = RhinoDoc.ActiveDoc;
+        if (doc == null)
+        {
+          AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "RhinoDoc.ActiveDoc is null.");
+          da.SetData(0, "Error");
+          da.SetData(1, string.Empty);
+          da.SetData(2, "RhinoDoc.ActiveDoc is null.");
+          return;
+        }
+
+        if (string.IsNullOrWhiteSpace(apiBaseUrl))
+        {
+          AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "ApiBaseUrl is required.");
+          da.SetData(0, "Error");
+          return;
+        }
+
+        if (string.IsNullOrWhiteSpace(projectId))
+        {
+          AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "ProjectId is required.");
+          da.SetData(0, "Error");
+          return;
+        }
+
+        var direction = ParseDirection(directionText);
+        var local = ReadLocalSnapshot(doc);
+        var syncState = new RhinoSyncStateStore(doc);
+        var localApplier = new RhinoCloudSyncLocalApplier(doc);
+        var engine = new CloudSyncEngine();
+
+        using (var client = new HttpProgesiCloudClient(new ProgesiCloudClientOptions
+        {
+          BaseUrl = apiBaseUrl.Trim(),
+          ProjectId = projectId.Trim(),
+          BearerToken = token ?? string.Empty
+        }))
+        {
+          var cloud = client.GetCloudSnapshotAsync(CancellationToken.None).GetAwaiter().GetResult();
+          var result = engine.ExecuteAsync(
+              direction,
+              local,
+              cloud,
+              syncState,
+              client,
+              localApplier,
+              CancellationToken.None).GetAwaiter().GetResult();
+
+          if (result.Conflicts.Count > 0)
+            AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, result.Conflicts.Count + " conflict(s) detected.");
+
+          da.SetData(0, FormatSummary(result));
+          da.SetData(1, FormatConflicts(result));
+          da.SetData(2, string.Join(Environment.NewLine, result.Log ?? Array.Empty<string>()));
+        }
+      }
+      catch (Exception ex)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, ex.Message);
+        da.SetData(0, "Error");
+        da.SetData(1, string.Empty);
+        da.SetData(2, ex.ToString());
+      }
+    }
+
+    private static CloudSyncDirection ParseDirection(string directionText)
+    {
+      if (string.Equals(directionText?.Trim(), "Pull", StringComparison.OrdinalIgnoreCase))
+        return CloudSyncDirection.Pull;
+
+      return CloudSyncDirection.Push;
+    }
+
+    private static CloudSnapshot ReadLocalSnapshot(RhinoDoc doc)
+    {
+      var varRepo = new RhinoVariableRepository(doc);
+      var metaRepo = new RhinoMetadataRepository(doc);
+      var clusterRepo = new RhinoVariableClusterRepository(doc);
+
+      var variables = varRepo.GetAllAsync().GetAwaiter().GetResult();
+      var metadata = metaRepo.ListAsync(0, 100000).GetAwaiter().GetResult();
+      var clusters = clusterRepo.GetAllAsync().GetAwaiter().GetResult();
+
+      return CloudSnapshotMapper.FromDomain(variables, metadata, clusters);
+    }
+
+    private static string FormatSummary(CloudSyncResult result)
+    {
+      return "vars=" + result.VariablesApplied
+          + ", meta=" + result.MetadataApplied
+          + ", clusters=" + result.ClustersApplied
+          + ", skipped=" + result.Skipped
+          + ", conflicts=" + result.Conflicts.Count;
+    }
+
+    private static string FormatConflicts(CloudSyncResult result)
+    {
+      if (result.Conflicts == null || result.Conflicts.Count == 0)
+        return string.Empty;
+
+      var sb = new StringBuilder();
+      foreach (var conflict in result.Conflicts)
+      {
+        sb.Append(conflict.ObjectType)
+          .Append(' ')
+          .Append(conflict.Id)
+          .Append(": local=")
+          .Append(conflict.LocalHash)
+          .Append(" cloud=")
+          .Append(conflict.CloudHash)
+          .AppendLine();
+      }
+
+      return sb.ToString().TrimEnd();
+    }
+  }
+}

--- a/src/ProgesiGrasshopperAssembly/Infrastructure/Cloud/RhinoCloudSyncStores.cs
+++ b/src/ProgesiGrasshopperAssembly/Infrastructure/Cloud/RhinoCloudSyncStores.cs
@@ -1,0 +1,63 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Progesi.LiveDataExchange.Cloud;
+using ProgesiRepositories.Rhino;
+using Rhino;
+using Rhino.DocObjects.Tables;
+
+namespace ProgesiGrasshopperAssembly.Infrastructure.Cloud
+{
+  public sealed class RhinoSyncStateStore : ISyncStateStore
+  {
+    private const string Section = "Progesi.CloudSync";
+
+    private readonly StringTable _table;
+
+    public RhinoSyncStateStore(RhinoDoc doc)
+    {
+      if (doc == null) throw new System.ArgumentNullException(nameof(doc));
+      _table = doc.Strings ?? throw new System.InvalidOperationException("RhinoDoc.Strings is null.");
+    }
+
+    public string GetLastSyncedHash(CloudSyncObjectType objectType, int id)
+    {
+      return _table.GetValue(Section, Key(objectType, id)) ?? string.Empty;
+    }
+
+    public void SetLastSyncedHash(CloudSyncObjectType objectType, int id, string contentHash)
+    {
+      _table.SetString(Section, Key(objectType, id), contentHash ?? string.Empty);
+    }
+
+    private static string Key(CloudSyncObjectType objectType, int id)
+        => objectType + ":" + id;
+  }
+
+  public sealed class RhinoCloudSyncLocalApplier : ICloudSyncLocalApplier
+  {
+    private readonly RhinoDoc _doc;
+
+    public RhinoCloudSyncLocalApplier(RhinoDoc doc)
+    {
+      _doc = doc ?? throw new System.ArgumentNullException(nameof(doc));
+    }
+
+    public Task ApplyVariableAsync(CloudVariableRecord record, CancellationToken ct = default)
+    {
+      var repo = new RhinoVariableRepository(_doc);
+      return repo.SaveAsync(CloudSnapshotMapper.ToVariable(record), ct);
+    }
+
+    public Task ApplyMetadataAsync(CloudMetadataRecord record, CancellationToken ct = default)
+    {
+      var repo = new RhinoMetadataRepository(_doc);
+      return repo.UpsertAsync(CloudSnapshotMapper.ToMetadata(record), ct);
+    }
+
+    public Task ApplyClusterAsync(CloudClusterRecord record, CancellationToken ct = default)
+    {
+      var repo = new RhinoVariableClusterRepository(_doc);
+      return repo.SaveAsync(CloudSnapshotMapper.ToCluster(record), ct);
+    }
+  }
+}

--- a/tests/Progesi.LiveDataExchange.Tests/Cloud/CloudSyncEngineTests.cs
+++ b/tests/Progesi.LiveDataExchange.Tests/Cloud/CloudSyncEngineTests.cs
@@ -1,0 +1,159 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Progesi.LiveDataExchange.Cloud;
+using Xunit;
+
+namespace Progesi.LiveDataExchange.Tests.Cloud
+{
+  public sealed class CloudSyncEngineTests
+  {
+    private readonly CloudSyncEngine _engine = new CloudSyncEngine();
+
+    [Fact]
+    public async Task Unchanged_Object_Is_Skipped()
+    {
+      var sync = new InMemorySyncStateStore();
+      var local = SnapshotWithVariable(1, "base");
+      var cloud = SnapshotWithVariable(1, "base");
+      sync.SetLastSyncedHash(CloudSyncObjectType.Variable, 1, "base");
+
+      var fakeCloud = new FakeCloudClient { Snapshot = cloud };
+      var fakeLocal = new FakeLocalApplier();
+
+      var result = await _engine.ExecuteAsync(
+          CloudSyncDirection.Push,
+          local,
+          cloud,
+          sync,
+          fakeCloud,
+          fakeLocal);
+
+      result.VariablesApplied.Should().Be(0);
+      result.Skipped.Should().Be(1);
+      result.Conflicts.Should().BeEmpty();
+      fakeCloud.UpsertedVariables.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Push_Applies_Local_Only_Change()
+    {
+      var sync = new InMemorySyncStateStore();
+      sync.SetLastSyncedHash(CloudSyncObjectType.Variable, 1, "base");
+
+      var local = SnapshotWithVariable(1, "local-new");
+      var cloud = SnapshotWithVariable(1, "base");
+      var fakeCloud = new FakeCloudClient { Snapshot = cloud };
+      var fakeLocal = new FakeLocalApplier();
+
+      var result = await _engine.ExecuteAsync(
+          CloudSyncDirection.Push,
+          local,
+          cloud,
+          sync,
+          fakeCloud,
+          fakeLocal);
+
+      result.VariablesApplied.Should().Be(1);
+      fakeCloud.UpsertedVariables.Should().HaveCount(1);
+      fakeCloud.UpsertedVariables[0].ContentHash.Should().Be("local-new");
+      sync.GetLastSyncedHash(CloudSyncObjectType.Variable, 1).Should().Be("local-new");
+      result.Conflicts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Pull_Applies_Cloud_Only_Change()
+    {
+      var sync = new InMemorySyncStateStore();
+      sync.SetLastSyncedHash(CloudSyncObjectType.Variable, 1, "base");
+
+      var local = SnapshotWithVariable(1, "base");
+      var cloud = SnapshotWithVariable(1, "cloud-new");
+      var fakeCloud = new FakeCloudClient { Snapshot = cloud };
+      var fakeLocal = new FakeLocalApplier();
+
+      var result = await _engine.ExecuteAsync(
+          CloudSyncDirection.Pull,
+          local,
+          cloud,
+          sync,
+          fakeCloud,
+          fakeLocal);
+
+      result.VariablesApplied.Should().Be(1);
+      fakeLocal.AppliedVariables.Should().HaveCount(1);
+      fakeLocal.AppliedVariables[0].ContentHash.Should().Be("cloud-new");
+      sync.GetLastSyncedHash(CloudSyncObjectType.Variable, 1).Should().Be("cloud-new");
+    }
+
+    [Fact]
+    public async Task Both_Changed_Different_Hashes_Reports_Conflict()
+    {
+      var sync = new InMemorySyncStateStore();
+      sync.SetLastSyncedHash(CloudSyncObjectType.Variable, 1, "base");
+
+      var local = SnapshotWithVariable(1, "local-new");
+      var cloud = SnapshotWithVariable(1, "cloud-new");
+      var fakeCloud = new FakeCloudClient { Snapshot = cloud };
+      var fakeLocal = new FakeLocalApplier();
+
+      var result = await _engine.ExecuteAsync(
+          CloudSyncDirection.Push,
+          local,
+          cloud,
+          sync,
+          fakeCloud,
+          fakeLocal);
+
+      result.VariablesApplied.Should().Be(0);
+      result.Conflicts.Should().HaveCount(1);
+      result.Conflicts[0].LocalHash.Should().Be("local-new");
+      result.Conflicts[0].CloudHash.Should().Be("cloud-new");
+      fakeCloud.UpsertedVariables.Should().BeEmpty();
+      fakeLocal.AppliedVariables.Should().BeEmpty();
+      sync.GetLastSyncedHash(CloudSyncObjectType.Variable, 1).Should().Be("base");
+    }
+
+    [Fact]
+    public async Task Converged_Local_Equals_Cloud_Updates_Base_Without_Apply()
+    {
+      var sync = new InMemorySyncStateStore();
+      sync.SetLastSyncedHash(CloudSyncObjectType.Variable, 1, "base");
+
+      var local = SnapshotWithVariable(1, "same");
+      var cloud = SnapshotWithVariable(1, "same");
+      var fakeCloud = new FakeCloudClient { Snapshot = cloud };
+      var fakeLocal = new FakeLocalApplier();
+
+      var result = await _engine.ExecuteAsync(
+          CloudSyncDirection.Push,
+          local,
+          cloud,
+          sync,
+          fakeCloud,
+          fakeLocal);
+
+      result.VariablesApplied.Should().Be(0);
+      result.Conflicts.Should().BeEmpty();
+      sync.GetLastSyncedHash(CloudSyncObjectType.Variable, 1).Should().Be("same");
+      fakeCloud.UpsertedVariables.Should().BeEmpty();
+    }
+
+    private static CloudSnapshot SnapshotWithVariable(int id, string hash)
+    {
+      return new CloudSnapshot
+      {
+        Variables =
+        {
+          new CloudVariableRecord
+          {
+            Id = id,
+            ContentHash = hash,
+            Name = "Var" + id,
+            ValueJson = "\"v\""
+          }
+        }
+      };
+    }
+  }
+}

--- a/tests/Progesi.LiveDataExchange.Tests/Cloud/CloudSyncTestDoubles.cs
+++ b/tests/Progesi.LiveDataExchange.Tests/Cloud/CloudSyncTestDoubles.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Progesi.LiveDataExchange.Cloud;
+
+namespace Progesi.LiveDataExchange.Tests.Cloud
+{
+  internal sealed class FakeCloudClient : IProgesiCloudClient
+  {
+    public CloudSnapshot Snapshot { get; set; } = new CloudSnapshot();
+    public IList<CloudVariableRecord> UpsertedVariables { get; } = new List<CloudVariableRecord>();
+    public IList<CloudMetadataRecord> UpsertedMetadata { get; } = new List<CloudMetadataRecord>();
+    public IList<CloudClusterRecord> UpsertedClusters { get; } = new List<CloudClusterRecord>();
+
+    public Task<CloudSnapshot> GetCloudSnapshotAsync(CancellationToken ct = default)
+        => Task.FromResult(CloneSnapshot(Snapshot));
+
+    public Task UpsertVariableAsync(CloudVariableRecord record, CancellationToken ct = default)
+    {
+      UpsertedVariables.Add(record);
+      UpsertIntoSnapshot(record);
+      return Task.CompletedTask;
+    }
+
+    public Task UpsertMetadataAsync(CloudMetadataRecord record, CancellationToken ct = default)
+    {
+      UpsertedMetadata.Add(record);
+      UpsertIntoSnapshot(record);
+      return Task.CompletedTask;
+    }
+
+    public Task UpsertClusterAsync(CloudClusterRecord record, CancellationToken ct = default)
+    {
+      UpsertedClusters.Add(record);
+      UpsertIntoSnapshot(record);
+      return Task.CompletedTask;
+    }
+
+    private void UpsertIntoSnapshot(CloudVariableRecord record)
+    {
+      var existing = Snapshot.Variables.FirstOrDefault(v => v.Id == record.Id);
+      if (existing == null)
+        Snapshot.Variables.Add(record);
+      else
+      {
+        existing.ContentHash = record.ContentHash;
+        existing.Name = record.Name;
+        existing.ValueJson = record.ValueJson;
+      }
+    }
+
+    private void UpsertIntoSnapshot(CloudMetadataRecord record)
+    {
+      var existing = Snapshot.Metadata.FirstOrDefault(v => v.Id == record.Id);
+      if (existing == null)
+        Snapshot.Metadata.Add(record);
+      else
+      {
+        existing.ContentHash = record.ContentHash;
+        existing.CreatedBy = record.CreatedBy;
+      }
+    }
+
+    private void UpsertIntoSnapshot(CloudClusterRecord record)
+    {
+      var existing = Snapshot.Clusters.FirstOrDefault(v => v.Id == record.Id);
+      if (existing == null)
+        Snapshot.Clusters.Add(record);
+      else
+      {
+        existing.ContentHash = record.ContentHash;
+        existing.Name = record.Name;
+      }
+    }
+
+    private static CloudSnapshot CloneSnapshot(CloudSnapshot source)
+    {
+      return new CloudSnapshot
+      {
+        Variables = source.Variables.ToList(),
+        Metadata = source.Metadata.ToList(),
+        Clusters = source.Clusters.ToList()
+      };
+    }
+  }
+
+  internal sealed class FakeLocalApplier : ICloudSyncLocalApplier
+  {
+    public CloudSnapshot Snapshot { get; } = new CloudSnapshot();
+    public IList<CloudVariableRecord> AppliedVariables { get; } = new List<CloudVariableRecord>();
+
+    public Task ApplyVariableAsync(CloudVariableRecord record, CancellationToken ct = default)
+    {
+      AppliedVariables.Add(record);
+      var existing = Snapshot.Variables.FirstOrDefault(v => v.Id == record.Id);
+      if (existing == null)
+        Snapshot.Variables.Add(record);
+      else
+      {
+        existing.ContentHash = record.ContentHash;
+        existing.Name = record.Name;
+        existing.ValueJson = record.ValueJson;
+      }
+
+      return Task.CompletedTask;
+    }
+
+    public Task ApplyMetadataAsync(CloudMetadataRecord record, CancellationToken ct = default)
+    {
+      var existing = Snapshot.Metadata.FirstOrDefault(v => v.Id == record.Id);
+      if (existing == null)
+        Snapshot.Metadata.Add(record);
+      else
+        existing.ContentHash = record.ContentHash;
+      return Task.CompletedTask;
+    }
+
+    public Task ApplyClusterAsync(CloudClusterRecord record, CancellationToken ct = default)
+    {
+      var existing = Snapshot.Clusters.FirstOrDefault(v => v.Id == record.Id);
+      if (existing == null)
+        Snapshot.Clusters.Add(record);
+      else
+        existing.ContentHash = record.ContentHash;
+      return Task.CompletedTask;
+    }
+  }
+}

--- a/tests/Progesi.LiveDataExchange.Tests/Progesi.LiveDataExchange.Tests.csproj
+++ b/tests/Progesi.LiveDataExchange.Tests/Progesi.LiveDataExchange.Tests.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>


### PR DESCRIPTION
## Phase 4 / A3.4a — Rhino ↔ cloud sync (push/pull + conflict detect/report)

Explicit push/pull sync embedded in `Progesi.LiveDataExchange` + a **new cloud sibling GH component**, per the confirmed decisions.

- **`CloudSyncEngine`** — three-way `ContentHash` rule: skip / apply (direction-gated) / converged / **CONFLICT (both sides differ → reported, not applied, base kept so it re-surfaces)**. No silent overwrite.
- **`HttpProgesiCloudClient`** over the existing API (`X-Project-Id` + Bearer/`X-Test-Roles`); **`RhinoSyncStateStore`** (StringTable) holds per-object last-synced hashes; new **`ProgesiCloudSyncComponent`** (DataEx — Cloud). Dev bearer token (**MSAL device-code = A3.4-auth follow-up**).
- **Known limitation:** syncs upserts, not deletions (deletion-sync = documented follow-up; nothing silently deleted).
- **Scope:** no API/Core/AxisVar/frozen-DataExchange changes; no runtime packages (test SDK only). **414 → 419**, 0 failed. Engine CI-unit-tested (5 cases).

⚠️ **MANDATORY manual GH validation before merge** (push · edit-and-push · pull · both-sides-conflict, against a running local API + provisioned project + dev token).